### PR TITLE
Polish editor panel UI

### DIFF
--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -1,12 +1,12 @@
 import type { CSSProperties } from "react"
 import { Button } from "@/components/ui/button"
-import { cn } from "@/lib/cn"
 import { GlassPanel } from "@/components/ui/glass-panel"
 import { IconButton } from "@/components/ui/icon-button"
 import { Select } from "@/components/ui/select"
 import { Slider } from "@/components/ui/slider"
 import { Toggle } from "@/components/ui/toggle"
 import { Typography } from "@/components/ui/typography"
+import { cn } from "@/lib/cn"
 
 const typeSamples = [
   {
@@ -131,7 +131,7 @@ function GlassPreview({
       <Typography
         className="relative z-1"
         tone={light ? "onLight" : "muted"}
-        variant="monoXs"
+        variant="caption"
       >
         {caption}
       </Typography>
@@ -242,7 +242,7 @@ export default function DesignPage() {
               className="grid gap-[var(--ds-space-2)] border-white/4 border-b py-[12px] first:pt-0 last:border-b-0 last:pb-0 sm:grid-cols-[minmax(140px,180px)_minmax(0,1fr)] sm:gap-[var(--ds-space-4)]"
               key={sample.label}
             >
-              <Typography tone="muted" variant="monoXs">
+              <Typography tone="muted" variant="caption">
                 {sample.label}
               </Typography>
               <Typography variant={sample.variant}>{sample.text}</Typography>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,11 +63,12 @@
     --layout-width: calc(100vw - (2 * var(--safe)));
     --column-width: calc(
       (var(--layout-width) - (var(--columns) - 1) * var(--gap)) /
-        var(--columns)
+      var(--columns)
     );
     --ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
     --ds-font-sans: var(--geist-sans);
     --ds-font-mono: var(--geist-mono);
+    --ds-font-value: var(--ds-font-mono);
     --ds-color-canvas: #080808;
     --ds-color-glass-panel: rgb(18 18 22 / 0.55);
     --ds-color-glass-pill: rgb(18 18 22 / 0.5);
@@ -167,6 +168,16 @@
 
   table {
     border-collapse: collapse;
+  }
+
+  input,
+  textarea,
+  select,
+  option,
+  [data-ds-value] {
+    font-family: var(--ds-font-value);
+    font-feature-settings: "zero" 1;
+    font-variant-numeric: tabular-nums slashed-zero;
   }
 
   textarea {
@@ -269,21 +280,27 @@
 
   .type-mono-md {
     font-family: var(--ds-font-mono);
+    font-feature-settings: "zero" 1;
     font-size: 13px;
+    font-variant-numeric: tabular-nums slashed-zero;
     font-weight: 400;
     line-height: 16px;
   }
 
   .type-mono-sm {
     font-family: var(--ds-font-mono);
+    font-feature-settings: "zero" 1;
     font-size: 11px;
+    font-variant-numeric: tabular-nums slashed-zero;
     font-weight: 400;
     line-height: 14px;
   }
 
   .type-mono-xs {
     font-family: var(--ds-font-mono);
+    font-feature-settings: "zero" 1;
     font-size: 10px;
+    font-variant-numeric: tabular-nums slashed-zero;
     font-weight: 400;
     line-height: 12px;
   }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
+import Link from "next/link"
 
 const primaryActionClassName =
-  "inline-flex items-center justify-center rounded-[var(--ds-radius-control)] bg-[var(--ds-color-text-primary)] px-5 py-2 text-[12px] font-medium leading-4 text-[var(--ds-color-text-on-light)] transition-[background-color,transform] duration-160 ease-[var(--ease-out-cubic)] hover:bg-white/82 active:scale-[0.98] active:bg-white/72";
+  "inline-flex items-center justify-center rounded-[var(--ds-radius-control)] bg-[var(--ds-color-text-primary)] px-5 py-2 text-[12px] font-medium leading-4 text-[var(--ds-color-text-on-light)] transition-[background-color,transform] duration-160 ease-[var(--ease-out-cubic)] hover:bg-white/82 active:scale-[0.98] active:bg-white/72"
 
 export default function NotFound() {
   return (
@@ -14,14 +14,14 @@ export default function NotFound() {
 
       <section className="relative w-full max-w-2xl rounded-[28px] border border-[var(--ds-border-panel-strong)] bg-[rgb(12_12_16_/_0.72)] p-6 shadow-[var(--ds-shadow-panel-dark)] backdrop-blur-[24px] sm:p-8">
         <div className="mb-8 flex items-center justify-between gap-4">
-          <p className="font-[var(--ds-font-mono)] text-[11px] text-white/52 uppercase tracking-[0.24em]">
-            Error 404
+          <p className="text-[11px] text-white/52 uppercase tracking-[0.24em]">
+            Error <span className="font-[var(--ds-font-mono)]">404</span>
           </p>
           <div className="h-px flex-1 bg-[linear-gradient(90deg,rgb(255_255_255_/_0.14),transparent)]" />
         </div>
 
         <div className="space-y-4">
-          <p className="font-[var(--ds-font-mono)] text-[12px] text-white/38 uppercase tracking-[0.2em]">
+          <p className="text-[12px] text-white/38 uppercase tracking-[0.2em]">
             Route not found
           </p>
           <h1 className="max-w-xl font-semibold text-[clamp(3rem,9vw,5.5rem)] text-[var(--ds-color-text-primary)] leading-[0.9] tracking-[-0.05em]">
@@ -40,5 +40,5 @@ export default function NotFound() {
         </div>
       </section>
     </main>
-  );
+  )
 }

--- a/src/components/editor/editor-canvas-viewport.tsx
+++ b/src/components/editor/editor-canvas-viewport.tsx
@@ -2,9 +2,11 @@
 
 import {
   type DragEvent,
+  type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
 import { useEditorRenderer } from "@/hooks/use-editor-renderer"
@@ -86,9 +88,23 @@ export function EditorCanvasViewport() {
   ])
 
   const [isDragOver, setIsDragOver] = useState(false)
+  const [isSpacePressed, setIsSpacePressed] = useState(false)
+  const [isPointerPanning, setIsPointerPanning] = useState(false)
   const addLayer = useLayerStore((state) => state.addLayer)
   const setLayerAsset = useLayerStore((state) => state.setLayerAsset)
   const loadAsset = useAssetStore((state) => state.loadAsset)
+  const pointerPanRef = useRef<{
+    pointerId: number
+    originX: number
+    originY: number
+    startPanX: number
+    startPanY: number
+  } | null>(null)
+
+  const stopPointerPan = useCallback(() => {
+    pointerPanRef.current = null
+    setIsPointerPanning(false)
+  }, [])
 
   const handleDragOver = useCallback((event: DragEvent) => {
     event.preventDefault()
@@ -128,6 +144,42 @@ export function EditorCanvasViewport() {
   )
 
   useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null): boolean =>
+      target instanceof HTMLElement &&
+      (target.isContentEditable ||
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement)
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === " " && !isEditableTarget(event.target)) {
+        setIsSpacePressed(true)
+      }
+    }
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key === " ") {
+        setIsSpacePressed(false)
+      }
+    }
+
+    const handleWindowBlur = () => {
+      setIsSpacePressed(false)
+      stopPointerPan()
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    window.addEventListener("keyup", handleKeyUp)
+    window.addEventListener("blur", handleWindowBlur)
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+      window.removeEventListener("keyup", handleKeyUp)
+      window.removeEventListener("blur", handleWindowBlur)
+    }
+  }, [stopPointerPan])
+
+  useEffect(() => {
     if (!immersiveCanvas) {
       return
     }
@@ -155,29 +207,35 @@ export function EditorCanvasViewport() {
     const handleWheel = (event: WheelEvent) => {
       const shouldZoom = event.metaKey || event.ctrlKey
 
-      if (!shouldZoom) {
+      event.preventDefault()
+
+      const state = useEditorStore.getState()
+
+      if (shouldZoom) {
+        event.stopPropagation()
+
+        const rect = viewportElement.getBoundingClientRect()
+        const pointer = {
+          x: event.clientX - rect.left - rect.width / 2,
+          y: event.clientY - rect.top - rect.height / 2,
+        }
+        const nextZoom = clampZoom(state.zoom * getWheelZoomFactor(event.deltaY))
+        const nextState = applyZoomAtPoint(
+          state.zoom,
+          state.panOffset,
+          pointer,
+          nextZoom
+        )
+
+        state.setZoom(nextState.zoom)
+        state.setPan(nextState.panOffset.x, nextState.panOffset.y)
         return
       }
 
-      event.preventDefault()
-      event.stopPropagation()
-
-      const rect = viewportElement.getBoundingClientRect()
-      const state = useEditorStore.getState()
-      const pointer = {
-        x: event.clientX - rect.left - rect.width / 2,
-        y: event.clientY - rect.top - rect.height / 2,
-      }
-      const nextZoom = clampZoom(state.zoom * getWheelZoomFactor(event.deltaY))
-      const nextState = applyZoomAtPoint(
-        state.zoom,
-        state.panOffset,
-        pointer,
-        nextZoom
+      state.setPan(
+        state.panOffset.x - event.deltaX,
+        state.panOffset.y - event.deltaY
       )
-
-      state.setZoom(nextState.zoom)
-      state.setPan(nextState.panOffset.x, nextState.panOffset.y)
     }
 
     viewportElement.addEventListener("wheel", handleWheel, { passive: false })
@@ -187,14 +245,103 @@ export function EditorCanvasViewport() {
     }
   }, [viewportRef])
 
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || !isSpacePressed) {
+        return
+      }
+
+      event.preventDefault()
+
+      const state = useEditorStore.getState()
+      pointerPanRef.current = {
+        pointerId: event.pointerId,
+        originX: event.clientX,
+        originY: event.clientY,
+        startPanX: state.panOffset.x,
+        startPanY: state.panOffset.y,
+      }
+      setIsPointerPanning(true)
+      event.currentTarget.setPointerCapture(event.pointerId)
+    },
+    [isSpacePressed]
+  )
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const activePan = pointerPanRef.current
+
+      if (!activePan || activePan.pointerId !== event.pointerId) {
+        return
+      }
+
+      useEditorStore.getState().setPan(
+        activePan.startPanX + (event.clientX - activePan.originX),
+        activePan.startPanY + (event.clientY - activePan.originY)
+      )
+    },
+    []
+  )
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const activePan = pointerPanRef.current
+
+      if (!activePan || activePan.pointerId !== event.pointerId) {
+        return
+      }
+
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId)
+      }
+
+      stopPointerPan()
+    },
+    [stopPointerPan]
+  )
+
+  const handlePointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const activePan = pointerPanRef.current
+
+      if (!activePan || activePan.pointerId !== event.pointerId) {
+        return
+      }
+
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId)
+      }
+
+      stopPointerPan()
+    },
+    [stopPointerPan]
+  )
+
+  let viewportCursor: "grab" | "grabbing" | undefined
+
+  if (isPointerPanning) {
+    viewportCursor = "grabbing"
+  } else if (isSpacePressed) {
+    viewportCursor = "grab"
+  }
+
   return (
     <>
       <div
         ref={viewportRef}
         className="absolute inset-0 overflow-hidden"
+        role="application"
+        aria-label="Canvas viewport"
+        style={{
+          cursor: viewportCursor,
+        }}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
       >
         <div
           className="absolute inset-0"

--- a/src/components/editor/editor-canvas-viewport.tsx
+++ b/src/components/editor/editor-canvas-viewport.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { type DragEvent, useCallback, useEffect, useMemo, useState } from "react"
+import {
+  type DragEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import { useEditorRenderer } from "@/hooks/use-editor-renderer"
 import { inferFileAssetKind } from "@/lib/editor/media-file"
 import {
@@ -238,7 +244,7 @@ export function EditorCanvasViewport() {
 
         {isDragOver ? (
           <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center border-2 border-dashed border-white/30 bg-black/30 backdrop-blur-[2px]">
-            <span className="font-[var(--ds-font-mono)] text-xs text-white/70">
+            <span className="font-[var(--ds-font-sans)] text-xs text-white/70">
               Drop to add layer
             </span>
           </div>

--- a/src/components/editor/editor-timeline-overlay.tsx
+++ b/src/components/editor/editor-timeline-overlay.tsx
@@ -70,7 +70,7 @@ const GENERAL_TIMELINE_PROPERTIES = [
   { color: "#F7B365", property: "saturation" },
 ] as const
 
-const COLLAPSED_SHELL_HEIGHT = 52
+const COLLAPSED_SHELL_HEIGHT = 46
 const COLLAPSED_SHELL_WIDTH = 580
 const EXPANDED_SHELL_HEIGHT = 380
 const EXPANDED_SHELL_WIDTH = 820
@@ -342,7 +342,7 @@ function TimelineTransport({
           ) : (
             <CircleIcon height={10} width={10} />
           )}
-          <Typography as="span" tone="secondary" variant="monoSm">
+          <Typography as="span" tone="secondary" variant="caption">
             Auto-Key
           </Typography>
         </IconButton>
@@ -354,7 +354,7 @@ function TimelineTransport({
       />
 
       <div className="inline-flex items-center gap-2">
-        <Typography as="span" tone="secondary" variant="monoSm">
+        <Typography as="span" tone="secondary" variant="caption">
           Dur
         </Typography>
         <NumberInput
@@ -384,7 +384,7 @@ function TimelineTransport({
           as="span"
           className="whitespace-nowrap"
           tone="secondary"
-          variant="monoSm"
+          variant="caption"
         >
           sec
         </Typography>
@@ -818,7 +818,7 @@ export function EditorTimelineOverlay() {
                                 isFocused && "border-white/8 bg-white/8",
                                 hasTrack
                                   ? "text-[var(--ds-color-text-primary)]"
-                                  : "text-[var(--ds-color-text-muted)]"
+                                  : "text-[var(--ds-color-text-secondary)]"
                               )}
                               key={entry.id}
                               onClick={() => {
@@ -841,29 +841,12 @@ export function EditorTimelineOverlay() {
                                 <Typography
                                   as="span"
                                   className="min-w-0"
-                                  tone={hasTrack ? "primary" : "muted"}
-                                  variant="monoSm"
+                                  tone={hasTrack ? "primary" : "secondary"}
+                                  variant="caption"
                                 >
                                   {entry.label}
                                 </Typography>
                               </div>
-                              <span
-                                aria-hidden="true"
-                                className={cn(
-                                  "inline-flex h-[7px] w-[7px] shrink-0 rounded-full",
-                                  hasTrack
-                                    ? "bg-[rgb(var(--timeline-track-rgb,122_162_255)_/_0.9)] shadow-[0_0_10px_rgb(var(--timeline-track-rgb,122_162_255)_/_0.35)]"
-                                    : "bg-white/14"
-                                )}
-                                style={
-                                  hasTrack
-                                    ? ({
-                                        "--timeline-track-rgb":
-                                          hexToRgbChannels(entry.color),
-                                      } as CSSProperties)
-                                    : undefined
-                                }
-                              />
                             </button>
                           )
                         })

--- a/src/components/editor/editor-topbar.tsx
+++ b/src/components/editor/editor-topbar.tsx
@@ -3,6 +3,7 @@
 import {
   DownloadIcon,
   DragHandleDots2Icon,
+  GearIcon,
   GitHubLogoIcon,
   ResetIcon,
   StarFilledIcon,
@@ -16,6 +17,7 @@ import { FloatingDesktopPanel } from "@/components/editor/floating-desktop-panel
 import { GlassPanel } from "@/components/ui/glass-panel"
 import { IconButton } from "@/components/ui/icon-button"
 import { Typography } from "@/components/ui/typography"
+import { cn } from "@/lib/cn"
 import {
   applyEditorHistorySnapshot,
   buildEditorHistorySnapshot,
@@ -50,7 +52,7 @@ function GitHubStarLink({ mobile = false }: { mobile?: boolean }) {
     >
       <GitHubLogoIcon height={14} width={14} />
       <StarFilledIcon height={12} width={12} />
-      <Typography as="span" tone="secondary" variant="monoSm">
+      <Typography as="span" tone="secondary" variant="caption">
         Star
       </Typography>
     </Link>
@@ -60,6 +62,9 @@ function GitHubStarLink({ mobile = false }: { mobile?: boolean }) {
 export function EditorTopBar() {
   const immersiveCanvas = useEditorStore((state) => state.immersiveCanvas)
   const mobilePanel = useEditorStore((state) => state.mobilePanel)
+  const rightSidebarVisible = useEditorStore((state) => state.sidebars.right)
+  const sidebarView = useEditorStore((state) => state.sidebarView)
+  const setSidebarView = useEditorStore((state) => state.setSidebarView)
   const zoom = useEditorStore((state) => state.zoom)
   const panOffset = useEditorStore((state) => state.panOffset)
   const hasMovedFloatingPanels = useEditorStore(
@@ -269,6 +274,10 @@ export function EditorTopBar() {
     setPan(nextState.panOffset.x, nextState.panOffset.y)
   }
 
+  const toggleSidebarView = () => {
+    setSidebarView(sidebarView === "scene" ? "properties" : "scene")
+  }
+
   if (immersiveCanvas) {
     return null
   }
@@ -363,13 +372,30 @@ export function EditorTopBar() {
                       onClick={resetFloatingPanels}
                       type="button"
                     >
-                      <Typography as="span" tone="secondary" variant="monoSm">
+                      <Typography as="span" tone="secondary" variant="caption">
                         Reset layout
                       </Typography>
                     </button>
                   </motion.div>
                 ) : null}
               </AnimatePresence>
+              {rightSidebarVisible ? (
+                <IconButton
+                  aria-label={
+                    sidebarView === "scene"
+                      ? "Layer properties"
+                      : "Scene settings"
+                  }
+                  className={cn(
+                    "h-7 w-7",
+                    sidebarView === "scene" && "bg-white/10"
+                  )}
+                  onClick={toggleSidebarView}
+                  variant="default"
+                >
+                  <GearIcon height={16} width={16} />
+                </IconButton>
+              ) : null}
               <IconButton
                 aria-label="Export"
                 className="h-7 w-7 disabled:opacity-45"

--- a/src/components/editor/layer-picker.tsx
+++ b/src/components/editor/layer-picker.tsx
@@ -4,8 +4,8 @@ import {
   CameraIcon,
   CodeIcon,
   ImageIcon,
-  PlusIcon,
   MagicWandIcon,
+  PlusIcon,
   TextIcon,
   VideoIcon,
 } from "@radix-ui/react-icons"
@@ -338,7 +338,7 @@ function EffectCard({
         <div
           className={cn("min-w-0 px-2 pt-1 pb-2", item.description && "pr-6")}
         >
-          <div className="overflow-hidden text-ellipsis whitespace-nowrap font-[var(--ds-font-mono)] text-[11px] text-[var(--ds-color-text-primary)] leading-[14px]">
+          <div className="overflow-hidden text-ellipsis whitespace-nowrap font-[var(--ds-font-sans)] text-[11px] text-[var(--ds-color-text-primary)] leading-[14px]">
             {item.label}
           </div>
         </div>
@@ -358,7 +358,7 @@ function SourceButton({
 
   return (
     <button
-      className="inline-flex h-7 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-full border border-white/8 bg-[rgb(255_255_255_/_0.03)] px-3 font-[var(--ds-font-mono)] text-[10px] text-[var(--ds-color-text-secondary)] leading-none transition-[transform,border-color,background-color,color] duration-[180ms] ease-[cubic-bezier(0.32,0.72,0,1)] hover:border-white/14 hover:bg-[rgb(255_255_255_/_0.07)] hover:text-[var(--ds-color-text-primary)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2 active:scale-[0.97]"
+      className="inline-flex h-7 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-full border border-white/8 bg-[rgb(255_255_255_/_0.03)] px-3 font-[var(--ds-font-sans)] text-[10px] text-[var(--ds-color-text-secondary)] leading-none transition-[transform,border-color,background-color,color] duration-[180ms] ease-[cubic-bezier(0.32,0.72,0,1)] hover:border-white/14 hover:bg-[rgb(255_255_255_/_0.07)] hover:text-[var(--ds-color-text-primary)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2 active:scale-[0.97]"
       onClick={() => onSelect(item.value)}
       type="button"
     >
@@ -578,7 +578,7 @@ export function LayerPicker({ className, onSelect }: LayerPickerProps) {
                     variant="panel"
                   >
                     <div className="border-[var(--ds-border-divider)] border-b px-3 pt-3 pb-2.5">
-                      <div className="mb-2 font-[var(--ds-font-mono)] text-[10px] text-[var(--ds-color-text-muted)] uppercase tracking-[0.14em]">
+                      <div className="mb-2 font-[var(--ds-font-sans)] text-[10px] text-[var(--ds-color-text-muted)] uppercase tracking-[0.14em]">
                         Source
                       </div>
                       <div className="flex flex-wrap gap-1.5">
@@ -601,7 +601,7 @@ export function LayerPicker({ className, onSelect }: LayerPickerProps) {
                             return (
                               <button
                                 className={cn(
-                                  "relative inline-flex h-7 cursor-pointer items-center justify-center overflow-hidden rounded-full border border-transparent px-2.5 py-1 font-[var(--ds-font-mono)] text-[10px] text-[var(--ds-color-text-secondary)] leading-none transition-[transform,color] duration-[180ms] ease-[cubic-bezier(0.32,0.72,0,1)] hover:text-[var(--ds-color-text-primary)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2 active:scale-[0.97]",
+                                  "relative inline-flex h-7 cursor-pointer items-center justify-center overflow-hidden rounded-full border border-transparent px-2.5 py-1 font-[var(--ds-font-sans)] text-[10px] text-[var(--ds-color-text-secondary)] leading-none transition-[transform,color] duration-[180ms] ease-[cubic-bezier(0.32,0.72,0,1)] hover:text-[var(--ds-color-text-primary)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2 active:scale-[0.97]",
                                   active &&
                                     "text-[var(--ds-color-text-primary)]"
                                 )}

--- a/src/components/editor/layer-sidebar.tsx
+++ b/src/components/editor/layer-sidebar.tsx
@@ -41,44 +41,6 @@ type LayerAction = "delete" | "reset"
 const thumbnailBaseClassName =
   "relative h-7 w-7 overflow-hidden rounded-[var(--ds-radius-thumb)] border border-white/6 bg-[linear-gradient(135deg,rgb(255_255_255_/_0.07),rgb(255_255_255_/_0.03))]"
 
-function getLayerSecondaryText(
-  layer: EditorLayer,
-  asset: EditorAsset | null
-): string {
-  if (layer.runtimeError) {
-    return layer.runtimeError
-  }
-
-  if (
-    layer.type === "image" ||
-    layer.type === "video" ||
-    layer.type === "model"
-  ) {
-    return asset?.fileName ?? "No asset selected"
-  }
-
-  if (layer.type === "live") {
-    return "webcam"
-  }
-
-  if (layer.type === "custom-shader") {
-    return (
-      (typeof layer.params.sourceFileName === "string" &&
-        layer.params.sourceFileName) ||
-      "custom shader"
-    )
-  }
-
-  if (layer.type === "text") {
-    return (
-      (typeof layer.params.text === "string" && layer.params.text.trim()) ||
-      "text"
-    )
-  }
-
-  return layer.type.replaceAll("-", " ")
-}
-
 function getThumbnailClassName(
   layer: EditorLayer,
   asset: EditorAsset | null
@@ -243,19 +205,12 @@ const LayerListItem = memo(function LayerListItem({
               }
             />
 
-            <div className="flex min-w-0 flex-col gap-0.5">
+            <div className="flex min-w-0 min-h-7 items-center">
               <Typography
-                className="overflow-hidden text-ellipsis whitespace-nowrap"
+                className="overflow-hidden text-ellipsis whitespace-nowrap leading-none"
                 variant="label"
               >
                 {layer.name}
-              </Typography>
-              <Typography
-                className="overflow-hidden text-ellipsis whitespace-nowrap"
-                tone="muted"
-                variant="monoXs"
-              >
-                {getLayerSecondaryText(layer, asset)}
               </Typography>
             </div>
           </button>
@@ -362,19 +317,12 @@ const LayerListItem = memo(function LayerListItem({
             }
           />
 
-          <div className="flex min-w-0 flex-col gap-0.5">
+          <div className="flex min-w-0 min-h-7 items-center">
             <Typography
-              className="overflow-hidden text-ellipsis whitespace-nowrap"
+              className="overflow-hidden text-ellipsis whitespace-nowrap leading-none"
               variant="label"
             >
               {layer.name}
-            </Typography>
-            <Typography
-              className="overflow-hidden text-ellipsis whitespace-nowrap"
-              tone="muted"
-              variant="monoXs"
-            >
-              {getLayerSecondaryText(layer, asset)}
             </Typography>
           </div>
         </button>

--- a/src/components/editor/mobile-editor-dock.tsx
+++ b/src/components/editor/mobile-editor-dock.tsx
@@ -67,7 +67,7 @@ export function MobileEditorDock() {
                 as="span"
                 className="leading-none"
                 tone={isActive ? "primary" : "muted"}
-                variant="monoXs"
+                variant="caption"
               >
                 {label}
               </Typography>

--- a/src/components/editor/properties-sidebar.tsx
+++ b/src/components/editor/properties-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { DragHandleDots2Icon, GearIcon } from "@radix-ui/react-icons"
+import { DragHandleDots2Icon } from "@radix-ui/react-icons"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { FloatingDesktopPanel } from "@/components/editor/floating-desktop-panel"
@@ -587,27 +587,6 @@ export function PropertiesSidebar() {
             className="flex h-full min-h-0 flex-col gap-0 p-0"
             variant="panel"
           >
-            <div className="flex items-center justify-end border-b border-[var(--ds-border-divider)] px-3 py-1.5">
-              <IconButton
-                aria-label={
-                  sidebarView === "scene"
-                    ? "Layer properties"
-                    : "Scene settings"
-                }
-                className={cn(
-                  "h-7 w-7",
-                  sidebarView === "scene" && "bg-white/10"
-                )}
-                onClick={() =>
-                  setSidebarView(
-                    sidebarView === "scene" ? "properties" : "scene"
-                  )
-                }
-                variant="default"
-              >
-                <GearIcon height={16} width={16} />
-              </IconButton>
-            </div>
             <AnimatePresence initial={false} mode="wait">
               {renderAnimatedContent()}
             </AnimatePresence>
@@ -645,7 +624,7 @@ export function PropertiesSidebar() {
                 className="flex h-full min-h-0 flex-col gap-0 p-0"
                 variant="panel"
               >
-                <div className="flex items-center justify-between border-b border-[var(--ds-border-divider)] px-3 py-1.5">
+                <div className="flex items-center justify-start border-b border-[var(--ds-border-divider)] px-3 py-1.5">
                   <IconButton
                     aria-label="Move properties panel"
                     className="h-7 w-7 cursor-grab text-[var(--ds-color-text-muted)] active:cursor-grabbing"
@@ -653,25 +632,6 @@ export function PropertiesSidebar() {
                     {...dragHandleProps}
                   >
                     <DragHandleDots2Icon height={14} width={14} />
-                  </IconButton>
-                  <IconButton
-                    aria-label={
-                      sidebarView === "scene"
-                        ? "Layer properties"
-                        : "Scene settings"
-                    }
-                    className={cn(
-                      "h-7 w-7",
-                      sidebarView === "scene" && "bg-white/10"
-                    )}
-                    onClick={() =>
-                      setSidebarView(
-                        sidebarView === "scene" ? "properties" : "scene"
-                      )
-                    }
-                    variant="default"
-                  >
-                    <GearIcon height={16} width={16} />
                   </IconButton>
                 </div>
                 <AnimatePresence initial={false} mode="wait">

--- a/src/components/ui/color-picker/index.tsx
+++ b/src/components/ui/color-picker/index.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
-import { cn } from "@/lib/cn"
 import { GlassPanel } from "@/components/ui/glass-panel"
+import { cn } from "@/lib/cn"
 
 type HsvColor = {
   h: number
@@ -58,7 +58,9 @@ function hexToRgb(value: string): { b: number; g: number; r: number } {
 
 function rgbToHex(red: number, green: number, blue: number): string {
   return `#${[red, green, blue]
-    .map((value) => clamp(Math.round(value), 0, 255).toString(16).padStart(2, "0"))
+    .map((value) =>
+      clamp(Math.round(value), 0, 255).toString(16).padStart(2, "0")
+    )
     .join("")
     .toUpperCase()}`
 }
@@ -83,7 +85,7 @@ function rgbToHsv(red: number, green: number, blue: number): HsvColor {
   }
 
   return {
-    h: ((h * 60) + 360) % 360,
+    h: (h * 60 + 360) % 360,
     s: max === 0 ? 0 : delta / max,
     v: max,
   }
@@ -151,7 +153,10 @@ export function ColorPicker({
   const gestureActiveRef = useRef(false)
   const [isOpen, setIsOpen] = useState(false)
   const [inputValue, setInputValue] = useState(normalizeHex(value) ?? "#FFFFFF")
-  const [popupPosition, setPopupPosition] = useState<PopupPosition>({ left: 0, top: 0 })
+  const [popupPosition, setPopupPosition] = useState<PopupPosition>({
+    left: 0,
+    top: 0,
+  })
   const [color, setColor] = useState(() => {
     const rgb = hexToRgb(value)
     return rgbToHsv(rgb.r, rgb.g, rgb.b)
@@ -197,7 +202,8 @@ export function ColorPicker({
         trigger?.contains(target) ||
         surface?.contains(target) ||
         hue?.contains(target) ||
-        (target instanceof HTMLElement && target.closest("[data-color-picker-popup]"))
+        (target instanceof HTMLElement &&
+          target.closest("[data-color-picker-popup]"))
       ) {
         return
       }
@@ -279,13 +285,17 @@ export function ColorPicker({
     commitColor({ h: hue, s: color.s, v: color.v })
   }
 
-  const handleSurfacePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+  const handleSurfacePointerDown = (
+    event: React.PointerEvent<HTMLDivElement>
+  ) => {
     beginInteraction()
     event.currentTarget.setPointerCapture(event.pointerId)
     updateSurface(event.clientX, event.clientY)
   }
 
-  const handleSurfacePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+  const handleSurfacePointerMove = (
+    event: React.PointerEvent<HTMLDivElement>
+  ) => {
     if (event.buttons !== 1) {
       return
     }
@@ -335,7 +345,10 @@ export function ColorPicker({
       {isOpen
         ? createPortal(
             <div data-color-picker-popup="" ref={popupRef} style={popupStyle}>
-              <GlassPanel className="flex w-[208px] flex-col gap-3 p-3" variant="panel">
+              <GlassPanel
+                className="flex w-[208px] flex-col gap-3 p-3"
+                variant="panel"
+              >
                 <div
                   className="relative h-[132px] w-full cursor-crosshair overflow-hidden rounded-[10px] select-none"
                   onPointerCancel={endInteraction}
@@ -391,13 +404,13 @@ export function ColorPicker({
                     type="text"
                     value={inputValue}
                   />
-                  <span className="text-right font-[var(--ds-font-mono)] text-[10px] leading-3 text-[var(--ds-color-text-muted)] uppercase">
+                  <span className="text-right font-[var(--ds-font-sans)] text-[10px] leading-3 text-[var(--ds-color-text-muted)] uppercase">
                     HEX
                   </span>
                 </div>
               </GlassPanel>
             </div>,
-            document.body,
+            document.body
           )
         : null}
     </div>

--- a/src/components/ui/number-input/index.tsx
+++ b/src/components/ui/number-input/index.tsx
@@ -1,11 +1,6 @@
 "use client"
 
-import {
-  type InputHTMLAttributes,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+import { type InputHTMLAttributes, useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/cn"
 
 type NumberInputProps = Omit<
@@ -71,7 +66,9 @@ export function NumberInput({
     )
 
     onChange(clampedValue)
-    setDraftValue(formatValue ? formatValue(clampedValue) : clampedValue.toString())
+    setDraftValue(
+      formatValue ? formatValue(clampedValue) : clampedValue.toString()
+    )
   }
 
   return (

--- a/src/components/ui/select/index.tsx
+++ b/src/components/ui/select/index.tsx
@@ -66,17 +66,18 @@ export function Select({
     >
       <div className={cn("flex w-fit flex-col gap-1", className)}>
         {label ? (
-          <BaseSelect.Label className="font-[var(--ds-font-mono)] text-[10px] leading-3 text-[var(--ds-color-text-muted)]">
+          <BaseSelect.Label className="font-[var(--ds-font-sans)] text-[10px] leading-3 text-[var(--ds-color-text-muted)]">
             {label}
           </BaseSelect.Label>
         ) : null}
 
         <BaseSelect.Trigger
           aria-label={triggerAriaLabel}
+          data-ds-value={isIconTrigger ? undefined : ""}
           className={cn(
             isIconTrigger
-              ? "group inline-flex h-7 w-7 min-w-0 shrink-0 cursor-pointer items-center justify-center rounded-[var(--ds-radius-icon)] border-0 bg-transparent p-0 text-[var(--ds-color-text-tertiary)] transition-[background-color,box-shadow,color,transform] duration-160 ease-[var(--ease-out-cubic)] will-change-transform hover:not-data-disabled:shadow-[inset_0_0_0_1px_rgb(255_255_255_/_0.04)] active:not-data-disabled:scale-[0.96] data-[popup-open]:bg-white/12 data-[popup-open]:text-white/70 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-45 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[var(--ds-border-active)]"
-              : "group inline-flex min-h-8 w-fit min-w-0 cursor-pointer items-center justify-between gap-[10px] rounded-[var(--ds-radius-icon)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] px-[10px] py-[6px] text-[var(--ds-color-text-secondary)] transition-[background-color,border-color,transform] duration-160 ease-[var(--ease-out-cubic)] hover:not-data-disabled:bg-white/8 hover:not-data-disabled:border-[var(--ds-border-hover)] active:not-data-disabled:scale-[0.98] data-[popup-open]:bg-white/8 data-[popup-open]:border-[var(--ds-border-hover)] data-[disabled]:cursor-not-allowed data-[disabled]:opacity-45 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[var(--ds-border-active)]",
+              ? "group inline-flex h-7 w-7 min-w-0 shrink-0 cursor-pointer items-center justify-center rounded-[var(--ds-radius-icon)] border-0 bg-transparent p-0 text-[var(--ds-color-text-tertiary)] transition-[background-color,box-shadow,color,transform] duration-160 ease-[var(--ease-out-cubic)] will-change-transform hover:not-data-disabled:shadow-[inset_0_0_0_1px_rgb(255_255_255_/_0.04)] active:not-data-disabled:scale-[0.96] data-[popup-open]:bg-white/12 data-[popup-open]:text-white/70 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-45 focus-visible:shadow-[inset_0_0_0_1px_var(--ds-border-active)]"
+              : "group inline-flex min-h-8 w-fit min-w-0 cursor-pointer items-center justify-between gap-[10px] rounded-[var(--ds-radius-icon)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] px-[10px] py-[6px] text-[var(--ds-color-text-secondary)] transition-[background-color,border-color,box-shadow,transform] duration-160 ease-[var(--ease-out-cubic)] hover:not-data-disabled:bg-white/8 hover:not-data-disabled:border-[var(--ds-border-hover)] active:not-data-disabled:scale-[0.98] data-[popup-open]:bg-white/8 data-[popup-open]:border-[var(--ds-border-hover)] data-[disabled]:cursor-not-allowed data-[disabled]:opacity-45 focus-visible:border-[var(--ds-border-active)] focus-visible:shadow-[inset_0_0_0_1px_var(--ds-border-active)]",
             triggerClassName
           )}
         >
@@ -84,7 +85,7 @@ export function Select({
             className={cn(
               isIconTrigger
                 ? "inline-flex items-center justify-center leading-none text-inherit"
-                : "min-w-0 flex-1 font-[var(--ds-font-mono)] text-[11px] leading-[14px] text-inherit data-[placeholder]:text-[var(--ds-color-text-secondary)]",
+                : "min-w-0 flex-1 truncate text-left text-[11px] leading-[14px] text-inherit data-[placeholder]:text-[var(--ds-color-text-secondary)]",
               valueClassName
             )}
             placeholder={placeholder}
@@ -122,7 +123,10 @@ export function Select({
                   key={option.value}
                   value={option.value}
                 >
-                  <BaseSelect.ItemText className="block font-[var(--ds-font-mono)] text-[11px] leading-[14px]">
+                  <BaseSelect.ItemText
+                    className="block text-[11px] leading-[14px]"
+                    data-ds-value=""
+                  >
                     {option.label}
                   </BaseSelect.ItemText>
                 </BaseSelect.Item>

--- a/src/components/ui/slider/index.tsx
+++ b/src/components/ui/slider/index.tsx
@@ -251,14 +251,17 @@ export function Slider({
         ) : (
           <span />
         )}
-        <span className="inline-flex w-16 shrink-0 justify-end">
+        <span
+          className="inline-flex w-16 shrink-0 justify-end"
+          data-ds-value=""
+        >
           <span className="relative inline-flex pb-px">
             {isEditingValue ? (
               <input
                 aria-label={
                   typeof label === "string" ? `${label} value` : "Slider value"
                 }
-                className="h-[14px] border-none bg-transparent p-0 text-right font-[var(--ds-font-mono)] text-[11px] leading-[14px] text-[var(--ds-color-text-primary)] outline-none transition-[color] duration-160 ease-[var(--ease-out-cubic)]"
+                className="h-[14px] border-none bg-transparent p-0 text-right text-[11px] leading-[14px] text-[var(--ds-color-text-primary)] outline-none transition-[color] duration-160 ease-[var(--ease-out-cubic)]"
                 id={inputId}
                 inputMode="decimal"
                 onBlur={commitInputValue}
@@ -278,7 +281,7 @@ export function Slider({
                     ? `Edit ${label} value`
                     : "Edit slider value"
                 }
-                className="cursor-pointer border-none bg-transparent p-0 text-right font-[var(--ds-font-mono)] text-[11px] leading-[14px] text-[var(--ds-color-text-secondary)] transition-[color] duration-160 ease-[var(--ease-out-cubic)] hover:text-[var(--ds-color-text-primary)]"
+                className="cursor-pointer border-none bg-transparent p-0 text-right text-[11px] leading-[14px] text-[var(--ds-color-text-secondary)] transition-[color] duration-160 ease-[var(--ease-out-cubic)] hover:text-[var(--ds-color-text-primary)]"
                 onClick={() => {
                   setDraftValue(formattedValue)
                   setIsEditingValue(true)

--- a/src/components/ui/xy-pad/index.tsx
+++ b/src/components/ui/xy-pad/index.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { type CSSProperties, type KeyboardEvent, type PointerEvent, type ReactNode, useMemo, useRef } from "react"
+import {
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+  useMemo,
+  useRef,
+} from "react"
 import { cn } from "@/lib/cn"
 
 type XYPadProps = {
@@ -57,7 +64,7 @@ export function XYPad({
         "--xy-pad-x": `${((clamp(value[0], min, max) - min) / range) * 100}%`,
         "--xy-pad-y": `${(1 - (clamp(value[1], min, max) - min) / range) * 100}%`,
       }) as CSSProperties,
-    [max, min, range, value],
+    [max, min, range, value]
   )
 
   const commitPosition = (clientX: number, clientY: number) => {
@@ -70,8 +77,16 @@ export function XYPad({
     const rect = surface.getBoundingClientRect()
     const normalizedX = clamp((clientX - rect.left) / rect.width, 0, 1)
     const normalizedY = clamp((clientY - rect.top) / rect.height, 0, 1)
-    const nextX = clamp(roundToStep(min + normalizedX * range, step, min), min, max)
-    const nextY = clamp(roundToStep(min + (1 - normalizedY) * range, step, min), min, max)
+    const nextX = clamp(
+      roundToStep(min + normalizedX * range, step, min),
+      min,
+      max
+    )
+    const nextY = clamp(
+      roundToStep(min + (1 - normalizedY) * range, step, min),
+      min,
+      max
+    )
 
     onValueChange([nextX, nextY])
   }
@@ -137,11 +152,19 @@ export function XYPad({
   }
 
   return (
-    <div className={cn("flex w-full flex-col gap-[var(--ds-space-2)]", className)}>
+    <div
+      className={cn("flex w-full flex-col gap-[var(--ds-space-2)]", className)}
+    >
       <div className="flex items-center justify-between gap-[var(--ds-space-3)]">
         <div className="inline-flex min-w-0 items-center gap-2">
-          {label ? <span className="text-[11px] leading-[14px] font-normal text-white/45">{label}</span> : <span />}
-          <span className="inline-flex min-h-[18px] items-center rounded-full border border-white/8 bg-white/6 px-1.5 font-[var(--ds-font-mono)] text-[10px] leading-3 text-[var(--ds-color-text-muted)]">
+          {label ? (
+            <span className="text-[11px] leading-[14px] font-normal text-white/45">
+              {label}
+            </span>
+          ) : (
+            <span />
+          )}
+          <span className="inline-flex min-h-[18px] items-center rounded-full border border-white/8 bg-white/6 px-1.5 font-[var(--ds-font-sans)] text-[10px] leading-3 text-[var(--ds-color-text-muted)]">
             X/Y
           </span>
         </div>


### PR DESCRIPTION
## Summary
- polish editor panel typography so labels use Geist Sans while values and numeric surfaces use Geist Mono with slashed zero
- tighten and clean up timeline, layer, and select controls to improve spacing, contrast, truncation, and open-state stability
- move the scene/properties settings toggle into the top action bar and simplify the layer list rows

## Testing
- targeted `biome check` runs on the edited UI files
- Next.js dev server recompiles cleanly after the changes

## Notes
- `biome check src/components/editor/properties-sidebar.tsx src/components/editor/editor-topbar.tsx` still reports two pre-existing `useExhaustiveDependencies` warnings in `properties-sidebar.tsx`
