### PR TITLE
perf: lazy-load the export dialog and video-encoding stack out of the main editor bundle

### DIFF
--- a/src/components/editor/editor-topbar.tsx
+++ b/src/components/editor/editor-topbar.tsx
@@ -12,6 +12,7 @@ import {
   ZoomOutIcon,
 } from "@radix-ui/react-icons"
 import { AnimatePresence, motion } from "motion/react"
+import dynamic from "next/dynamic"
 import Link from "next/link"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { FloatingDesktopPanel } from "@/components/editor/floating-desktop-panel"
@@ -36,7 +37,11 @@ import {
   useSoundStore,
   useTimelineStore,
 } from "@/store"
-import { EditorExportDialog } from "./editor-export-dialog"
+
+const EditorExportDialog = dynamic(
+  () => import("./editor-export-dialog").then((mod) => mod.EditorExportDialog),
+  { ssr: false }
+)
 
 const HISTORY_COMMIT_DEBOUNCE_MS = 220
 const GITHUB_REPO_URL = "https://github.com/basementstudio/shader-lab"
@@ -94,6 +99,14 @@ export function EditorTopBar() {
   const toggleSoundEnabled = useSoundStore((state) => state.toggleEnabled)
 
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false)
+  const [hasOpenedExport, setHasOpenedExport] = useState(false)
+
+  const handleExportDialogOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      setHasOpenedExport(true)
+    }
+    setIsExportDialogOpen(open)
+  }, [])
   const applyingHistoryRef = useRef(false)
   const committedSnapshotRef = useRef(buildEditorHistorySnapshot())
   const pendingBaseSnapshotRef = useRef<ReturnType<
@@ -460,7 +473,7 @@ export function EditorTopBar() {
               <IconButton
                 aria-label="Export"
                 className="h-7 w-7 disabled:opacity-45"
-                onClick={() => setIsExportDialogOpen(true)}
+                onClick={() => handleExportDialogOpenChange(true)}
                 tooltip="Export"
                 tooltipSide="bottom"
                 uiSound="action.export"
@@ -542,7 +555,7 @@ export function EditorTopBar() {
               <IconButton
                 aria-label="Export"
                 className="h-7 w-7 disabled:opacity-45"
-                onClick={() => setIsExportDialogOpen(true)}
+                onClick={() => handleExportDialogOpenChange(true)}
                 tooltip="Download"
                 uiSound="action.export"
                 variant="default"
@@ -570,10 +583,12 @@ export function EditorTopBar() {
         </div>
       ) : null}
 
-      <EditorExportDialog
-        onOpenChange={setIsExportDialogOpen}
-        open={isExportDialogOpen}
-      />
+      {hasOpenedExport ? (
+        <EditorExportDialog
+          onOpenChange={handleExportDialogOpenChange}
+          open={isExportDialogOpen}
+        />
+      ) : null}
     </>
   )
 }

--- a/src/lib/editor/video-export-encoder.ts
+++ b/src/lib/editor/video-export-encoder.ts
@@ -1,13 +1,5 @@
 "use client"
 
-import {
-  ArrayBufferTarget as Mp4ArrayBufferTarget,
-  Muxer as Mp4Muxer,
-} from "mp4-muxer"
-import {
-  ArrayBufferTarget as WebMArrayBufferTarget,
-  Muxer as WebMMuxer,
-} from "webm-muxer"
 import type { VideoExportFormat } from "@/lib/editor/export"
 
 type Mp4MuxerCodec = "avc" | "hevc"
@@ -334,11 +326,13 @@ export async function getSupportedVideoExportConfig(
   )
 }
 
-function createMuxer(
+async function createMuxer(
   support: SupportedVideoExportConfig,
   options: CreateVideoExportEncoderOptions
-): VideoMuxer {
+): Promise<VideoMuxer> {
   if (support.format === "mp4") {
+    const { ArrayBufferTarget: Mp4ArrayBufferTarget, Muxer: Mp4Muxer } =
+      await import("mp4-muxer")
     const target = new Mp4ArrayBufferTarget()
     const muxer = new Mp4Muxer({
       fastStart: "in-memory",
@@ -363,6 +357,8 @@ function createMuxer(
     }
   }
 
+  const { ArrayBufferTarget: WebMArrayBufferTarget, Muxer: WebMMuxer } =
+    await import("webm-muxer")
   const target = new WebMArrayBufferTarget()
   const muxer = new WebMMuxer({
     firstTimestampBehavior: "offset",
@@ -449,7 +445,7 @@ export async function createVideoExportEncoder(
   let getEncoderError: (() => Error | null) | null = null
 
   for (const candidate of options.format === "mp4" ? supports : [support]) {
-    const nextMuxer = createMuxer(candidate, options)
+    const nextMuxer = await createMuxer(candidate, options)
     const result = createConfiguredEncoder(
       getAppliedEncoderConfig(candidate.encoderConfig, options),
       (chunk, meta) => {


### PR DESCRIPTION
Closes #87 (Plan 004).

## What

- **`video-export-encoder.ts`** — removed the static `mp4-muxer`/`webm-muxer` imports. `createMuxer` (single call site, inside the already-async encoder factory) is now async and dynamically imports **only the muxer for the chosen format** — the plan's preferred per-format option, which the existing `support.format` branch made natural. No module-scope muxer types needed (the codec unions are local string types).
- **`editor-topbar.tsx`** — `EditorExportDialog` (1788 lines + the whole export pipeline) is now `next/dynamic` with `ssr: false`. The dialog was previously rendered unconditionally, so per the plan there's also a `hasOpenedExport` latch: the chunk isn't even fetched until the first open, and the dialog stays mounted afterwards so close animations/state behave normally.

## Measurements (First Load JS, `/tools/shader-lab`)

Next 16 + Turbopack no longer prints per-route sizes in the build table, so numbers are the sum of script chunks referenced by the prerendered route HTML:

- Before: **2656.0 KB** (main chunk 2024.8 KB, muxers confirmed inside via `ftyp`/`matroska` signatures)
- After: **2556.1 KB** — **−99.9 KB (−3.8%)**
- New async chunks (loaded on demand): export dialog 46.3 KB, mp4-muxer 30.6 KB, webm-muxer 27.0 KB

## Verification

- `bun run build`, `bun run typecheck:tsc`, `bun run lint`, `bun test` → all exit 0
- Done-criteria greps pass: no value imports of either muxer under `src/`; topbar uses `next/dynamic`
- Outstanding manual checks (will be run in-browser and recorded here): dialog opens on Export click; short MP4 + WebM exports produce playable files

**Stacked on #92** (lint cleanup). Merge #92 first; GitHub retargets this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)