### PR TITLE
fix: only invoke onRuntimeError with null after a previously reported error

### DIFF
--- a/.changeset/fix-onruntimeerror-null.md
+++ b/.changeset/fix-onruntimeerror-null.md
@@ -1,0 +1,5 @@
+---
+"@basementstudio/shader-lab": patch
+---
+
+`onRuntimeError` on `<ShaderLabComposition>` is no longer called with `null` after every successful renderer initialization. It now only fires with `null` once a previously reported error has been resolved, and consecutive identical messages are not repeated. Consumers that surfaced the message without a null check no longer show a false error state.

--- a/README.md
+++ b/README.md
@@ -90,10 +90,20 @@ Handle runtime errors:
 <ShaderLabComposition
   config={config}
   onRuntimeError={(message) => {
-    console.error(message)
+    if (message) {
+      console.error(message)
+    } else {
+      console.info("Shader Lab runtime error resolved.")
+    }
   }}
 />
 ```
+
+`onRuntimeError` is called with a string message when a runtime error occurs
+(renderer initialization failure, shader compilation error, missing WebGPU
+support). After an error has been reported, it is called once with `null` when
+the error is resolved so error UIs can recover. It is never called with `null`
+before an error has been reported.
 
 ## 2. Use a Composition as a Texture
 

--- a/packages/shader-lab-react/README.md
+++ b/packages/shader-lab-react/README.md
@@ -90,10 +90,20 @@ Handle runtime errors:
 <ShaderLabComposition
   config={config}
   onRuntimeError={(message) => {
-    console.error(message)
+    if (message) {
+      console.error(message)
+    } else {
+      console.info("Shader Lab runtime error resolved.")
+    }
   }}
 />
 ```
+
+`onRuntimeError` is called with a string message when a runtime error occurs
+(renderer initialization failure, shader compilation error, missing WebGPU
+support). After an error has been reported, it is called once with `null` when
+the error is resolved so error UIs can recover. It is never called with `null`
+before an error has been reported.
 
 ## 2. Use a Composition as a Texture
 

--- a/packages/shader-lab-react/src/shader-lab-composition.tsx
+++ b/packages/shader-lab-react/src/shader-lab-composition.tsx
@@ -9,6 +9,14 @@ import type { ShaderLabConfig } from "./types"
 export interface ShaderLabCompositionProps {
   className?: string
   config: ShaderLabConfig
+  /**
+   * Called with a string message when a runtime error occurs (renderer
+   * initialization failure, shader compilation error, missing WebGPU
+   * support). After a non-null error has been reported, it is called once
+   * with `null` when the error is resolved so error UIs can recover. It is
+   * never called with `null` before an error has been reported, and it is
+   * not called again for consecutive identical messages.
+   */
   onRuntimeError?: (message: string | null) => void
   style?: CSSProperties
 }
@@ -41,6 +49,7 @@ export function ShaderLabComposition({
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const frameRef = useRef<number | null>(null)
   const lastTimeRef = useRef<number | null>(null)
+  const lastReportedErrorRef = useRef<string | null>(null)
   const [runtimeError, setRuntimeError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -50,10 +59,19 @@ export function ShaderLabComposition({
       return
     }
 
-    if (!browserSupportsWebGPU()) {
-      const message = "WebGPU is not available in this browser."
+    const handleRuntimeError = (message: string | null) => {
       setRuntimeError(message)
+
+      if (message === lastReportedErrorRef.current) {
+        return
+      }
+
+      lastReportedErrorRef.current = message
       onRuntimeError?.(message)
+    }
+
+    if (!browserSupportsWebGPU()) {
+      handleRuntimeError("WebGPU is not available in this browser.")
       return
     }
 
@@ -64,11 +82,6 @@ export function ShaderLabComposition({
     let runtimeRenderer: Awaited<
       ReturnType<typeof createWebGPURenderer>
     > | null = null
-
-    const handleRuntimeError = (message: string | null) => {
-      setRuntimeError(message)
-      onRuntimeError?.(message)
-    }
 
     const getViewportSize = (): RendererSize => {
       const bounds = canvas.getBoundingClientRect()


### PR DESCRIPTION
Closes #81.

## Problem

`<ShaderLabComposition>` called `onRuntimeError(null)` after every successful renderer init and config change (the `null` was an internal "clear error state" signal leaking through the consumer callback). The README example doesn't null-check, so anyone copying it logged `null` errors — or pinned a permanent false error in their UI.

## Fix

`handleRuntimeError` still updates the internal overlay state unconditionally, but only invokes the consumer callback when the message differs from the last delivered one (tracked in a component-level ref that survives config-change effect re-runs). The `browserSupportsWebGPU()` failure branch now routes through the same funnel.

Consumer-visible behavior:

| Scenario | Before | After |
|---|---|---|
| First successful init | called with `null` | not called |
| Config change, still successful | called with `null` again | not called |
| Real error | called | called once |
| Same error repeats | called each time | deduplicated |
| Error then recovery | — | called with `null` exactly once |
| Recovery then new error | called | called with new message |

Also documents the semantics on the prop's JSDoc and updates both READMEs' example to null-check (with a paragraph explaining the `null`-on-recovery contract).

Patch changeset included.

## Verification

Package typecheck, `bun run build:runtime`, `bun run typecheck:tsc`, `bun run lint`, `bun test`, and `bunx changeset status --since=origin/main` all pass.

**Stacked on #92** (lint cleanup). Merge #92 first; GitHub retargets this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)