### PR TITLE
test: establish a test baseline for the editor's pure serialization and math logic

### DIFF
--- a/src/lib/editor/__tests__/composition.test.ts
+++ b/src/lib/editor/__tests__/composition.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test"
+import {
+  getCenteredCropFrame,
+  getCompositionFrame,
+  intersectCompositionFrames,
+} from "@/lib/editor/composition"
+import { DEFAULT_SCENE_CONFIG } from "@/types/editor"
+
+describe("getCenteredCropFrame", () => {
+  test("ratio null returns the full canvas at the origin", () => {
+    expect(getCenteredCropFrame({ height: 1080, width: 1920 }, null)).toEqual({
+      height: 1080,
+      width: 1920,
+      x: 0,
+      y: 0,
+    })
+  })
+
+  test("wide ratio in a tall canvas spans full width, centered vertically", () => {
+    const frame = getCenteredCropFrame(
+      { height: 1920, width: 1080 },
+      16 / 9
+    )
+
+    expect(frame.width).toBe(1080)
+    expect(frame.height).toBe(Math.round(1080 / (16 / 9)))
+    expect(frame.x).toBe(0)
+    expect(frame.y).toBe(Math.round((1920 - frame.height) / 2))
+  })
+
+  test("tall ratio in a wide canvas spans full height, centered horizontally", () => {
+    const frame = getCenteredCropFrame(
+      { height: 1080, width: 1920 },
+      9 / 16
+    )
+
+    expect(frame.height).toBe(1080)
+    expect(frame.width).toBe(Math.round(1080 * (9 / 16)))
+    expect(frame.y).toBe(0)
+    expect(frame.x).toBe(Math.round((1920 - frame.width) / 2))
+  })
+
+  test("degenerate 0x0 canvas is clamped to a minimum of 1x1 with no NaN", () => {
+    const fullFrame = getCenteredCropFrame({ height: 0, width: 0 }, null)
+
+    expect(fullFrame).toEqual({ height: 1, width: 1, x: 0, y: 0 })
+
+    const croppedFrame = getCenteredCropFrame({ height: 0, width: 0 }, 16 / 9)
+
+    expect(croppedFrame.width).toBe(1)
+    expect(croppedFrame.height).toBeGreaterThanOrEqual(1)
+    expect(Number.isNaN(croppedFrame.x)).toBe(false)
+    expect(Number.isNaN(croppedFrame.y)).toBe(false)
+  })
+})
+
+describe("intersectCompositionFrames", () => {
+  test("overlapping frames intersect", () => {
+    const left = { height: 100, width: 100, x: 0, y: 0 }
+    const right = { height: 100, width: 100, x: 50, y: 50 }
+
+    expect(intersectCompositionFrames(left, right)).toEqual({
+      height: 50,
+      width: 50,
+      x: 50,
+      y: 50,
+    })
+  })
+
+  test("a frame contained in another intersects to the inner frame", () => {
+    const outer = { height: 1080, width: 1920, x: 0, y: 0 }
+    const inner = { height: 200, width: 300, x: 100, y: 100 }
+
+    expect(intersectCompositionFrames(outer, inner)).toEqual(inner)
+  })
+
+  test("non-overlapping frames collapse to a 1x1 frame at the max origin", () => {
+    // The implementation clamps width/height to >= 1 and keeps
+    // x/y at max(left, right), so disjoint inputs do not produce
+    // negative sizes — they degrade to a 1x1 frame.
+    const left = { height: 10, width: 10, x: 0, y: 0 }
+    const right = { height: 5, width: 5, x: 20, y: 20 }
+
+    expect(intersectCompositionFrames(left, right)).toEqual({
+      height: 1,
+      width: 1,
+      x: 20,
+      y: 20,
+    })
+  })
+})
+
+describe("getCompositionFrame", () => {
+  test("screen aspect returns the full canvas", () => {
+    const frame = getCompositionFrame(DEFAULT_SCENE_CONFIG, {
+      height: 900,
+      width: 1440,
+    })
+
+    expect(frame).toEqual({ height: 900, width: 1440, x: 0, y: 0 })
+  })
+
+  test("16:9 aspect crops a tall canvas", () => {
+    const frame = getCompositionFrame(
+      { ...DEFAULT_SCENE_CONFIG, compositionAspect: "16:9" },
+      { height: 1920, width: 1080 }
+    )
+
+    expect(frame.width).toBe(1080)
+    expect(frame.height).toBe(Math.round(1080 / (16 / 9)))
+  })
+})

