### PR TITLE
ci: validate the editor app (lint, typecheck, tests), not just the published package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Build package
         run: bun run --cwd packages/shader-lab-react build
 
+      - name: Lint app
+        run: bun run lint
+
+      - name: Type check app
+        run: bun run typecheck:tsc
+
+      - name: Test
+        run: bun test
+
       - name: Ensure changeset exists for PR changes
         if: github.event_name == 'pull_request'
         run: bunx changeset status --since=origin/${{ github.base_ref }}


### PR DESCRIPTION
Closes #85 (Plan 002).

## What

Adds three steps to the `validate` job in `.github/workflows/ci.yml`, after "Build package" and before the changeset gate:

- **Lint app** — `bun run lint`
- **Type check app** — `bun run typecheck:tsc` (stock tsc, not the tsgo preview build)
- **Test** — `bun test` (the Plan 001 suite, 50 tests)

Existing steps and their order are untouched — the package build stays before the app typecheck because the app resolves `@basementstudio/shader-lab` from the package's `dist/`.

## Plan notes

- Step 1 gate: lint/typecheck initially **failed** on the unmodified tree (4 pre-existing biome errors) — the plan's STOP condition. Resolved by the prerequisite cleanup PR #92 rather than improvising here.
- `plans/README.md` doesn't exist in the repo (plans are the #84–#91 issues), so the status-row step is N/A.

## Verification

Exact CI sequence dry-run locally, single command chain:
`bun install --frozen-lockfile && bun run --cwd packages/shader-lab-react typecheck && bun run --cwd packages/shader-lab-react build && bun run lint && bun run typecheck:tsc && bun test` → exit 0.

**Stacked on #93** (Plan 001 — the tests this wires in) → which stacks on #92. Merge order: #92 → #93 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)