### PR TITLE
fix: harden .lab project import — zod validation, custom-shader consent gate, SVG raster cap

### DIFF
--- a/src/components/editor/editor-export-dialog.tsx
+++ b/src/components/editor/editor-export-dialog.tsx
@@ -50,6 +50,7 @@ import {
 import {
   applyLabProjectFile,
   buildLabProjectFile,
+  hasImportedCustomShaderCode,
   parseLabProjectFile,
 } from "@/lib/editor/project-file"
 import {
@@ -697,6 +698,20 @@ export function EditorExportDialog({
     try {
       const input = await file.text()
       const projectFile = parseLabProjectFile(input)
+
+      // Imported custom-shader source executes in the importer's browser, so
+      // require explicit consent before applying anything from the file.
+      // TODO(design): replace window.confirm with a styled confirm dialog.
+      if (
+        hasImportedCustomShaderCode(projectFile) &&
+        !window.confirm(
+          "This project contains custom shader code that will run in your browser. Only continue if you trust the source. Run custom shaders?"
+        )
+      ) {
+        setStatusMessage("Project import cancelled.")
+        return
+      }
+
       const result = applyLabProjectFile(
         projectFile,
         useAssetStore.getState().assets

--- a/src/lib/editor/__tests__/project-file.test.ts
+++ b/src/lib/editor/__tests__/project-file.test.ts
@@ -3,6 +3,7 @@ import {
   type LabProjectFile,
   parseLabProjectFile,
 } from "@/lib/editor/project-file"
+import type { EditorLayer } from "@/types/editor"
 
 function createValidProjectFile(): LabProjectFile {
   return {
@@ -14,6 +15,27 @@ function createValidProjectFile(): LabProjectFile {
     selectedLayerId: null,
     timeline: { duration: 6, loop: true, tracks: [] },
     version: 2,
+  }
+}
+
+function createValidLayer(): EditorLayer {
+  return {
+    assetId: null,
+    blendMode: "normal",
+    compositeMode: "filter",
+    expanded: true,
+    hue: 0,
+    id: "layer-1",
+    kind: "source",
+    locked: false,
+    maskConfig: { invert: false, mode: "multiply", source: "luminance" },
+    name: "Gradient",
+    opacity: 1,
+    params: { speed: 1 },
+    runtimeError: null,
+    saturation: 1,
+    type: "gradient",
+    visible: true,
   }
 }
 
@@ -108,5 +130,46 @@ describe("parseLabProjectFile", () => {
     expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
       "Project file is missing composition dimensions."
     )
+  })
+
+  test("rejects a layer entry that is not an object", () => {
+    const fixture = { ...createValidProjectFile(), layers: ["nope"] }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Project file is missing a valid layer stack."
+    )
+  })
+
+  test("rejects a non-finite composition dimension", () => {
+    const fixture = {
+      ...createValidProjectFile(),
+      composition: { height: 1080, width: Number.POSITIVE_INFINITY },
+    }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Project file is missing composition dimensions."
+    )
+  })
+
+  test("rejects a timeline duration that is not a number", () => {
+    const fixture = {
+      ...createValidProjectFile(),
+      timeline: { duration: "6", loop: true, tracks: [] },
+    }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Project file is missing timeline data."
+    )
+  })
+
+  test("preserves unknown extra keys in a layer's params", () => {
+    const layer = createValidLayer()
+    layer.params = { ...layer.params, futureParam: "kept" }
+    const fixture = { ...createValidProjectFile(), layers: [layer] }
+
+    const parsed = parseLabProjectFile(JSON.stringify(fixture))
+
+    expect(parsed.layers).toHaveLength(1)
+    expect(parsed.layers[0]?.params).toEqual({ futureParam: "kept", speed: 1 })
   })
 })

--- a/src/lib/editor/project-file.ts
+++ b/src/lib/editor/project-file.ts
@@ -1,8 +1,13 @@
+import { z } from "zod"
 import { useAssetStore } from "@/store/asset-store"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
 import { useTimelineStore } from "@/store/timeline-store"
 import { createDefaultColorCurves } from "@/lib/color-curves"
+import {
+  CUSTOM_EFFECT_STARTER,
+  CUSTOM_SHADER_STARTER,
+} from "@/lib/editor/custom-shader/shared"
 import type {
   EditorAsset,
   EditorLayer,
@@ -10,7 +15,15 @@ import type {
   SceneConfig,
   Size,
 } from "@/types/editor"
-import { DEFAULT_SCENE_CONFIG } from "@/types/editor"
+import {
+  BLEND_MODES,
+  DEFAULT_SCENE_CONFIG,
+  EFFECT_LAYER_TYPES,
+  LAYER_COMPOSITE_MODES,
+  MASK_MODES,
+  MASK_SOURCES,
+  SOURCE_LAYER_TYPES,
+} from "@/types/editor"
 
 export interface LabProjectFile extends ProjectPresetConfig {
   composition: Size
@@ -45,6 +58,139 @@ export function buildLabProjectFile(): LabProjectFile {
   }
 }
 
+const parameterValueSchema = z.union([
+  z.number(),
+  z.string(),
+  z.boolean(),
+  z.tuple([z.number(), z.number()]),
+  z.tuple([z.number(), z.number(), z.number()]),
+])
+
+const maskConfigSchema = z.looseObject({
+  invert: z.boolean(),
+  mode: z.enum(MASK_MODES),
+  source: z.enum(MASK_SOURCES),
+})
+
+// Fields shared by every layer kind. Later additions to `BaseLayer`
+// (e.g. `maskConfig`) stay optional so legacy `.lab` files keep importing.
+const baseLayerShape = {
+  assetId: z.string().nullable(),
+  blendMode: z.enum(BLEND_MODES),
+  compositeMode: z.enum(LAYER_COMPOSITE_MODES),
+  expanded: z.boolean(),
+  fluidInteractionEvents: z.array(z.looseObject({})).optional(),
+  hue: z.number(),
+  id: z.string(),
+  locked: z.boolean(),
+  maskConfig: maskConfigSchema.optional(),
+  name: z.string(),
+  opacity: z.number(),
+  params: z.record(z.string(), parameterValueSchema),
+  runtimeError: z.string().nullable().optional(),
+  saturation: z.number(),
+  visible: z.boolean(),
+}
+
+const layerSchema = z.discriminatedUnion("kind", [
+  z.looseObject({
+    ...baseLayerShape,
+    kind: z.literal("effect"),
+    type: z.enum(EFFECT_LAYER_TYPES),
+  }),
+  z.looseObject({
+    ...baseLayerShape,
+    kind: z.literal("model"),
+    type: z.literal("model"),
+  }),
+  z.looseObject({
+    ...baseLayerShape,
+    kind: z.literal("source"),
+    type: z.enum(SOURCE_LAYER_TYPES),
+  }),
+])
+
+const timelineKeyframeSchema = z.looseObject({
+  id: z.string(),
+  time: z.number(),
+  value: parameterValueSchema,
+})
+
+const timelineTrackSchema = z.looseObject({
+  binding: z.looseObject({}),
+  enabled: z.boolean(),
+  id: z.string(),
+  keyframes: z.array(timelineKeyframeSchema),
+  layerId: z.string(),
+})
+
+const assetReferenceSchema = z.looseObject({
+  fileName: z.string(),
+  id: z.string(),
+  kind: z.string(),
+})
+
+const labProjectFileSchema = z.looseObject({
+  assets: z.array(assetReferenceSchema),
+  composition: z.looseObject({
+    height: z.number().positive(),
+    width: z.number().positive(),
+  }),
+  exportedAt: z.string().optional(),
+  format: z.literal("shader-lab"),
+  layers: z.array(layerSchema),
+  sceneConfig: z.looseObject({}).optional(),
+  selectedLayerId: z.string().nullable().optional(),
+  timeline: z.looseObject({
+    duration: z.number(),
+    loop: z.boolean(),
+    tracks: z.array(timelineTrackSchema),
+  }),
+  version: z.union([z.literal(1), z.literal(2)]),
+})
+
+// Checked in order; the first rule matching any issue path wins so the
+// user-facing wording stays identical to the pre-zod manual checks.
+const PARSE_ISSUE_MESSAGES: {
+  matches: (path: readonly PropertyKey[]) => boolean
+  message: string
+}[] = [
+  {
+    matches: (path) => path[0] === "format",
+    message: "This file is not a Shader Lab `.lab` project.",
+  },
+  {
+    matches: (path) => path[0] === "version",
+    message: "Unsupported Shader Lab project version.",
+  },
+  {
+    matches: (path) => path[0] === "layers",
+    message: "Project file is missing a valid layer stack.",
+  },
+  {
+    matches: (path) => path[0] === "timeline" && path[1] === "tracks",
+    message: "Project file is missing valid timeline tracks.",
+  },
+  {
+    matches: (path) => path[0] === "timeline",
+    message: "Project file is missing timeline data.",
+  },
+  {
+    matches: (path) => path[0] === "composition",
+    message: "Project file is missing composition dimensions.",
+  },
+]
+
+function toParseError(issues: readonly z.core.$ZodIssue[]): Error {
+  for (const rule of PARSE_ISSUE_MESSAGES) {
+    if (issues.some((issue) => rule.matches(issue.path))) {
+      return new Error(rule.message)
+    }
+  }
+
+  return new Error("The selected file is not a valid Shader Lab project.")
+}
+
 export function parseLabProjectFile(input: string): LabProjectFile {
   let parsed: unknown
 
@@ -58,37 +204,41 @@ export function parseLabProjectFile(input: string): LabProjectFile {
     throw new Error("The selected file is not a valid Shader Lab project.")
   }
 
-  const candidate = parsed as Partial<LabProjectFile>
+  const result = labProjectFileSchema.safeParse(parsed)
 
-  if (candidate.format !== "shader-lab") {
-    throw new Error("This file is not a Shader Lab `.lab` project.")
+  if (!result.success) {
+    throw toParseError(result.error.issues)
   }
 
-  if (!(candidate.version === 1 || candidate.version === 2)) {
-    throw new Error("Unsupported Shader Lab project version.")
-  }
+  return structuredClone(result.data) as unknown as LabProjectFile
+}
 
-  if (!Array.isArray(candidate.layers)) {
-    throw new Error("Project file is missing a valid layer stack.")
-  }
+const CUSTOM_SHADER_STARTER_SOURCES = new Set<string>([
+  CUSTOM_EFFECT_STARTER,
+  CUSTOM_SHADER_STARTER,
+])
 
-  if (!(candidate.timeline && typeof candidate.timeline === "object")) {
-    throw new Error("Project file is missing timeline data.")
-  }
+/**
+ * Whether the project ships custom-shader source that differs from the
+ * built-in starters — i.e. code authored elsewhere that would execute in the
+ * importer's browser and should require explicit consent first.
+ */
+export function hasImportedCustomShaderCode(
+  projectFile: LabProjectFile
+): boolean {
+  return projectFile.layers.some((layer) => {
+    if (layer.type !== "custom-shader") {
+      return false
+    }
 
-  if (!Array.isArray(candidate.timeline.tracks)) {
-    throw new Error("Project file is missing valid timeline tracks.")
-  }
+    const sourceCode = layer.params.sourceCode
 
-  if (
-    !(candidate.composition && typeof candidate.composition === "object") ||
-    typeof candidate.composition.width !== "number" ||
-    typeof candidate.composition.height !== "number"
-  ) {
-    throw new Error("Project file is missing composition dimensions.")
-  }
-
-  return structuredClone(candidate as LabProjectFile)
+    return (
+      typeof sourceCode === "string" &&
+      sourceCode.trim().length > 0 &&
+      !CUSTOM_SHADER_STARTER_SOURCES.has(sourceCode)
+    )
+  })
 }
 
 export function applyLabProjectFile(

--- a/src/renderer/pipeline-manager.ts
+++ b/src/renderer/pipeline-manager.ts
@@ -45,7 +45,7 @@ function parseSvgRasterResolution(value: unknown): number {
     return 2048
   }
 
-  return Math.round(parsed)
+  return Math.min(8192, Math.round(parsed))
 }
 
 function createLayerSignature(layer: RenderableLayerPass): string {


### PR DESCRIPTION
Closes #86 (Plan 003).

## Why

Opening a shared `.lab` file currently executes the author's JavaScript in the importer's browser: custom-shader `sourceCode` is serialized into the file, `parseLabProjectFile` validated only the top-level shape then `structuredClone`d everything into the stores, and the custom-shader pass compiles+runs that source via `new Function`. A secondary DoS: `svgRasterResolution` was sized into a canvas with no upper bound.

Custom shaders running arbitrary TSL is the feature — this doesn't sandbox authoring. It (a) validates imports with zod, (b) requires one explicit confirmation before imported custom-shader code runs, (c) caps the SVG raster resolution.

## What

- **zod schema** (`project-file.ts`) — `parseLabProjectFile` now `safeParse`s. Strict where it matters (format literal, version 1|2, layer `kind`/`type` via `discriminatedUnion` against the real type enums, blend/composite/mask enums, positive-finite composition dims, timeline field types); loose where data must round-trip (`z.looseObject` on layers/tracks/keyframes/assets so unknown keys survive; `params` is a record of the exact `ParameterValue` union — unknown param *keys* preserved). Legacy-compat: `maskConfig`/`fluidInteractionEvents`/`runtimeError` are optional because they post-date the format. An ordered issue→message map keeps the **exact** pre-existing error strings, so all Plan 001 tests pass unmodified.
- **Consent gate** (`editor-export-dialog.tsx`, the single import call site) — after a successful parse and **before** `applyLabProjectFile`, `hasImportedCustomShaderCode()` checks for any custom-shader layer whose `sourceCode` is non-empty and differs from both built-in starters; if so, `window.confirm` (styled dialog flagged as a design follow-up in a TODO) gates it. Cancel aborts the whole import without touching any store.
- **SVG cap** (`pipeline-manager.ts`) — `parseSvgRasterResolution` now returns `Math.min(8192, Math.round(parsed))`.

## Tests

4 new `project-file.test.ts` cases (string layer entry rejected, `Infinity` width rejected, string `duration` rejected, unknown param keys preserved) on top of the 11 Plan 001 cases.

## Verification

- `bun test` → 54 pass (project-file: 15)
- `bun run typecheck:tsc`, `bun run lint` → exit 0
- Outstanding manual checks (in-browser, will record here): re-import a project with edited custom-shader source → confirm appears before any code runs; Cancel aborts; Confirm loads and runs; starter-only/no-custom-shader imports silently; normal round-trip unchanged; SVG > 8192 rasterizes at 8192.

App-only changes → no changeset. **Stacked on #93** (Plan 001 — its tests are the regression net) → #92. Merge order: #92 → #93 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)