--- a/src/lib/editor/__tests__/parameter-schema.test.ts
+++ b/src/lib/editor/__tests__/parameter-schema.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildParameterValues,
+  cloneParameterValue,
+  cloneParameterValues,
+  isParameterValueEqual,
+  parameterValuesSignature,
+  valueSignature,
+} from "@/lib/editor/parameter-schema"
+import type {
+  LayerParameterValues,
+  ParameterDefinitions,
+} from "@/types/editor"
+
+describe("cloneParameterValue", () => {
+  test("returns a new array instance for tuple values", () => {
+    const original: [number, number] = [1, 2]
+    const clone = cloneParameterValue(original)
+
+    expect(clone).not.toBe(original)
+    expect(clone).toEqual(original)
+  })
+
+  test("returns a new array instance for vec3 tuple values", () => {
+    const original: [number, number, number] = [0.1, 0.2, 0.3]
+    const clone = cloneParameterValue(original)
+
+    expect(clone).not.toBe(original)
+    expect(clone).toEqual(original)
+  })
+
+  test("passes primitives through unchanged", () => {
+    expect(cloneParameterValue(4)).toBe(4)
+    expect(cloneParameterValue("hello")).toBe("hello")
+    expect(cloneParameterValue(true)).toBe(true)
+    expect(cloneParameterValue(false)).toBe(false)
+  })
+})
+
+describe("cloneParameterValues", () => {
+  test("clones every entry", () => {
+    const source: LayerParameterValues = {
+      color: "#ff0000",
+      offset: [3, 4],
+      strength: 0.5,
+    }
+    const clone = cloneParameterValues(source)
+
+    expect(clone).not.toBe(source)
+    expect(clone).toEqual(source)
+    expect(clone.offset).not.toBe(source.offset)
+  })
+
+  test("mutating a cloned array value does not affect the source", () => {
+    const source: LayerParameterValues = {
+      offset: [3, 4],
+    }
+    const clone = cloneParameterValues(source)
+    const clonedOffset = clone.offset as [number, number]
+
+    clonedOffset[0] = 99
+
+    expect(source.offset).toEqual([3, 4])
+  })
+})
+
+describe("buildParameterValues", () => {
+  const definitions: ParameterDefinitions = [
+    {
+      defaultValue: 0.5,
+      key: "strength",
+      label: "Strength",
+      type: "number",
+    },
+    {
+      defaultValue: [1, 2],
+      key: "offset",
+      label: "Offset",
+      type: "vec2",
+    },
+    {
+      defaultValue: "#ffffff",
+      key: "color",
+      label: "Color",
+      type: "color",
+    },
+  ]
+
+  test("produces one entry per definition keyed by key", () => {
+    const values = buildParameterValues(definitions)
+
+    expect(Object.keys(values).sort()).toEqual(["color", "offset", "strength"])
+    expect(values.strength).toBe(0.5)
+    expect(values.color).toBe("#ffffff")
+  })
+
+  test("array defaults are equal to but not the same reference as the definition default", () => {
+    const values = buildParameterValues(definitions)
+    const offsetDefinition = definitions[1]
+
+    expect(values.offset).toEqual([1, 2])
+    expect(values.offset).not.toBe(offsetDefinition?.defaultValue)
+  })
+})
+
+describe("isParameterValueEqual", () => {
+  test("equal primitives", () => {
+    expect(isParameterValueEqual(1, 1)).toBe(true)
+    expect(isParameterValueEqual("a", "a")).toBe(true)
+    expect(isParameterValueEqual(true, true)).toBe(true)
+    expect(isParameterValueEqual(1, 2)).toBe(false)
+  })
+
+  test("equal tuples", () => {
+    expect(isParameterValueEqual([1, 2], [1, 2])).toBe(true)
+    expect(isParameterValueEqual([1, 2, 3], [1, 2, 3])).toBe(true)
+  })
+
+  test("unequal tuples", () => {
+    expect(isParameterValueEqual([1, 2], [1, 3])).toBe(false)
+    expect(isParameterValueEqual([1, 2], [1, 2, 3])).toBe(false)
+  })
+
+  test("tuple vs primitive", () => {
+    expect(isParameterValueEqual([1, 2], 1)).toBe(false)
+    expect(isParameterValueEqual(1, [1, 2])).toBe(false)
+  })
+})
+
+describe("valueSignature", () => {
+  test("is stable for equal inputs", () => {
+    expect(valueSignature(0.5)).toBe(valueSignature(0.5))
+    expect(valueSignature([1, 2])).toBe(valueSignature([1, 2]))
+    expect(valueSignature("#fff")).toBe(valueSignature("#fff"))
+  })
+
+  test("differs for different inputs", () => {
+    expect(valueSignature(0.5)).not.toBe(valueSignature(0.6))
+    expect(valueSignature([1, 2])).not.toBe(valueSignature([2, 1]))
+    expect(valueSignature(true)).not.toBe(valueSignature(false))
+  })
+})
+
+describe("parameterValuesSignature", () => {
+  test("is stable for equal inputs", () => {
+    const left: LayerParameterValues = { offset: [1, 2], strength: 0.5 }
+    const right: LayerParameterValues = { offset: [1, 2], strength: 0.5 }
+
+    expect(parameterValuesSignature(left)).toBe(
+      parameterValuesSignature(right)
+    )
+  })
+
+  test("differs for different inputs", () => {
+    const left: LayerParameterValues = { offset: [1, 2], strength: 0.5 }
+    const right: LayerParameterValues = { offset: [1, 2], strength: 0.6 }
+
+    expect(parameterValuesSignature(left)).not.toBe(
+      parameterValuesSignature(right)
+    )
+  })
+
+  test("does not depend on key insertion order", () => {
+    const ordered: LayerParameterValues = { alpha: 1, beta: 2 }
+    const reversed: LayerParameterValues = { beta: 2, alpha: 1 }
+
+    expect(parameterValuesSignature(ordered)).toBe(
+      parameterValuesSignature(reversed)
+    )
+  })
+})

