### PR TITLE
fix: close the video encoder on failed exports and time out stalled video texture loads

### DIFF
--- a/src/lib/editor/export.ts
+++ b/src/lib/editor/export.ts
@@ -340,6 +340,8 @@ export async function exportVideo(
     width: outputCanvas.width,
   })
 
+  let finalized = false
+
   try {
     throwIfAborted(options.abortSignal)
     await prewarmExportFrame(renderer, renderCanvas, projectState, {
@@ -416,8 +418,13 @@ export async function exportVideo(
     })
     throwIfAborted(options.abortSignal)
 
-    return await encoder.finalize()
+    const blob = await encoder.finalize()
+    finalized = true
+    return blob
   } finally {
+    if (!finalized) {
+      encoder.close()
+    }
     renderer.dispose()
     destroyHiddenRenderCanvas(renderCanvas)
   }

--- a/src/lib/editor/video-export-encoder.ts
+++ b/src/lib/editor/video-export-encoder.ts
@@ -29,6 +29,7 @@ type CreateVideoExportEncoderOptions = {
 }
 
 type VideoExportEncoder = {
+  close: () => void
   encodeCanvasFrame: (
     canvas: HTMLCanvasElement,
     frameIndex: number,
@@ -486,6 +487,12 @@ export async function createVideoExportEncoder(
   }
 
   return {
+    close() {
+      if (encoder.state !== "closed") {
+        encoder.close()
+      }
+    },
+
     async encodeCanvasFrame(canvas, frameIndex, duration, timestamp) {
       encoderError = getEncoderError?.() ?? encoderError
 

--- a/src/renderer/media-texture.ts
+++ b/src/renderer/media-texture.ts
@@ -2,6 +2,7 @@ import * as THREE from "three/webgpu"
 
 type VideoPlaybackMode = "export" | "live"
 const DEFAULT_SVG_RASTER_RESOLUTION = 2048
+const VIDEO_LOAD_TIMEOUT_MS = 30_000
 
 export interface ImageTextureSource {
   height?: number | null
@@ -227,6 +228,39 @@ export function createVideoTexture(url: string): Promise<VideoHandle> {
     let frozen = false
     let loop = true
     let playbackRate = 1
+    let settled = false
+
+    const timeoutId = setTimeout(() => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      video.onerror = null
+      video.src = ""
+      video.load()
+      reject(new Error(`Timed out loading video texture: ${url}`))
+    }, VIDEO_LOAD_TIMEOUT_MS)
+
+    const settleResolve = (handle: VideoHandle) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearTimeout(timeoutId)
+      resolve(handle)
+    }
+
+    const settleReject = (error: Error) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearTimeout(timeoutId)
+      reject(error)
+    }
 
     video.addEventListener(
       "playing",
@@ -254,7 +288,7 @@ export function createVideoTexture(url: string): Promise<VideoHandle> {
           await video.play()
         }
 
-        resolve({
+        settleResolve({
           dispose: () => {
             texture.dispose()
             video.pause()
@@ -323,13 +357,13 @@ export function createVideoTexture(url: string): Promise<VideoHandle> {
       "loadedmetadata",
       () => {
         video.playbackRate = playbackRate
-        video.play().catch(reject)
+        video.play().catch(settleReject)
       },
       { once: true }
     )
 
     video.onerror = () => {
-      reject(new Error(`Failed to load video texture: ${url}`))
+      settleReject(new Error(`Failed to load video texture: ${url}`))
     }
 
     video.src = url


### PR DESCRIPTION
Closes #88 (Plan 005).

## What

Two resource-lifecycle fixes in the export/media path:

**1. Encoder leak on failed/cancelled exports** — `exportVideo`'s `finally` disposed the renderer and hidden canvas but never closed the WebCodecs `VideoEncoder` (only the success path's `finalize()` did). Repeated failed/cancelled exports accumulate open hardware encoder instances until the browser cap makes later exports fail opaquely.
- `VideoExportEncoder` gains `close(): void`, guarded by `encoder.state !== "closed"` — idempotent and safe after `finalize()` (which leaves state `"closed"`; WebCodecs also closes state on fatal errors, so close-after-error is a no-op too).
- `exportVideo` tracks a `finalized` flag and calls `encoder.close()` in the existing `finally` when not finalized, before the preserved `renderer.dispose()` / `destroyHiddenRenderCanvas()` order.

**2. Stalled video loads hang forever** — `createVideoTexture`'s promise only settled on `playing` or error; a stalled video left the layer stuck loading and leaked the element. Now a 30 s timeout rejects with `Timed out loading video texture: <url>`, detaches handlers, clears `src`, and calls `load()` to release the element. `resolve`/`reject` are wrapped in settle helpers sharing a `settled` flag with the timer, so the timeout can never reject an already-settled promise and late events after timeout are ignored. Success path unchanged.

`packages/shader-lab-react/**` untouched (its `media-texture.ts` is a different 66-line module) — no changeset needed.

## Verification

- `bun test`, `bun run typecheck:tsc`, `bun run lint` → all exit 0
- Outstanding manual checks (will be run in-browser and recorded here): cancel-then-export loop (cancel 5×, then a full export succeeds); normal video layer loads as before.

**Stacked on #92** (lint cleanup). Merge #92 first; GitHub retargets this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)