### PR TITLE
fix export resolution caps and enable hevc-first mp4 encoding

### DIFF
--- a/src/components/editor/editor-export-dialog.tsx
+++ b/src/components/editor/editor-export-dialog.tsx
@@ -27,12 +27,15 @@ import { cn } from "@/lib/cn"
 import { getEffectiveCompositionSize } from "@/lib/editor/composition"
 import {
   ASPECT_PRESET_LABELS,
+  clampExportSize,
   type ExportAspectPreset,
   type ExportQualityPreset,
   exportStillImage,
   exportVideo,
   getAspectRatioForPreset,
   getDimensionsForPreset,
+  getMaxDimensionForQuality,
+  getMaxExportDimension,
   getSupportedVideoMimeType,
   type VideoExportFormat,
 } from "@/lib/editor/export"
@@ -78,6 +81,7 @@ const QUALITY_PRESETS: ExportQualityPreset[] = [
 const VIDEO_FPS_PRESETS = [24, 30, 60] as const
 const DEFAULT_VIDEO_EXPORT_DURATION = 8
 const VIDEO_DURATION_STEP = 0.25
+const DEFAULT_MAX_EXPORT_DIMENSION = 8192
 
 function roundDurationForExport(value: number): number {
   if (!Number.isFinite(value) || value <= 0) {
@@ -118,6 +122,9 @@ export function EditorExportDialog({
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [contentHeight, setContentHeight] = useState<number | null>(null)
+  const [maxExportDimension, setMaxExportDimension] = useState(
+    DEFAULT_MAX_EXPORT_DIMENSION
+  )
   const [imageAspect, setImageAspect] = useState<ExportAspectPreset>("original")
   const [imageQuality, setImageQuality] =
     useState<ExportQualityPreset>("standard")
@@ -125,7 +132,8 @@ export function EditorExportDialog({
     getDimensionsForPreset(
       useEditorStore.getState().canvasSize,
       "original",
-      "standard"
+      "standard",
+      DEFAULT_MAX_EXPORT_DIMENSION
     )
   )
   const [videoAspect, setVideoAspect] = useState<ExportAspectPreset>("original")
@@ -135,7 +143,8 @@ export function EditorExportDialog({
     getDimensionsForPreset(
       useEditorStore.getState().canvasSize,
       "original",
-      "standard"
+      "standard",
+      DEFAULT_MAX_EXPORT_DIMENSION
     )
   )
   const [videoDuration, setVideoDuration] = useState(timelineDuration)
@@ -216,6 +225,20 @@ export function EditorExportDialog({
   useEffect(() => {
     let cancelled = false
 
+    void getMaxExportDimension().then((dimension) => {
+      if (!cancelled) {
+        setMaxExportDimension(dimension)
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
     void Promise.all([
       getSupportedVideoMimeType("webm"),
       getSupportedVideoMimeType("mp4"),
@@ -261,15 +284,25 @@ export function EditorExportDialog({
 
   useEffect(() => {
     setImageSize(
-      getDimensionsForPreset(compositionSize, imageAspect, imageQuality)
+      getDimensionsForPreset(
+        compositionSize,
+        imageAspect,
+        imageQuality,
+        maxExportDimension
+      )
     )
-  }, [compositionSize, imageAspect, imageQuality])
+  }, [compositionSize, imageAspect, imageQuality, maxExportDimension])
 
   useEffect(() => {
     setVideoSize(
-      getDimensionsForPreset(compositionSize, videoAspect, videoQuality)
+      getDimensionsForPreset(
+        compositionSize,
+        videoAspect,
+        videoQuality,
+        maxExportDimension
+      )
     )
-  }, [compositionSize, videoAspect, videoQuality])
+  }, [compositionSize, videoAspect, videoQuality, maxExportDimension])
 
   useEffect(() => {
     if (!open || videoDurationDirty) {
@@ -318,44 +351,73 @@ export function EditorExportDialog({
     [activeTab, clearFeedback]
   )
 
+  const imageMaxDimension = Math.min(
+    maxExportDimension,
+    getMaxDimensionForQuality(imageQuality)
+  )
+  const videoMaxDimension = Math.min(
+    maxExportDimension,
+    getMaxDimensionForQuality(videoQuality)
+  )
+
   function updateImageWidth(nextWidth: number) {
     const width = Math.max(1, Math.round(nextWidth))
     const ratio = getAspectRatioForPreset(compositionSize, imageAspect)
 
-    setImageSize({
-      height: Math.max(1, Math.round(width / ratio)),
-      width,
-    })
+    setImageSize(
+      clampExportSize(
+        {
+          height: Math.max(1, Math.round(width / ratio)),
+          width,
+        },
+        imageMaxDimension
+      )
+    )
   }
 
   function updateImageHeight(nextHeight: number) {
     const height = Math.max(1, Math.round(nextHeight))
     const ratio = getAspectRatioForPreset(compositionSize, imageAspect)
 
-    setImageSize({
-      height,
-      width: Math.max(1, Math.round(height * ratio)),
-    })
+    setImageSize(
+      clampExportSize(
+        {
+          height,
+          width: Math.max(1, Math.round(height * ratio)),
+        },
+        imageMaxDimension
+      )
+    )
   }
 
   function updateVideoWidth(nextWidth: number) {
     const width = Math.max(1, Math.round(nextWidth))
     const ratio = getAspectRatioForPreset(compositionSize, videoAspect)
 
-    setVideoSize({
-      height: Math.max(1, Math.round(width / ratio)),
-      width,
-    })
+    setVideoSize(
+      clampExportSize(
+        {
+          height: Math.max(1, Math.round(width / ratio)),
+          width,
+        },
+        videoMaxDimension
+      )
+    )
   }
 
   function updateVideoHeight(nextHeight: number) {
     const height = Math.max(1, Math.round(nextHeight))
     const ratio = getAspectRatioForPreset(compositionSize, videoAspect)
 
-    setVideoSize({
-      height,
-      width: Math.max(1, Math.round(height * ratio)),
-    })
+    setVideoSize(
+      clampExportSize(
+        {
+          height,
+          width: Math.max(1, Math.round(height * ratio)),
+        },
+        videoMaxDimension
+      )
+    )
   }
 
   async function handleImageExport() {
@@ -631,6 +693,7 @@ export function EditorExportDialog({
                           imageQuality={imageQuality}
                           imageSize={imageSize}
                           isWorking={isWorking}
+                          maxExportDimension={maxExportDimension}
                           onExport={handleImageExport}
                           onImageAspectChange={setImageAspect}
                           onImageHeightChange={updateImageHeight}
@@ -641,6 +704,7 @@ export function EditorExportDialog({
                       {activeTab === "video" ? (
                         <VideoTabContent
                           isWorking={isWorking}
+                          maxExportDimension={maxExportDimension}
                           mp4Supported={videoSupport.mp4}
                           onExport={handleVideoExport}
                           onVideoAspectChange={setVideoAspect}
@@ -706,6 +770,7 @@ export function EditorExportDialog({
                             imageQuality={imageQuality}
                             imageSize={imageSize}
                             isWorking={isWorking}
+                            maxExportDimension={maxExportDimension}
                             onExport={handleImageExport}
                             onImageAspectChange={setImageAspect}
                             onImageHeightChange={updateImageHeight}
@@ -716,6 +781,7 @@ export function EditorExportDialog({
                         {activeTab === "video" ? (
                           <VideoTabContent
                             isWorking={isWorking}
+                            maxExportDimension={maxExportDimension}
                             mp4Supported={videoSupport.mp4}
                             onExport={handleVideoExport}
                             onVideoAspectChange={setVideoAspect}
@@ -797,6 +863,7 @@ function ImageTabContent({
   imageQuality,
   imageSize,
   isWorking,
+  maxExportDimension,
   onExport,
   onImageAspectChange,
   onImageHeightChange,
@@ -807,6 +874,7 @@ function ImageTabContent({
   imageQuality: ExportQualityPreset
   imageSize: { height: number; width: number }
   isWorking: boolean
+  maxExportDimension: number
   onExport: () => Promise<void>
   onImageAspectChange: (preset: ExportAspectPreset) => void
   onImageHeightChange: (value: number) => void
@@ -849,7 +917,8 @@ function ImageTabContent({
       />
 
       <Typography className="leading-[14px]" tone="muted" variant="caption">
-        Uses the current playhead frame.
+        Uses the current playhead frame. Max export dimension on this device:{" "}
+        {maxExportDimension}px.
       </Typography>
 
       <Button disabled={isWorking} onClick={() => void onExport()}>
@@ -862,6 +931,7 @@ function ImageTabContent({
 
 function VideoTabContent({
   isWorking,
+  maxExportDimension,
   mp4Supported,
   onExport,
   onVideoAspectChange,
@@ -881,6 +951,7 @@ function VideoTabContent({
   webmSupported,
 }: {
   isWorking: boolean
+  maxExportDimension: number
   mp4Supported: boolean
   onExport: () => Promise<void>
   onVideoAspectChange: (preset: ExportAspectPreset) => void
@@ -989,7 +1060,8 @@ function VideoTabContent({
           />
         </div>
         <Typography className="leading-[14px]" tone="muted" variant="caption">
-          {videoProgress?.label ?? "\u00A0"}
+          {videoProgress?.label ??
+            `Max export dimension on this device: ${maxExportDimension}px.`}
         </Typography>
       </div>
 

--- a/src/lib/editor/export.ts
+++ b/src/lib/editor/export.ts
@@ -20,12 +20,14 @@ export type ExportAspectPreset = "16:9" | "1:1" | "4:5" | "9:16" | "original"
 export type ExportQualityPreset = "draft" | "high" | "standard" | "ultra"
 export type VideoExportFormat = "mp4" | "webm"
 
-export const EXPORT_QUALITY_SCALE: Record<ExportQualityPreset, number> = {
-  draft: 0.5,
-  high: 2,
-  standard: 1,
-  ultra: 4,
+export const EXPORT_QUALITY_LONG_EDGE: Record<ExportQualityPreset, number> = {
+  draft: 1280,
+  standard: 1920,
+  high: 3840,
+  ultra: 7680,
 }
+
+const DEFAULT_MAX_EXPORT_DIMENSION = 8192
 
 export const ASPECT_PRESET_LABELS: Record<ExportAspectPreset, string> = {
   "16:9": "16:9",
@@ -100,24 +102,93 @@ export function getAspectRatioForPreset(
 export function getDimensionsForPreset(
   compositionSize: Size,
   aspectPreset: ExportAspectPreset,
-  qualityPreset: ExportQualityPreset
+  qualityPreset: ExportQualityPreset,
+  maxDimension = Number.POSITIVE_INFINITY
 ): Size {
   const ratio = getAspectRatio(compositionSize, aspectPreset)
-  const longEdge = Math.max(compositionSize.width, compositionSize.height)
-  const scaledLongEdge = clampDimension(
-    longEdge * EXPORT_QUALITY_SCALE[qualityPreset]
+  const targetLongEdge = clampDimension(
+    Math.min(getMaxDimensionForQuality(qualityPreset), maxDimension)
   )
 
   if (ratio >= 1) {
     return {
-      height: clampDimension(scaledLongEdge / ratio),
-      width: scaledLongEdge,
+      height: clampDimension(targetLongEdge / ratio),
+      width: targetLongEdge,
     }
   }
 
   return {
-    height: scaledLongEdge,
-    width: clampDimension(scaledLongEdge * ratio),
+    height: targetLongEdge,
+    width: clampDimension(targetLongEdge * ratio),
+  }
+}
+
+export function getMaxDimensionForQuality(
+  qualityPreset: ExportQualityPreset
+): number {
+  return EXPORT_QUALITY_LONG_EDGE[qualityPreset]
+}
+
+export function clampExportSize(size: Size, maxDimension: number): Size {
+  const width = clampDimension(size.width)
+  const height = clampDimension(size.height)
+  const limit = clampDimension(maxDimension)
+  const longEdge = Math.max(width, height)
+
+  if (longEdge <= limit) {
+    return { width, height }
+  }
+
+  const scale = limit / longEdge
+
+  return {
+    width: clampDimension(width * scale),
+    height: clampDimension(height * scale),
+  }
+}
+
+export async function getMaxExportDimension(): Promise<number> {
+  if (
+    typeof navigator === "undefined" ||
+    !("gpu" in navigator) ||
+    typeof navigator.gpu.requestAdapter !== "function"
+  ) {
+    return DEFAULT_MAX_EXPORT_DIMENSION
+  }
+
+  try {
+    const adapter = await navigator.gpu.requestAdapter()
+    return (
+      adapter?.limits.maxTextureDimension2D ?? DEFAULT_MAX_EXPORT_DIMENSION
+    )
+  } catch {
+    return DEFAULT_MAX_EXPORT_DIMENSION
+  }
+}
+
+function getSourceRenderSizeForExport(
+  compositionSize: Size,
+  aspectPreset: ExportAspectPreset,
+  outputSize: Size
+): Size {
+  const sourceRatio =
+    compositionSize.width / Math.max(compositionSize.height, 1)
+  const targetRatio = getAspectRatio(compositionSize, aspectPreset)
+
+  if (Math.abs(targetRatio - sourceRatio) <= 0.0001) {
+    return outputSize
+  }
+
+  if (targetRatio > sourceRatio) {
+    return {
+      width: outputSize.width,
+      height: clampDimension(outputSize.width / sourceRatio),
+    }
+  }
+
+  return {
+    width: clampDimension(outputSize.height * sourceRatio),
+    height: outputSize.height,
   }
 }
 
@@ -132,15 +203,29 @@ export async function exportStillImage(
   projectState: RenderProjectState,
   options: StillExportOptions
 ): Promise<Blob> {
-  const renderScale = EXPORT_QUALITY_SCALE[options.qualityPreset]
-  const sourceRenderSize = {
-    height: clampDimension(projectState.compositionSize.height * renderScale),
-    width: clampDimension(projectState.compositionSize.width * renderScale),
-  }
-
+  const maxExportDimension = await getMaxExportDimension()
+  const maxAllowedDimension = Math.min(
+    maxExportDimension,
+    getMaxDimensionForQuality(options.qualityPreset)
+  )
+  const clampedOutputSize = clampExportSize(
+    {
+      width: options.width,
+      height: options.height,
+    },
+    maxAllowedDimension
+  )
   const outputCanvas = document.createElement("canvas")
-  outputCanvas.width = clampDimension(options.width)
-  outputCanvas.height = clampDimension(options.height)
+  outputCanvas.width = clampedOutputSize.width
+  outputCanvas.height = clampedOutputSize.height
+  const sourceRenderSize = getSourceRenderSizeForExport(
+    projectState.compositionSize,
+    options.aspectPreset,
+    {
+      width: outputCanvas.width,
+      height: outputCanvas.height,
+    }
+  )
 
   return exportStillWithNewRenderer(
     projectState,
@@ -208,17 +293,26 @@ export async function exportVideo(
     )
   }
 
-  const renderScale = EXPORT_QUALITY_SCALE[options.qualityPreset]
-  const sourceRenderSize = {
-    height: clampDimension(projectState.compositionSize.height * renderScale),
-    width: clampDimension(projectState.compositionSize.width * renderScale),
-  }
-
   const renderCanvas = createHiddenRenderCanvas()
+  const maxExportDimension = await getMaxExportDimension()
+  const maxAllowedDimension = Math.min(
+    maxExportDimension,
+    getMaxDimensionForQuality(options.qualityPreset)
+  )
   const exportSize = normalizeVideoExportSize(options.format, {
-    width: options.width,
-    height: options.height,
+    ...clampExportSize(
+      {
+        width: options.width,
+        height: options.height,
+      },
+      maxAllowedDimension
+    ),
   })
+  const sourceRenderSize = getSourceRenderSizeForExport(
+    projectState.compositionSize,
+    options.aspectPreset,
+    exportSize
+  )
   const outputCanvas = document.createElement("canvas")
   outputCanvas.width = exportSize.width
   outputCanvas.height = exportSize.height

--- a/src/lib/editor/video-export-encoder.ts
+++ b/src/lib/editor/video-export-encoder.ts
@@ -10,7 +10,7 @@ import {
 } from "webm-muxer"
 import type { VideoExportFormat } from "@/lib/editor/export"
 
-type Mp4MuxerCodec = "avc"
+type Mp4MuxerCodec = "avc" | "hevc"
 type WebMMuxerCodec = "V_VP8" | "V_VP9"
 
 export type SupportedVideoExportConfig = {
@@ -87,6 +87,19 @@ function getMp4CodecCandidates(width: number, height: number): string[] {
   return [`avc1.6400${level}`, `avc1.4d00${level}`, `avc1.42001E`]
 }
 
+const HEVC_MP4_CODEC_CANDIDATES = [
+  "hvc1.1.6.L186.B0",
+  "hev1.1.6.L186.B0",
+  "hvc1.1.6.L123.00",
+  "hev1.1.6.L123.00",
+] as const
+
+type HevcVideoEncoderConfig = VideoEncoderConfig & {
+  hevc?: {
+    format: "hevc" | "annexb"
+  }
+}
+
 async function resolveSupportedWebMConfig(
   width: number,
   height: number,
@@ -135,6 +148,30 @@ async function resolveSupportedMp4Config(
     typeof VideoFrame === "undefined"
   ) {
     return null
+  }
+
+  for (const codec of HEVC_MP4_CODEC_CANDIDATES) {
+    const support = await VideoEncoder.isConfigSupported({
+      bitrate,
+      codec,
+      framerate: fps,
+      height,
+      width,
+      hevc: {
+        format: "hevc",
+      },
+    } as HevcVideoEncoderConfig).catch(() => null)
+
+    if (!support?.config) {
+      continue
+    }
+
+    return {
+      encoderConfig: support.config as VideoEncoderConfig,
+      format: "mp4",
+      mimeType: "video/mp4",
+      muxerCodec: "hevc",
+    }
   }
 
   for (const codec of getMp4CodecCandidates(width, height)) {
@@ -278,7 +315,7 @@ export async function createVideoExportEncoder(
     framerate: options.fps,
     height: options.height,
     width: options.width,
-  })
+  } as VideoEncoderConfig)
 
   return {
     async encodeCanvasFrame(canvas, frameIndex, duration, timestamp) {


### PR DESCRIPTION
This changes the export pipeline so quality presets map to fixed output tiers instead of scaling relative to the current composition size.

  Before this change, high and ultra multiplied the live composition dimensions, which could produce oversized render targets on wide scenes and trigger WebGPU texture allocation failures on some devices. Export sizing now behaves as expected:

  - draft targets 1280px
  - standard targets 1920px
  - high targets 3840px
  - ultra targets 7680px

The export path now also clamps output dimensions based on the selected quality tier and the current device’s WebGPU texture limit, preventing oversized ender targets while keeping preset semantics stable across machines. Manual width/height edits are clamped to the same effective cap.

On the video side, MP4 export now probes HEVC/H.265 first and falls back to AVC/H.264 only when HEVC is not supported by the current browser/device. This allows 8K-class MP4 export on environments where HEVC encoding is available, while leaving the existing WebM export path unchanged.