--- a/src/lib/editor/__tests__/project-file.test.ts
+++ b/src/lib/editor/__tests__/project-file.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test"
+import {
+  type LabProjectFile,
+  parseLabProjectFile,
+} from "@/lib/editor/project-file"
+
+function createValidProjectFile(): LabProjectFile {
+  return {
+    assets: [],
+    composition: { height: 1080, width: 1920 },
+    exportedAt: "2026-06-10T00:00:00.000Z",
+    format: "shader-lab",
+    layers: [],
+    selectedLayerId: null,
+    timeline: { duration: 6, loop: true, tracks: [] },
+    version: 2,
+  }
+}
+
+describe("parseLabProjectFile", () => {
+  test("parses a valid v2 project file", () => {
+    const fixture = createValidProjectFile()
+    const parsed = parseLabProjectFile(JSON.stringify(fixture))
+
+    expect(parsed).toEqual(fixture)
+  })
+
+  test("returns a clone that is independent of later parses", () => {
+    const input = JSON.stringify(createValidProjectFile())
+    const first = parseLabProjectFile(input)
+
+    first.timeline.duration = 999
+    first.layers.push({} as never)
+
+    const second = parseLabProjectFile(input)
+
+    expect(second.timeline.duration).toBe(6)
+    expect(second.layers).toEqual([])
+  })
+
+  test("rejects input that is not valid JSON", () => {
+    expect(() => parseLabProjectFile("not json {")).toThrow(
+      "The selected file is not valid JSON."
+    )
+  })
+
+  test("rejects JSON that is not an object", () => {
+    expect(() => parseLabProjectFile("null")).toThrow(
+      "The selected file is not a valid Shader Lab project."
+    )
+  })
+
+  test("rejects a file with the wrong format marker", () => {
+    const fixture = { ...createValidProjectFile(), format: "other" }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "This file is not a Shader Lab `.lab` project."
+    )
+  })
+
+  test("rejects an unsupported version", () => {
+    const fixture = { ...createValidProjectFile(), version: 3 }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Unsupported Shader Lab project version."
+    )
+  })
+
+  test("accepts version 1", () => {
+    const fixture = { ...createValidProjectFile(), version: 1 }
+
+    expect(parseLabProjectFile(JSON.stringify(fixture)).version).toBe(1)
+  })
+
+  test("rejects a non-array layer stack", () => {
+    const fixture = { ...createValidProjectFile(), layers: "nope" }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Project file is missing a valid layer stack."
+    )
+  })
+
+  test("rejects missing timeline data", () => {
+    const { timeline: _timeline, ...fixture } = createValidProjectFile()
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Project file is missing timeline data."
+    )
+  })
+
+  test("rejects a timeline without a tracks array", () => {
+    const fixture = {
+      ...createValidProjectFile(),
+      timeline: { duration: 6, loop: true },
+    }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Project file is missing valid timeline tracks."
+    )
+  })
+
+  test("rejects a composition without a height", () => {
+    const fixture = {
+      ...createValidProjectFile(),
+      composition: { width: 1920 },
+    }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Project file is missing composition dimensions."
+    )
+  })
+})

