### PR TITLE
Fix export crop leakage from scene composition

### DIFF
--- a/src/components/editor/editor-export-dialog.tsx
+++ b/src/components/editor/editor-export-dialog.tsx
@@ -25,7 +25,6 @@ import { IconButton } from "@/components/ui/icon-button"
 import { NumberInput as EditableNumberInput } from "@/components/ui/number-input"
 import { Typography } from "@/components/ui/typography"
 import { cn } from "@/lib/cn"
-import { getEffectiveCompositionSize } from "@/lib/editor/composition"
 import {
   ASPECT_PRESET_LABELS,
   clampExportSize,
@@ -117,11 +116,12 @@ export function EditorExportDialog({
   onOpenChange,
 }: EditorExportDialogProps) {
   const reduceMotion = useReducedMotion() ?? false
-  const canvasSize = useEditorStore((state) => state.canvasSize)
+  const outputSize = useEditorStore((state) => state.outputSize)
   const sceneConfig = useEditorStore((state) => state.sceneConfig)
-  const compositionSize = useMemo(
-    () => getEffectiveCompositionSize(sceneConfig, canvasSize),
-    [canvasSize, sceneConfig]
+  const compositionSize = outputSize
+  const suggestedAspectPreset = useMemo(
+    () => getSuggestedExportAspectPreset(sceneConfig),
+    [sceneConfig]
   )
   const assets = useAssetStore((state) => state.assets)
   const layers = useLayerStore((state) => state.layers)
@@ -143,7 +143,7 @@ export function EditorExportDialog({
     useState<ExportQualityPreset>("standard")
   const [imageSize, setImageSize] = useState(() =>
     getDimensionsForPreset(
-      useEditorStore.getState().canvasSize,
+      useEditorStore.getState().outputSize,
       "original",
       "standard",
       DEFAULT_MAX_EXPORT_DIMENSION
@@ -154,7 +154,7 @@ export function EditorExportDialog({
     useState<ExportQualityPreset>("standard")
   const [videoSize, setVideoSize] = useState(() =>
     getDimensionsForPreset(
-      useEditorStore.getState().canvasSize,
+      useEditorStore.getState().outputSize,
       "original",
       "standard",
       DEFAULT_MAX_EXPORT_DIMENSION
@@ -331,6 +331,8 @@ export function EditorExportDialog({
     setVideoDuration(defaultVideoDuration)
     setVideoDurationDirty(false)
     setVideoProgress(null)
+    setImageAspect(suggestedAspectPreset)
+    setVideoAspect(suggestedAspectPreset)
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -359,7 +361,7 @@ export function EditorExportDialog({
           ? document.activeElement
           : null
 
-      if (!activeElement || !dialogRef.current?.contains(activeElement)) {
+      if (!(activeElement && dialogRef.current?.contains(activeElement))) {
         event.preventDefault()
         ;(event.shiftKey ? lastFocusable : firstFocusable)?.focus()
         return
@@ -378,9 +380,7 @@ export function EditorExportDialog({
     }
 
     window.requestAnimationFrame(() => {
-      dialogRef.current
-        ?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
-        ?.focus()
+      dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus()
     })
 
     window.addEventListener("keydown", handleKeyDown)
@@ -389,7 +389,7 @@ export function EditorExportDialog({
       window.removeEventListener("keydown", handleKeyDown)
       previousFocusRef.current?.focus()
     }
-  }, [defaultVideoDuration, onOpenChange, open])
+  }, [defaultVideoDuration, onOpenChange, open, suggestedAspectPreset])
 
   const clearFeedback = useCallback(() => {
     setErrorMessage(null)
@@ -866,7 +866,9 @@ export function EditorExportDialog({
                             onVideoWidthChange={updateVideoWidth}
                             videoAspect={videoAspect}
                             videoDuration={videoDuration}
-                            videoDurationReadOnly={derivedVideoDuration !== null}
+                            videoDurationReadOnly={
+                              derivedVideoDuration !== null
+                            }
                             videoFormat={videoFormat}
                             videoFps={videoFps}
                             videoProgress={videoProgress}
@@ -1402,10 +1404,7 @@ function buildRenderProjectState() {
 
   return {
     assets,
-    compositionSize: getEffectiveCompositionSize(
-      editorState.sceneConfig,
-      editorState.canvasSize
-    ),
+    compositionSize: editorState.outputSize,
     layers,
     sceneConfig: editorState.sceneConfig,
     timeline: {
@@ -1417,6 +1416,76 @@ function buildRenderProjectState() {
       selectedTrackId: timelineState.selectedTrackId,
       tracks: structuredClone(timelineState.tracks),
     },
+  }
+}
+
+function getSuggestedExportAspectPreset(
+  sceneConfig: ReturnType<typeof useEditorStore.getState>["sceneConfig"]
+): ExportAspectPreset {
+  const sceneRatio = getSceneCompositionAspectRatio(sceneConfig)
+
+  if (sceneRatio === null) {
+    return "original"
+  }
+
+  let closestPreset: ExportAspectPreset = "original"
+  let smallestDelta = Number.POSITIVE_INFINITY
+
+  for (const preset of ASPECT_PRESETS) {
+    if (preset === "original") {
+      continue
+    }
+
+    const presetRatio = getPresetRatio(preset)
+    const delta = Math.abs(sceneRatio - presetRatio)
+
+    if (delta < smallestDelta) {
+      closestPreset = preset
+      smallestDelta = delta
+    }
+  }
+
+  return smallestDelta <= 0.02 ? closestPreset : "original"
+}
+
+function getPresetRatio(
+  preset: Exclude<ExportAspectPreset, "original">
+): number {
+  switch (preset) {
+    case "1:1":
+      return 1
+    case "4:5":
+      return 4 / 5
+    case "9:16":
+      return 9 / 16
+    case "16:9":
+      return 16 / 9
+  }
+}
+
+function getSceneCompositionAspectRatio(
+  sceneConfig: ReturnType<typeof useEditorStore.getState>["sceneConfig"]
+): number | null {
+  switch (sceneConfig.compositionAspect) {
+    case "screen":
+      return null
+    case "16:9":
+      return 16 / 9
+    case "9:16":
+      return 9 / 16
+    case "4:3":
+      return 4 / 3
+    case "3:4":
+      return 3 / 4
+    case "1:1":
+      return 1
+    case "custom": {
+      const width = Math.max(1, sceneConfig.compositionWidth)
+      const height = Math.max(1, sceneConfig.compositionHeight)
+      return width / height
+    }
+    default:
+      return null
   }
 }
 

--- a/src/lib/editor/project-file.ts
+++ b/src/lib/editor/project-file.ts
@@ -1,18 +1,20 @@
-import type {
-  EditorAsset,
-  EditorLayer,
-  ProjectPresetConfig,
-  Size,
-} from "@/types/editor"
 import { useAssetStore } from "@/store/asset-store"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
 import { useTimelineStore } from "@/store/timeline-store"
-import { getEffectiveCompositionSize } from "@/lib/editor/composition"
+import type {
+  EditorAsset,
+  EditorLayer,
+  ProjectPresetConfig,
+  SceneConfig,
+  Size,
+} from "@/types/editor"
+import { DEFAULT_SCENE_CONFIG } from "@/types/editor"
 
 export interface LabProjectFile extends ProjectPresetConfig {
   composition: Size
   format: "shader-lab"
+  sceneConfig?: SceneConfig
 }
 
 export function buildLabProjectFile(): LabProjectFile {
@@ -27,20 +29,18 @@ export function buildLabProjectFile(): LabProjectFile {
       id: asset.id,
       kind: asset.kind,
     })),
-    composition: getEffectiveCompositionSize(
-      editorState.sceneConfig,
-      editorState.canvasSize
-    ),
+    composition: structuredClone(editorState.outputSize),
     exportedAt: new Date().toISOString(),
     format: "shader-lab",
     layers: structuredClone(layerState.layers),
+    sceneConfig: structuredClone(editorState.sceneConfig),
     selectedLayerId: layerState.selectedLayerId,
     timeline: structuredClone({
       duration: timelineState.duration,
       loop: timelineState.loop,
       tracks: timelineState.tracks,
     }),
-    version: 1,
+    version: 2,
   }
 }
 
@@ -63,7 +63,7 @@ export function parseLabProjectFile(input: string): LabProjectFile {
     throw new Error("This file is not a Shader Lab `.lab` project.")
   }
 
-  if (candidate.version !== 1) {
+  if (!(candidate.version === 1 || candidate.version === 2)) {
     throw new Error("Unsupported Shader Lab project version.")
   }
 
@@ -92,22 +92,28 @@ export function parseLabProjectFile(input: string): LabProjectFile {
 
 export function applyLabProjectFile(
   projectFile: LabProjectFile,
-  currentAssets: EditorAsset[],
+  currentAssets: EditorAsset[]
 ): { missingAssetCount: number } {
   const assetIds = new Set(currentAssets.map((asset) => asset.id))
-  const assetRefById = new Map(projectFile.assets.map((asset) => [asset.id, asset]))
+  const assetRefById = new Map(
+    projectFile.assets.map((asset) => [asset.id, asset])
+  )
 
   const nextLayers = projectFile.layers.map((layer) =>
-    hydrateImportedLayer(layer, assetIds, assetRefById),
+    hydrateImportedLayer(layer, assetIds, assetRefById)
   )
 
   const hasSelectedLayer = nextLayers.some(
-    (layer) => layer.id === projectFile.selectedLayerId,
+    (layer) => layer.id === projectFile.selectedLayerId
   )
 
   useLayerStore
     .getState()
-    .replaceState(nextLayers, hasSelectedLayer ? projectFile.selectedLayerId : null, null)
+    .replaceState(
+      nextLayers,
+      hasSelectedLayer ? projectFile.selectedLayerId : null,
+      null
+    )
 
   useTimelineStore.getState().replaceState({
     currentTime: 0,
@@ -120,19 +126,21 @@ export function applyLabProjectFile(
   })
 
   const editorStore = useEditorStore.getState()
-  editorStore.updateSceneConfig({
-    compositionAspect: "custom",
-    compositionHeight: projectFile.composition.height,
-    compositionWidth: projectFile.composition.width,
-  })
-  editorStore.setOutputSize(
-    projectFile.composition.width,
-    projectFile.composition.height
-  )
+  if (projectFile.version >= 2 && projectFile.sceneConfig) {
+    editorStore.updateSceneConfig(projectFile.sceneConfig)
+    editorStore.setOutputSize(
+      projectFile.composition.width,
+      projectFile.composition.height
+    )
+  } else {
+    // Legacy v1 files stored the viewport-fitted crop in `composition`,
+    // so importing that value as the real project composition poisons export.
+    editorStore.updateSceneConfig(DEFAULT_SCENE_CONFIG)
+  }
 
   return {
-    missingAssetCount: nextLayers.filter(
-      (layer) => Boolean(layer.assetId && layer.runtimeError),
+    missingAssetCount: nextLayers.filter((layer) =>
+      Boolean(layer.assetId && layer.runtimeError)
     ).length,
   }
 }
@@ -140,7 +148,7 @@ export function applyLabProjectFile(
 function hydrateImportedLayer(
   layer: EditorLayer,
   assetIds: Set<string>,
-  assetRefById: Map<string, LabProjectFile["assets"][number]>,
+  assetRefById: Map<string, LabProjectFile["assets"][number]>
 ): EditorLayer {
   if (!(layer.assetId && !assetIds.has(layer.assetId))) {
     return {


### PR DESCRIPTION
This fixes export corruption caused by scene/global composition crop leaking into real export state

Before this change, two paths were conflated:

- Scene config composition crop, which should only be an editor framing aid
- Real project/export composition, which should be driven by outputSize and the export dialog

That caused two failures:

- Export used crop-derived logicalSize, so several renderer passes laid out content as if the composition were portrait, producing the “contain/squash” look
- Legacy .lab files could import a crop-fitted composition and poison later exports
What changed:

- export dialog sizing and buildRenderProjectState() now use outputSize as the real composition basis
- scene crop only suggests a matching export preset when opening the dialog; it no longer drives export geometry
- .lab export now writes outputSize as composition and stores sceneConfig separately in version: 2
- legacy .lab imports no longer apply their polluted composition as the real project composition