### PR TITLE
Apply editor UI follow-ups on updated main

### DIFF
--- a/src/components/editor/editor-shortcuts.tsx
+++ b/src/components/editor/editor-shortcuts.tsx
@@ -20,6 +20,13 @@ function isEditableTarget(target: EventTarget | null): boolean {
 export function EditorShortcuts() {
   const selectedLayerIds = useLayerStore((state) => state.selectedLayerIds)
   const removeLayers = useLayerStore((state) => state.removeLayers)
+  const immersiveCanvas = useEditorStore((state) => state.immersiveCanvas)
+  const enterImmersiveCanvas = useEditorStore(
+    (state) => state.enterImmersiveCanvas
+  )
+  const exitImmersiveCanvas = useEditorStore(
+    (state) => state.exitImmersiveCanvas
+  )
   const timelinePanelOpen = useEditorStore((state) => state.timelinePanelOpen)
   const selectedKeyframeId = useTimelineStore(
     (state) => state.selectedKeyframeId
@@ -29,6 +36,23 @@ export function EditorShortcuts() {
 
   const handleKeyDown = useEffectEvent((event: KeyboardEvent) => {
     if (isEditableTarget(event.target)) {
+      return
+    }
+
+    if (
+      event.metaKey &&
+      !event.altKey &&
+      !event.ctrlKey &&
+      event.code === "Period"
+    ) {
+      event.preventDefault()
+
+      if (immersiveCanvas) {
+        exitImmersiveCanvas()
+      } else {
+        enterImmersiveCanvas()
+      }
+
       return
     }
 

--- a/src/components/editor/editor-timeline-overlay.tsx
+++ b/src/components/editor/editor-timeline-overlay.tsx
@@ -393,7 +393,7 @@ function TimelineTransport({
       <div className="inline-flex min-w-0 flex-1 items-center justify-end gap-1">
         <Typography
           as="span"
-          className="min-w-[104px] whitespace-nowrap text-right"
+          className="min-w-[104px] whitespace-nowrap text-right text-[12px]"
           tone="secondary"
           variant="monoMd"
         >

--- a/src/components/editor/editor-topbar.tsx
+++ b/src/components/editor/editor-topbar.tsx
@@ -6,7 +6,6 @@ import {
   GearIcon,
   GitHubLogoIcon,
   ResetIcon,
-  StarFilledIcon,
   ZoomInIcon,
   ZoomOutIcon,
 } from "@radix-ui/react-icons"
@@ -42,21 +41,17 @@ function GitHubStarLink({ mobile = false }: { mobile?: boolean }) {
   return (
     <HoverTooltip content="GitHub" side={mobile ? "top" : "bottom"}>
       <Link
-        aria-label="Star Shader Lab on GitHub"
+        aria-label="Open Shader Lab on GitHub"
         className={
           mobile
-            ? "inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-[var(--ds-radius-control)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] px-3 text-[var(--ds-color-text-secondary)] transition-[background-color,border-color,color,transform] duration-160 ease-[var(--ease-out-cubic)] hover:border-[var(--ds-border-hover)] hover:bg-white/8 hover:text-[var(--ds-color-text-primary)] active:scale-[0.98]"
-            : "inline-flex h-7 items-center justify-center gap-1.5 rounded-[var(--ds-radius-icon)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] px-3 text-[var(--ds-color-text-secondary)] transition-[background-color,border-color,color,transform] duration-160 ease-[var(--ease-out-cubic)] hover:border-[var(--ds-border-hover)] hover:bg-white/8 hover:text-[var(--ds-color-text-primary)] active:scale-[0.98]"
+            ? "inline-flex size-8 items-center justify-center rounded-[var(--ds-radius-control)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] text-[var(--ds-color-text-secondary)] transition-[background-color,border-color,color,transform] duration-160 ease-[var(--ease-out-cubic)] hover:border-[var(--ds-border-hover)] hover:bg-white/8 hover:text-[var(--ds-color-text-primary)] active:scale-[0.98]"
+            : "inline-flex h-7 w-7 items-center justify-center rounded-[var(--ds-radius-icon)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] text-[var(--ds-color-text-secondary)] transition-[background-color,border-color,color,transform] duration-160 ease-[var(--ease-out-cubic)] hover:border-[var(--ds-border-hover)] hover:bg-white/8 hover:text-[var(--ds-color-text-primary)] active:scale-[0.98]"
         }
         href={GITHUB_REPO_URL}
         rel="noreferrer"
         target="_blank"
       >
         <GitHubLogoIcon height={14} width={14} />
-        <StarFilledIcon height={12} width={12} />
-        <Typography as="span" tone="secondary" variant="caption">
-          Star
-        </Typography>
       </Link>
     </HoverTooltip>
   )

--- a/src/components/editor/layer-sidebar.tsx
+++ b/src/components/editor/layer-sidebar.tsx
@@ -5,7 +5,11 @@ import {
   EyeClosedIcon,
   EyeOpenIcon,
   FileIcon,
+  ImageIcon,
   LayoutIcon,
+  ShadowIcon,
+  TextIcon,
+  TransparencyGridIcon,
   TrashIcon,
 } from "@radix-ui/react-icons"
 import { Reorder, useDragControls } from "motion/react"
@@ -40,26 +44,41 @@ import type { AssetKind, EditorAsset, EditorLayer } from "@/types/editor"
 type LayerAction = "delete" | "reset"
 
 const thumbnailBaseClassName =
-  "relative h-7 w-7 overflow-hidden rounded-[var(--ds-radius-thumb)] border border-white/6 bg-[linear-gradient(135deg,rgb(255_255_255_/_0.07),rgb(255_255_255_/_0.03))]"
+  "relative size-7 overflow-hidden rounded-[var(--ds-radius-thumb)] border border-white/6"
 
-function getThumbnailClassName(
-  layer: EditorLayer,
+function LayerThumbnail({
+  asset,
+  layer,
+}: {
   asset: EditorAsset | null
-): string {
-  if (asset?.kind === "image" || asset?.kind === "video") {
-    return cn(thumbnailBaseClassName, "bg-center bg-cover")
+  layer: EditorLayer
+}) {
+  const hasPreview = asset?.kind === "image" || asset?.kind === "video"
+  let PlaceholderIcon = ImageIcon
+  if (layer.type === "pattern") {
+    PlaceholderIcon = TransparencyGridIcon
+  } else if (layer.type === "gradient") {
+    PlaceholderIcon = ShadowIcon
+  } else if (layer.type === "text") {
+    PlaceholderIcon = TextIcon
   }
 
-  if (layer.type === "model") {
-    return cn(
-      thumbnailBaseClassName,
-      "bg-[radial-gradient(circle_at_30%_30%,rgb(255_255_255_/_0.18),transparent_45%),linear-gradient(135deg,rgb(255_255_255_/_0.08),rgb(255_255_255_/_0.02))]"
-    )
-  }
-
-  return cn(
-    thumbnailBaseClassName,
-    "bg-[linear-gradient(135deg,rgb(255_255_255_/_0.1),rgb(255_255_255_/_0.03)),linear-gradient(180deg,rgb(255_255_255_/_0.05),transparent)] after:absolute after:inset-0 after:bg-[linear-gradient(90deg,transparent,rgb(255_255_255_/_0.18),transparent)] after:opacity-[0.35] after:content-['']"
+  return (
+    <div
+      className={cn(
+        thumbnailBaseClassName,
+        hasPreview
+          ? "bg-center bg-cover"
+          : "flex items-center justify-center bg-[var(--ds-color-surface-subtle)] text-[var(--ds-color-text-muted)]"
+      )}
+      style={
+        hasPreview ? { backgroundImage: `url("${asset.url}")` } : undefined
+      }
+    >
+      {hasPreview ? null : (
+        <PlaceholderIcon aria-hidden="true" height={14} width={14} />
+      )}
+    </div>
   )
 }
 
@@ -181,7 +200,7 @@ const LayerListItem = memo(function LayerListItem({
         <div className="grid min-w-0 grid-cols-[14px_minmax(0,1fr)] items-center gap-[var(--ds-space-2)]">
           <HoverTooltip content="Reorder" side="right">
             <button
-            aria-label={`Reorder ${layer.name}`}
+              aria-label={`Reorder ${layer.name}`}
               className={cn(
                 "inline-flex h-[14px] w-[14px] touch-none items-center justify-center bg-transparent p-0 text-[var(--ds-color-text-muted)]",
                 !layer.locked && "cursor-grab active:cursor-grabbing",
@@ -199,14 +218,7 @@ const LayerListItem = memo(function LayerListItem({
             onClick={(event) => onSelectLayer(layer.id, event)}
             type="button"
           >
-            <div
-              className={getThumbnailClassName(layer, asset)}
-              style={
-                asset?.kind === "image" || asset?.kind === "video"
-                  ? { backgroundImage: `url("${asset.url}")` }
-                  : undefined
-              }
-            />
+            <LayerThumbnail asset={asset} layer={layer} />
 
             <div className="flex min-w-0 min-h-7 items-center">
               <Typography
@@ -296,7 +308,7 @@ const LayerListItem = memo(function LayerListItem({
       <div className="grid min-w-0 grid-cols-[14px_minmax(0,1fr)] items-center gap-[var(--ds-space-2)]">
         <HoverTooltip content="Reorder" side="right">
           <button
-          aria-label={`Reorder ${layer.name}`}
+            aria-label={`Reorder ${layer.name}`}
             className={cn(
               "inline-flex h-[14px] w-[14px] touch-none items-center justify-center bg-transparent p-0 text-[var(--ds-color-text-muted)]",
               !layer.locked && "cursor-grab active:cursor-grabbing",
@@ -315,14 +327,7 @@ const LayerListItem = memo(function LayerListItem({
           onClick={(event) => onSelectLayer(layer.id, event)}
           type="button"
         >
-          <div
-            className={getThumbnailClassName(layer, asset)}
-            style={
-              asset?.kind === "image" || asset?.kind === "video"
-                ? { backgroundImage: `url("${asset.url}")` }
-                : undefined
-            }
-          />
+          <LayerThumbnail asset={asset} layer={layer} />
 
           <div className="flex min-w-0 min-h-7 items-center">
             <Typography
@@ -675,10 +680,10 @@ export function LayerSidebar() {
             </Typography>
             <div className="inline-flex items-center gap-1.5">
               <IconButton
-                aria-label="Enter immersive canvas mode"
+                aria-label="Hide UI (Cmd + .)"
                 className="pointer-events-auto"
                 onClick={enterImmersiveCanvas}
-                tooltip="Hide UI"
+                tooltip="Hide UI (Cmd + .)"
                 variant="ghost"
               >
                 <LayoutIcon height={14} width={14} />
@@ -758,10 +763,10 @@ export function LayerSidebar() {
                 </div>
                 <div className="inline-flex items-center gap-1.5">
                   <IconButton
-                    aria-label="Enter immersive canvas mode"
+                    aria-label="Hide UI (Cmd + .)"
                     className="pointer-events-auto"
                     onClick={enterImmersiveCanvas}
-                    tooltip="Hide UI"
+                    tooltip="Hide UI (Cmd + .)"
                     variant="ghost"
                   >
                     <LayoutIcon height={14} width={14} />

--- a/src/components/editor/properties-sidebar-content.tsx
+++ b/src/components/editor/properties-sidebar-content.tsx
@@ -48,9 +48,6 @@ import {
 export function EmptyPropertiesContent() {
   return (
     <div className="flex flex-col gap-1.5 p-4">
-      <Typography tone="secondary" variant="overline">
-        Properties
-      </Typography>
       <Typography variant="body">Select a layer to edit it.</Typography>
       <Typography tone="muted" variant="caption">
         Nothing to edit yet. Create a new layer in the left panel.
@@ -365,26 +362,25 @@ export function SelectedLayerPropertiesContent({
 
   return (
     <>
-      <div className="flex flex-col gap-1.5 border-b border-[var(--ds-border-divider)] px-4 pt-[14px] pb-3">
-        <div className="flex items-center justify-between gap-2">
-          <Typography tone="secondary" variant="overline">
-            Properties
-          </Typography>
+      <div className="flex flex-col gap-2 border-b border-[var(--ds-border-divider)] px-4 pt-[14px] pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex flex-col gap-1">
+            <Typography variant="title">{layerName}</Typography>
+            {layerSubtitle ? (
+              <Typography tone="muted" variant="monoXs">
+                {layerSubtitle}
+              </Typography>
+            ) : null}
+            {layerRuntimeError ? (
+              <Typography tone="muted" variant="caption">
+                {layerRuntimeError}
+              </Typography>
+            ) : null}
+          </div>
           <span className="inline-flex min-h-5 items-center rounded-[var(--ds-radius-icon)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-active)] px-[7px] font-[var(--ds-font-mono)] text-[10px] leading-3 text-[var(--ds-color-text-secondary)] capitalize">
             {formatLayerKind(layerKind)}
           </span>
         </div>
-        <Typography variant="title">{layerName}</Typography>
-        {layerSubtitle ? (
-          <Typography tone="muted" variant="monoXs">
-            {layerSubtitle}
-          </Typography>
-        ) : null}
-        {layerRuntimeError ? (
-          <Typography tone="muted" variant="caption">
-            {layerRuntimeError}
-          </Typography>
-        ) : null}
       </div>
 
       <div className="flex min-h-0 max-h-[min(62vh,620px)] flex-col gap-0 overflow-x-hidden overflow-y-auto">

--- a/src/components/editor/properties-sidebar.tsx
+++ b/src/components/editor/properties-sidebar.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { FloatingDesktopPanel } from "@/components/editor/floating-desktop-panel"
 import { GlassPanel } from "@/components/ui/glass-panel"
 import { IconButton } from "@/components/ui/icon-button"
+import { Typography } from "@/components/ui/typography"
 import { cn } from "@/lib/cn"
 import { getLayerDefinition } from "@/lib/editor/config/layer-registry"
 import { evaluateTimelineForLayers } from "@/lib/editor/timeline/evaluate"
@@ -624,15 +625,20 @@ export function PropertiesSidebar() {
                 className="flex h-full min-h-0 flex-col gap-0 p-0"
                 variant="panel"
               >
-                <div className="flex items-center justify-start border-b border-[var(--ds-border-divider)] px-3 py-1.5">
-                  <IconButton
-                    aria-label="Drag"
-                    className="h-7 w-7 cursor-grab text-[var(--ds-color-text-muted)] active:cursor-grabbing"
-                    variant="ghost"
-                    {...dragHandleProps}
-                  >
-                    <DragHandleDots2Icon height={14} width={14} />
-                  </IconButton>
+                <div className="flex items-center justify-start gap-2 border-b border-[var(--ds-border-divider)] px-3 py-1.5">
+                  <div className="inline-flex items-center gap-2">
+                    <IconButton
+                      aria-label="Move properties panel"
+                      className="h-7 w-7 cursor-grab text-[var(--ds-color-text-muted)] active:cursor-grabbing"
+                      variant="ghost"
+                      {...dragHandleProps}
+                    >
+                      <DragHandleDots2Icon height={14} width={14} />
+                    </IconButton>
+                    <Typography tone="secondary" variant="overline">
+                      {sidebarView === "scene" ? "Scene" : "Properties"}
+                    </Typography>
+                  </div>
                 </div>
                 <AnimatePresence initial={false} mode="wait">
                   {renderAnimatedContent()}

--- a/src/components/editor/scene-config-content.tsx
+++ b/src/components/editor/scene-config-content.tsx
@@ -157,162 +157,154 @@ export function SceneConfigContent() {
   )
 
   return (
-    <>
-      <div className="flex flex-col gap-1.5 border-b border-[var(--ds-border-divider)] px-4 pt-[14px] pb-3">
-        <Typography tone="secondary" variant="overline">
-          Scene
-        </Typography>
-      </div>
-
-      <div className="flex min-h-0 max-h-[min(62vh,620px)] flex-col gap-0 overflow-x-hidden overflow-y-auto">
-        {/* Composition */}
-        <Section title="Composition">
-          <Row label="Aspect">
-            <Select
-              onValueChange={(value) =>
-                handleUpdate("compositionAspect", value as CompositionAspect)
-              }
-              options={aspectOptions}
-              value={sceneConfig.compositionAspect}
-            />
-          </Row>
-          {sceneConfig.compositionAspect === "custom" && (
-            <div className="flex items-center justify-end gap-1.5">
-              <NumberInput
-                className={inputClassName}
-                min={1}
-                onChange={(value) =>
-                  handleUpdate("compositionWidth", Math.round(value))
-                }
-                parseValue={(value) => {
-                  const nextValue = Number.parseInt(value, 10)
-                  return Number.isFinite(nextValue) ? nextValue : null
-                }}
-                step={1}
-                value={sceneConfig.compositionWidth}
-              />
-              <Typography tone="muted" variant="monoXs">
-                :
-              </Typography>
-              <NumberInput
-                className={inputClassName}
-                min={1}
-                onChange={(value) =>
-                  handleUpdate("compositionHeight", Math.round(value))
-                }
-                parseValue={(value) => {
-                  const nextValue = Number.parseInt(value, 10)
-                  return Number.isFinite(nextValue) ? nextValue : null
-                }}
-                step={1}
-                value={sceneConfig.compositionHeight}
-              />
-            </div>
-          )}
-        </Section>
-
-        {/* Background */}
-        <Section title="Background">
-          <Row label="Color">
-            <ColorPicker
-              onValueChange={(value) => handleUpdate("backgroundColor", value)}
-              value={sceneConfig.backgroundColor}
-            />
-          </Row>
-        </Section>
-
-        {/* Color Adjustments */}
-        <Section title="Color Adjustments">
-          <Slider
-            label="Brightness"
-            max={100}
-            min={-100}
-            onValueChange={(value) => handleUpdate("brightness", value / 100)}
-            value={sceneConfig.brightness * 100}
-          />
-          <Slider
-            label="Contrast"
-            max={100}
-            min={-100}
-            onValueChange={(value) => handleUpdate("contrast", value / 100)}
-            value={sceneConfig.contrast * 100}
-          />
-          <Row label="Invert">
-            <Toggle
-              checked={sceneConfig.invert}
-              onCheckedChange={(value) => handleUpdate("invert", value)}
-            />
-          </Row>
-        </Section>
-
-        {/* Channel Mixer */}
-        <Section title="Channel Mixer">
-          <ChannelCurves
-            curves={channelCurves}
-            onCurveChange={handleCurveChange}
-          />
-        </Section>
-
-        {/* Clamp / Remap */}
-        <Section title="Clamp / Remap">
-          <Slider
-            label="Black Point"
-            max={100}
-            min={0}
-            onValueChange={(v) => handleUpdate("clampMin", v / 100)}
-            value={sceneConfig.clampMin * 100}
-          />
-          <Slider
-            label="White Point"
-            max={100}
-            min={0}
-            onValueChange={(v) => handleUpdate("clampMax", v / 100)}
-            value={sceneConfig.clampMax * 100}
-          />
-        </Section>
-
-        {/* Quantize */}
-        <Section title="Quantize">
-          <Slider
-            label="Levels"
-            max={256}
-            min={2}
+    <div className="flex min-h-0 max-h-[min(62vh,620px)] flex-col gap-0 overflow-x-hidden overflow-y-auto">
+      {/* Composition */}
+      <Section title="Composition">
+        <Row label="Aspect">
+          <Select
             onValueChange={(value) =>
-              handleUpdate("quantizeLevels", Math.round(value))
+              handleUpdate("compositionAspect", value as CompositionAspect)
             }
-            value={sceneConfig.quantizeLevels}
+            options={aspectOptions}
+            value={sceneConfig.compositionAspect}
           />
-        </Section>
-
-        {/* Color Map */}
-        <Section title="Color Map">
-          <Row label="Enabled">
-            <Toggle
-              checked={sceneConfig.colorMap !== null}
-              onCheckedChange={(enabled) => {
-                if (enabled) {
-                  updateSceneConfig({
-                    colorMap: {
-                      stops: [
-                        { position: 0, color: "#000000" },
-                        { position: 1, color: "#ffffff" },
-                      ],
-                    },
-                  })
-                } else {
-                  updateSceneConfig({ colorMap: null })
-                }
+        </Row>
+        {sceneConfig.compositionAspect === "custom" && (
+          <div className="flex items-center justify-end gap-1.5">
+            <NumberInput
+              className={inputClassName}
+              min={1}
+              onChange={(value) =>
+                handleUpdate("compositionWidth", Math.round(value))
+              }
+              parseValue={(value) => {
+                const nextValue = Number.parseInt(value, 10)
+                return Number.isFinite(nextValue) ? nextValue : null
               }}
+              step={1}
+              value={sceneConfig.compositionWidth}
             />
-          </Row>
-          {sceneConfig.colorMap && (
-            <GradientRamp
-              onChange={handleColorMapChange}
-              stops={sceneConfig.colorMap.stops}
+            <Typography tone="muted" variant="monoXs">
+              :
+            </Typography>
+            <NumberInput
+              className={inputClassName}
+              min={1}
+              onChange={(value) =>
+                handleUpdate("compositionHeight", Math.round(value))
+              }
+              parseValue={(value) => {
+                const nextValue = Number.parseInt(value, 10)
+                return Number.isFinite(nextValue) ? nextValue : null
+              }}
+              step={1}
+              value={sceneConfig.compositionHeight}
             />
-          )}
-        </Section>
-      </div>
-    </>
+          </div>
+        )}
+      </Section>
+
+      {/* Background */}
+      <Section title="Background">
+        <Row label="Color">
+          <ColorPicker
+            onValueChange={(value) => handleUpdate("backgroundColor", value)}
+            value={sceneConfig.backgroundColor}
+          />
+        </Row>
+      </Section>
+
+      {/* Color Adjustments */}
+      <Section title="Color Adjustments">
+        <Slider
+          label="Brightness"
+          max={100}
+          min={-100}
+          onValueChange={(value) => handleUpdate("brightness", value / 100)}
+          value={sceneConfig.brightness * 100}
+        />
+        <Slider
+          label="Contrast"
+          max={100}
+          min={-100}
+          onValueChange={(value) => handleUpdate("contrast", value / 100)}
+          value={sceneConfig.contrast * 100}
+        />
+        <Row label="Invert">
+          <Toggle
+            checked={sceneConfig.invert}
+            onCheckedChange={(value) => handleUpdate("invert", value)}
+          />
+        </Row>
+      </Section>
+
+      {/* Channel Mixer */}
+      <Section title="Channel Mixer">
+        <ChannelCurves
+          curves={channelCurves}
+          onCurveChange={handleCurveChange}
+        />
+      </Section>
+
+      {/* Clamp / Remap */}
+      <Section title="Clamp / Remap">
+        <Slider
+          label="Black Point"
+          max={100}
+          min={0}
+          onValueChange={(v) => handleUpdate("clampMin", v / 100)}
+          value={sceneConfig.clampMin * 100}
+        />
+        <Slider
+          label="White Point"
+          max={100}
+          min={0}
+          onValueChange={(v) => handleUpdate("clampMax", v / 100)}
+          value={sceneConfig.clampMax * 100}
+        />
+      </Section>
+
+      {/* Quantize */}
+      <Section title="Quantize">
+        <Slider
+          label="Levels"
+          max={256}
+          min={2}
+          onValueChange={(value) =>
+            handleUpdate("quantizeLevels", Math.round(value))
+          }
+          value={sceneConfig.quantizeLevels}
+        />
+      </Section>
+
+      {/* Color Map */}
+      <Section title="Color Map">
+        <Row label="Enabled">
+          <Toggle
+            checked={sceneConfig.colorMap !== null}
+            onCheckedChange={(enabled) => {
+              if (enabled) {
+                updateSceneConfig({
+                  colorMap: {
+                    stops: [
+                      { position: 0, color: "#000000" },
+                      { position: 1, color: "#ffffff" },
+                    ],
+                  },
+                })
+              } else {
+                updateSceneConfig({ colorMap: null })
+              }
+            }}
+          />
+        </Row>
+        {sceneConfig.colorMap && (
+          <GradientRamp
+            onChange={handleColorMapChange}
+            stops={sceneConfig.colorMap.stops}
+          />
+        )}
+      </Section>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- add the `Cmd + .` immersive canvas shortcut and expose it in the hide UI tooltip
- simplify the GitHub action to an icon-only link and tighten the timeline transport readout
- keep the properties/scene title in panel chrome and replace generic layer placeholders with type-specific Radix icons

## Verification
- `biome check src/components/editor/editor-shortcuts.tsx src/components/editor/editor-timeline-overlay.tsx src/components/editor/editor-topbar.tsx src/components/editor/properties-sidebar.tsx src/components/editor/properties-sidebar-content.tsx src/components/editor/scene-config-content.tsx src/components/editor/layer-sidebar.tsx`
- verified the Next.js dev server recompiles cleanly

## Notes
- `src/components/editor/properties-sidebar.tsx` still has two pre-existing `useExhaustiveDependencies` warnings unrelated to this PR