--- a/src/lib/editor/__tests__/timeline-evaluate.test.ts
+++ b/src/lib/editor/__tests__/timeline-evaluate.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from "bun:test"
+import {
+  type KeyframeEasing,
+  LINEAR_EASING,
+  STEP_EASING,
+} from "@/lib/easing-curve"
+import { evaluateTimelineForLayers } from "@/lib/editor/timeline/evaluate"
+import type {
+  AnimatableValueType,
+  EditorLayer,
+  ParameterValue,
+  TimelineKeyframe,
+  TimelineTrack,
+} from "@/types/editor"
+
+function createLayer(id: string): EditorLayer {
+  return {
+    assetId: null,
+    blendMode: "normal",
+    compositeMode: "filter",
+    expanded: false,
+    hue: 0,
+    id,
+    kind: "effect",
+    locked: false,
+    maskConfig: { invert: false, mode: "multiply", source: "luminance" },
+    name: "Test Layer",
+    opacity: 1,
+    params: {},
+    runtimeError: null,
+    saturation: 1,
+    type: "posterize",
+    visible: true,
+  }
+}
+
+function createKeyframe(
+  id: string,
+  time: number,
+  value: ParameterValue,
+  easing: KeyframeEasing = LINEAR_EASING
+): TimelineKeyframe {
+  return { easing, id, time, value }
+}
+
+function createParamTrack(
+  layerId: string,
+  key: string,
+  valueType: AnimatableValueType,
+  keyframes: TimelineKeyframe[]
+): TimelineTrack {
+  return {
+    binding: { key, kind: "param", label: key, valueType },
+    enabled: true,
+    id: `track-${layerId}-${key}`,
+    keyframes,
+    layerId,
+  }
+}
+
+describe("evaluateTimelineForLayers", () => {
+  test("returns an empty array when there are no tracks", () => {
+    expect(evaluateTimelineForLayers([createLayer("a")], [], 0)).toEqual([])
+  })
+
+  test("ignores tracks whose layer does not exist", () => {
+    const track = createParamTrack("missing-layer", "amount", "number", [
+      createKeyframe("k1", 0, 0),
+      createKeyframe("k2", 1, 10),
+    ])
+
+    expect(
+      evaluateTimelineForLayers([createLayer("a")], [track], 0.5)
+    ).toEqual([])
+  })
+
+  test("ignores disabled tracks", () => {
+    const track = {
+      ...createParamTrack("a", "amount", "number", [
+        createKeyframe("k1", 0, 0),
+        createKeyframe("k2", 1, 10),
+      ]),
+      enabled: false,
+    }
+
+    expect(
+      evaluateTimelineForLayers([createLayer("a")], [track], 0.5)
+    ).toEqual([])
+  })
+
+  describe("numeric interpolation with linear easing", () => {
+    const layer = createLayer("a")
+    const track = createParamTrack("a", "amount", "number", [
+      createKeyframe("k1", 0, 0),
+      createKeyframe("k2", 1, 10),
+    ])
+
+    test("at t=0 returns the first keyframe value", () => {
+      expect(evaluateTimelineForLayers([layer], [track], 0)).toEqual([
+        { layerId: "a", params: { amount: 0 }, properties: {} },
+      ])
+    })
+
+    test("at t=1 returns the last keyframe value", () => {
+      expect(evaluateTimelineForLayers([layer], [track], 1)).toEqual([
+        { layerId: "a", params: { amount: 10 }, properties: {} },
+      ])
+    })
+
+    test("at t=0.5 returns the linear midpoint", () => {
+      expect(evaluateTimelineForLayers([layer], [track], 0.5)).toEqual([
+        { layerId: "a", params: { amount: 5 }, properties: {} },
+      ])
+    })
+  })
+
+  test("step easing holds the from-keyframe value until the next keyframe", () => {
+    const layer = createLayer("a")
+    const track = createParamTrack("a", "amount", "number", [
+      createKeyframe("k1", 0, 0, STEP_EASING),
+      createKeyframe("k2", 1, 10, STEP_EASING),
+    ])
+
+    expect(evaluateTimelineForLayers([layer], [track], 0.99)).toEqual([
+      { layerId: "a", params: { amount: 0 }, properties: {} },
+    ])
+    expect(evaluateTimelineForLayers([layer], [track], 1)).toEqual([
+      { layerId: "a", params: { amount: 10 }, properties: {} },
+    ])
+  })
+
+  test("interpolates hex colors channel-wise with rounding", () => {
+    const layer = createLayer("a")
+    const track = createParamTrack("a", "tint", "color", [
+      createKeyframe("k1", 0, "#000000"),
+      createKeyframe("k2", 1, "#ffffff"),
+    ])
+
+    // lerp(0, 255, 0.5) = 127.5; toHex rounds to 128 = 0x80.
+    expect(evaluateTimelineForLayers([layer], [track], 0.5)).toEqual([
+      { layerId: "a", params: { tint: "#808080" }, properties: {} },
+    ])
+  })
+
+  test("interpolates vec2 tuples component-wise", () => {
+    const layer = createLayer("a")
+    const track = createParamTrack("a", "offset", "vec2", [
+      createKeyframe("k1", 0, [0, 0]),
+      createKeyframe("k2", 1, [10, 20]),
+    ])
+
+    expect(evaluateTimelineForLayers([layer], [track], 0.5)).toEqual([
+      { layerId: "a", params: { offset: [5, 10] }, properties: {} },
+    ])
+  })
+
+  test("clamps to the first keyframe value before the first keyframe", () => {
+    const layer = createLayer("a")
+    const track = createParamTrack("a", "amount", "number", [
+      createKeyframe("k1", 1, 3),
+      createKeyframe("k2", 2, 7),
+    ])
+
+    expect(evaluateTimelineForLayers([layer], [track], 0)).toEqual([
+      { layerId: "a", params: { amount: 3 }, properties: {} },
+    ])
+  })
+
+  test("clamps to the last keyframe value after the last keyframe", () => {
+    const layer = createLayer("a")
+    const track = createParamTrack("a", "amount", "number", [
+      createKeyframe("k1", 1, 3),
+      createKeyframe("k2", 2, 7),
+    ])
+
+    expect(evaluateTimelineForLayers([layer], [track], 5)).toEqual([
+      { layerId: "a", params: { amount: 7 }, properties: {} },
+    ])
+  })
+
+  test("a single-keyframe track always yields that keyframe's value", () => {
+    const layer = createLayer("a")
+    const track = createParamTrack("a", "amount", "number", [
+      createKeyframe("k1", 1, 3),
+    ])
+
+    expect(evaluateTimelineForLayers([layer], [track], 0)).toEqual([
+      { layerId: "a", params: { amount: 3 }, properties: {} },
+    ])
+    expect(evaluateTimelineForLayers([layer], [track], 9)).toEqual([
+      { layerId: "a", params: { amount: 3 }, properties: {} },
+    ])
+  })
+
+  test("layer property bindings land in properties, not params", () => {
+    const layer = createLayer("a")
+    const track: TimelineTrack = {
+      binding: {
+        kind: "layer",
+        label: "Opacity",
+        property: "opacity",
+        valueType: "number",
+      },
+      enabled: true,
+      id: "track-a-opacity",
+      keyframes: [createKeyframe("k1", 0, 0), createKeyframe("k2", 1, 1)],
+      layerId: "a",
+    }
+
+    expect(evaluateTimelineForLayers([layer], [track], 0.5)).toEqual([
+      { layerId: "a", params: {}, properties: { opacity: 0.5 } },
+    ])
+  })
+
+  test("merges multiple tracks for the same layer into one state", () => {
+    const layer = createLayer("a")
+    const amountTrack = createParamTrack("a", "amount", "number", [
+      createKeyframe("k1", 0, 0),
+      createKeyframe("k2", 1, 10),
+    ])
+    const offsetTrack = createParamTrack("a", "offset", "vec2", [
+      createKeyframe("k3", 0, [0, 0]),
+      createKeyframe("k4", 1, [2, 2]),
+    ])
+
+    expect(
+      evaluateTimelineForLayers([layer], [amountTrack, offsetTrack], 0.5)
+    ).toEqual([
+      {
+        layerId: "a",
+        params: { amount: 5, offset: [1, 1] },
+        properties: {},
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Closes #84 (Plan 001).

## What

First test suite in the repo — 50 tests across 4 files, no source changes:

- `src/lib/editor/__tests__/project-file.test.ts` — `parseLabProjectFile`: valid v1/v2 parse, deep-clone semantics, and every user-facing validation error message (these strings are load-bearing: Plan 003 asserts them when it swaps the manual checks for zod)
- `src/lib/editor/__tests__/parameter-schema.test.ts` — clone semantics, `buildParameterValues`, equality, signature stability + key-order independence
- `src/lib/editor/__tests__/timeline-evaluate.test.ts` — linear/step easing, hex-color rounding (`#808080` from `Math.round(127.5)`), vec2 midpoints, clamping outside the keyframe range, disabled/unknown-layer tracks, layer-property bindings, multi-track merging
- `src/lib/editor/__tests__/composition.test.ts` — centered crop math, degenerate 0×0 canvas clamping, frame intersection incl. the documented 1×1 clamp for disjoint frames

## Plan notes

- The zustand store imports pulled in by `project-file.ts` load cleanly under `bun test` — the plan's STOP condition about browser-only globals did not trigger.
- No `// BUG:` findings — all observed behavior matched the implementations.
- `plans/README.md` does not exist in the repo (plans are tracked as issues #84–#91), so the status-row step is N/A.

## Verification

- `bun test` → 50 pass, 0 fail (4 files)
- `bun run typecheck:tsc` → exit 0
- `bun run lint` → exit 0

**Stacked on #92** (lint cleanup — required for the lint gate). Merge #92 first; GitHub will retarget this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)