### PR TITLE
chore: fix pre-existing lint errors (prerequisite for plan PRs)

### DIFF
--- a/.changeset/lint-cleanup.md
+++ b/.changeset/lint-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@basementstudio/shader-lab": patch
+---
+
+Lint cleanup: convert type-only `three/webgpu` imports to `import type`, remove an unused suppression comment, and simplify a guard expression in the fluid runtime. No behavior changes.

--- a/packages/shader-lab-react/src/ambient/three-tsl.d.ts
+++ b/packages/shader-lab-react/src/ambient/three-tsl.d.ts
@@ -92,7 +92,6 @@ declare module "three/tsl" {
   export function cross(left: unknown, right: unknown): TSLNode
   export function div(left: unknown, right: unknown): TSLNode
   export function dot(left: unknown, right: unknown): TSLNode
-  // biome-ignore lint/suspicious/noExplicitAny: TSL Fn accepts both positional and destructured params
   export function Fn(
     fn: ShaderNodeFn | ((...args: never[]) => unknown),
     layout?: unknown

--- a/packages/shader-lab-react/src/fluid/runtime.ts
+++ b/packages/shader-lab-react/src/fluid/runtime.ts
@@ -351,9 +351,14 @@ export class ShaderLabFluidRuntime {
     color?: ShaderLabFluidSplatColor
   ): void {
     if (
-      !(this.readyState && this.renderer && this.velocity && this.density) ||
-      !this.splatMaterial ||
-      !this.splatTargetNode
+      !(
+        this.readyState &&
+        this.renderer &&
+        this.velocity &&
+        this.density &&
+        this.splatMaterial &&
+        this.splatTargetNode
+      )
     ) {
       return
     }

--- a/packages/shader-lab-react/src/renderer/chromatic-aberration-pass.ts
+++ b/packages/shader-lab-react/src/renderer/chromatic-aberration-pass.ts
@@ -11,7 +11,7 @@ import {
   vec2,
   vec4,
 } from "three/tsl"
-import * as THREE from "three/webgpu"
+import type * as THREE from "three/webgpu"
 import type { ShaderLabLayerConfig } from "../types"
 import { createPipelinePlaceholder, PassNode } from "./pass-node"
 

--- a/packages/shader-lab-react/src/renderer/directional-blur-pass.ts
+++ b/packages/shader-lab-react/src/renderer/directional-blur-pass.ts
@@ -1,4 +1,4 @@
-import * as THREE from "three/webgpu"
+import type * as THREE from "three/webgpu"
 import {
   cos,
   float,

--- a/packages/shader-lab-react/src/renderer/displacement-map-pass.ts
+++ b/packages/shader-lab-react/src/renderer/displacement-map-pass.ts
@@ -8,7 +8,7 @@ import {
   vec2,
   vec4,
 } from "three/tsl"
-import * as THREE from "three/webgpu"
+import type * as THREE from "three/webgpu"
 import type { ShaderLabLayerConfig } from "../types"
 import { createPipelinePlaceholder, PassNode } from "./pass-node"
 

--- a/packages/shader-lab-react/src/renderer/fluted-glass-pass.ts
+++ b/packages/shader-lab-react/src/renderer/fluted-glass-pass.ts
@@ -19,7 +19,7 @@ import {
   vec3,
   vec4,
 } from "three/tsl"
-import * as THREE from "three/webgpu"
+import type * as THREE from "three/webgpu"
 import type { LayerParameterValues } from "../types/editor"
 import { createPipelinePlaceholder, PassNode } from "./pass-node"
 import { simplexNoise3d } from "./shaders/tsl/noise/simplex-noise-3d"

--- a/src/components/editor/floating-desktop-panel.tsx
+++ b/src/components/editor/floating-desktop-panel.tsx
@@ -75,7 +75,9 @@ export function FloatingDesktopPanel({
   id,
   resolvePosition,
 }: FloatingDesktopPanelProps) {
-  const suppressResize = () => {}
+  const suppressResize = () => {
+    // Panels manage their own size; ignore resize requests from children.
+  }
   const panelRef = useRef<HTMLDivElement | null>(null)
   const dragStateRef = useRef<{
     pointerId: number

--- a/src/lib/editor/video-export-encoder.ts
+++ b/src/lib/editor/video-export-encoder.ts
@@ -232,7 +232,9 @@ async function probeEncoderConfig(
   config: VideoEncoderConfig,
   canvas: HTMLCanvasElement
 ): Promise<boolean> {
-  const result = createConfiguredEncoder(config, () => {})
+  const result = createConfiguredEncoder(config, () => {
+    // Probe only; errors are reported via the returned error() accessor.
+  })
 
   if (!result.encoder) {
     return false

--- a/src/types/three-tsl.d.ts
+++ b/src/types/three-tsl.d.ts
@@ -92,7 +92,6 @@ declare module "three/tsl" {
   export function cross(left: unknown, right: unknown): TSLNode
   export function div(left: unknown, right: unknown): TSLNode
   export function dot(left: unknown, right: unknown): TSLNode
-  // biome-ignore lint/suspicious/noExplicitAny: TSL Fn accepts both positional and destructured params
   export function Fn(
     fn: ShaderNodeFn | ((...args: never[]) => unknown),
     layout?: unknown


### PR DESCRIPTION
## Why

`bun run lint` fails on the unmodified tree (4 errors, 7 warnings). Every plan issue (#84–#91) gates on a clean lint run, and #85 (Plan 002) explicitly treats pre-existing lint errors as a STOP condition since adding a red gate to CI would block every PR. This small cleanup PR unblocks the whole series — the plan branches are stacked on it.

## What

- Convert type-only `three/webgpu` namespace imports to `import type` in four package pass files (the 4 `useImportType` errors)
- Remove unused `biome-ignore` suppression comments in both `three-tsl.d.ts` ambient declaration files
- Comment the two intentionally-empty callbacks (`noEmptyBlockStatements`)
- Simplify the `splat()` guard in the fluid runtime (boolean-algebra equivalent, `useSimplifiedLogicExpression`)

**Deliberately not fixed**: the two `useExhaustiveDependencies` warnings in `properties-sidebar.tsx`. Biome's autofix would remove `selectedLayerId` / timeline deps that are intentional effect triggers — that would change behavior. Warnings don't fail the lint gate.

Touches `packages/*` → patch changeset included (no runtime behavior changes; `import type` is erased at compile time).

## Verification

- `bun run lint` → exit 0 (2 warnings remain, see above)
- `bun run build:runtime`, `bun run typecheck:tsc`, package `typecheck` → all exit 0
- `bunx changeset status --since=origin/main` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)