### PR TITLE
feat: blob-tracking layer foundation — CPU tracker + inner-effects modules (plan 008 S1.2/S2.1)

### DIFF
--- a/plans/008-artifacts/status.md
+++ b/plans/008-artifacts/status.md
@@ -1,0 +1,58 @@
+# Blob-tracking layer (plan 008) — foundation delivered, GPU stages deferred
+
+## What this PR contains
+
+The two **pure, browser-independent, fully unit-tested** modules that plan 008
+deliberately isolates as its independently-landable foundation, plus the
+readback-API confirmation from the S1.1 spike:
+
+- `src/lib/blob-tracking/tracker.ts` — the CPU tracker (S1.2). Zero DOM/three
+  imports so it runs under `bun test` and mirrors into the package unchanged.
+  Motion/luminance binarization with `auto` fallback, 4-connected component
+  labeling, top-N by area, persistent greedy-NN matching + EMA smoothing +
+  grace despawn + monotonic ids + position-history ring, `reset()`, and the
+  once-per-distinct-`time` step guard.
+- `src/lib/blob-tracking/inner-effects.ts` — the inner-effect set (S2.1:
+  `EFFECT_LAYER_TYPES` minus `blur`) and tolerant `parseInnerEffectParams` /
+  `serializeInnerEffectParams`.
+- `__tests__/tracker.test.ts` (10) + `__tests__/inner-effects.test.ts` (9),
+  covering the full S1.2 and S2.1 case lists.
+
+Both modules are unwired: nothing registers a `blob-tracking` layer yet, so the
+editor's behavior is unchanged and no unverified/broken option appears in the
+picker. This is the safe, reviewable slice of a multi-day feature.
+
+## S1.1 readback spike result
+
+`renderer.readRenderTargetPixelsAsync(renderTarget, x, y, width, height)`
+exists in the installed `three@0.183.2`
+(`node_modules/three/src/renderers/common/Renderer.js:2884`), returns a Promise
+via `backend.copyTextureToBuffer(...)`, and matches the signature the plan
+assumes. The plan's STOP condition ("API doesn't exist") does **not** trigger.
+Runtime confirmation that it *resolves with plausible pixel data on the WebGPU
+backend* still requires a browser (see below).
+
+## What is deferred, and why
+
+The remaining stages are **GPU/DOM-bound and cannot be verified in this
+environment** — there is no WebGPU-capable browser reachable here (chrome
+tooling is pinned to the Chrome `stable` channel, which is not installed).
+Shipping them unverified would risk exactly the failure modes the plan calls
+out (nondeterministic export, decoration leakage into the mask, child-pass GPU
+leaks, readback throwing out of `render`). Deferred to a follow-up done at a
+workstation with a WebGPU browser:
+
+- **S1.3–S1.5**: register the layer (types/registry/factory/picker/shader-export
+  unsupported list), implement `BlobTrackingPass` (analysis RTs + feedback
+  swap, readback queue, SDF composite, `outputMode` mask), and verify live
+  tracking + export-twice determinism.
+- **S2.2–S2.4**: inner-effect child pass + sidebar section + the 22-type render
+  matrix.
+- **S3**: decoration overlay canvas (outlines/labels/lines/trails).
+- **S4**: package mirror (`packages/shader-lab-react/**`), README, changeset,
+  preview `.webp`.
+
+The tracker's public API (`step(grid, w, h, time, config)` / `getBlobs()` /
+`reset()`) is designed to be exactly what `BlobTrackingPass` and its package
+mirror will consume, so this foundation is not throwaway — it unblocks and
+de-risks the GPU stages.

--- a/src/lib/blob-tracking/__tests__/inner-effects.test.ts
+++ b/src/lib/blob-tracking/__tests__/inner-effects.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import {
+  INNER_EFFECT_NONE,
+  INNER_EFFECT_TYPES,
+  isInnerEffectType,
+  parseInnerEffectParams,
+  serializeInnerEffectParams,
+} from "@/lib/blob-tracking/inner-effects"
+
+describe("inner-effect set", () => {
+  test("excludes blur (no pass implementation)", () => {
+    expect(INNER_EFFECT_TYPES).not.toContain("blur")
+  })
+
+  test("includes a representative pass-backed effect", () => {
+    expect(INNER_EFFECT_TYPES).toContain("posterize")
+  })
+
+  test("recognizes valid inner effect types including none", () => {
+    expect(isInnerEffectType(INNER_EFFECT_NONE)).toBe(true)
+    expect(isInnerEffectType("posterize")).toBe(true)
+    expect(isInnerEffectType("blur")).toBe(false)
+    expect(isInnerEffectType("nonsense")).toBe(false)
+    expect(isInnerEffectType(42)).toBe(false)
+  })
+})
+
+describe("parseInnerEffectParams", () => {
+  test("none yields no parameters", () => {
+    expect(parseInnerEffectParams(INNER_EFFECT_NONE, "{}")).toEqual({})
+  })
+
+  test("fills defaults and applies a valid override (round-trip)", () => {
+    const serialized = serializeInnerEffectParams({
+      gamma: 1,
+      levels: 8,
+      mode: "luma",
+    })
+    const parsed = parseInnerEffectParams("posterize", serialized)
+
+    expect(parsed).toEqual({ gamma: 1, levels: 8, mode: "luma" })
+  })
+
+  test("bad JSON falls back to defaults", () => {
+    const parsed = parseInnerEffectParams("posterize", "not json {")
+
+    // posterize defaults from the registry
+    expect(parsed).toEqual({ gamma: 1, levels: 5, mode: "rgb" })
+  })
+
+  test("drops unknown keys", () => {
+    const parsed = parseInnerEffectParams(
+      "posterize",
+      JSON.stringify({ bogus: 123, levels: 12 })
+    )
+
+    expect(parsed.levels).toBe(12)
+    expect(parsed).not.toHaveProperty("bogus")
+  })
+
+  test("ignores values whose type does not match the definition", () => {
+    const parsed = parseInnerEffectParams(
+      "posterize",
+      JSON.stringify({ levels: "eight", mode: "luma" })
+    )
+
+    // levels stays at its numeric default; mode override is applied
+    expect(parsed.levels).toBe(5)
+    expect(parsed.mode).toBe("luma")
+  })
+
+  test("rejects an unknown inner effect type", () => {
+    expect(() =>
+      parseInnerEffectParams("blur" as never, "{}")
+    ).toThrow("Unknown inner effect type: blur")
+  })
+})

--- a/src/lib/blob-tracking/__tests__/tracker.test.ts
+++ b/src/lib/blob-tracking/__tests__/tracker.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test"
+import {
+  BlobTracker,
+  STATIC_STEPS_BEFORE_FALLBACK,
+  type TrackerConfig,
+  TRACK_GRACE_FRAMES,
+} from "@/lib/blob-tracking/tracker"
+
+type Cell = { luma?: number; motion?: number }
+
+function makeGrid(
+  width: number,
+  height: number,
+  cell: (x: number, y: number) => Cell
+): Uint8Array {
+  const grid = new Uint8Array(width * height * 4)
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const { luma = 0, motion = 0 } = cell(x, y)
+      const index = (y * width + x) * 4
+      grid[index] = motion
+      grid[index + 1] = luma
+      grid[index + 3] = 255
+    }
+  }
+  return grid
+}
+
+function lumaBlock(
+  width: number,
+  height: number,
+  blocks: { luma?: number; x0: number; x1: number; y0: number; y1: number }[]
+): Uint8Array {
+  return makeGrid(width, height, (x, y) => {
+    for (const block of blocks) {
+      if (x >= block.x0 && x <= block.x1 && y >= block.y0 && y <= block.y1) {
+        return { luma: block.luma ?? 255 }
+      }
+    }
+    return {}
+  })
+}
+
+function config(overrides: Partial<TrackerConfig> = {}): TrackerConfig {
+  return {
+    blobAmount: 32,
+    detectionMode: "luminance",
+    minBlobSize: 1,
+    motionThreshold: 0.2,
+    persistentTracking: false,
+    sensitivity: 0.5,
+    smoothing: 0,
+    ...overrides,
+  }
+}
+
+describe("BlobTracker detection", () => {
+  test("clusters a single connected component", () => {
+    const grid = lumaBlock(8, 8, [{ x0: 2, x1: 3, y0: 2, y1: 3 }])
+    const tracker = new BlobTracker()
+
+    tracker.step(grid, 8, 8, 0, config())
+    const blobs = tracker.getBlobs()
+
+    expect(blobs).toHaveLength(1)
+    expect(blobs[0]?.area).toBe(4)
+    expect(blobs[0]?.cx).toBeCloseTo((2.5 + 0.5) / 8, 5)
+    expect(blobs[0]?.cy).toBeCloseTo((2.5 + 0.5) / 8, 5)
+  })
+
+  test("does not merge separated components", () => {
+    const grid = lumaBlock(8, 8, [
+      { x0: 0, x1: 1, y0: 0, y1: 1 },
+      { x0: 5, x1: 6, y0: 5, y1: 6 },
+    ])
+    const tracker = new BlobTracker()
+
+    tracker.step(grid, 8, 8, 0, config())
+
+    expect(tracker.getBlobs()).toHaveLength(2)
+  })
+
+  test("drops components smaller than minBlobSize", () => {
+    const grid = lumaBlock(8, 8, [
+      { x0: 0, x1: 0, y0: 0, y1: 0 }, // area 1
+      { x0: 4, x1: 5, y0: 4, y1: 5 }, // area 4
+    ])
+    const tracker = new BlobTracker()
+
+    tracker.step(grid, 8, 8, 0, config({ minBlobSize: 2 }))
+    expect(tracker.getBlobs()).toHaveLength(1)
+    expect(tracker.getBlobs()[0]?.area).toBe(4)
+
+    tracker.reset()
+    tracker.step(grid, 8, 8, 0, config({ minBlobSize: 1 }))
+    expect(tracker.getBlobs()).toHaveLength(2)
+  })
+
+  test("keeps only the top-N components by area", () => {
+    const grid = lumaBlock(10, 10, [
+      { x0: 0, x1: 0, y0: 0, y1: 0 }, // area 1
+      { x0: 3, x1: 4, y0: 3, y1: 4 }, // area 4
+      { x0: 6, x1: 8, y0: 6, y1: 8 }, // area 9
+    ])
+    const tracker = new BlobTracker()
+
+    tracker.step(grid, 10, 10, 0, config({ blobAmount: 2 }))
+    const areas = tracker
+      .getBlobs()
+      .map((blob) => blob.area)
+      .sort((left, right) => right - left)
+
+    expect(areas).toEqual([9, 4])
+  })
+})
+
+describe("BlobTracker persistent tracking", () => {
+  test("keeps a stable id across a motion sequence", () => {
+    const tracker = new BlobTracker()
+    const cfg = config({ persistentTracking: true })
+
+    tracker.step(lumaBlock(16, 16, [{ x0: 2, x1: 3, y0: 2, y1: 3 }]), 16, 16, 0, cfg)
+    const firstId = tracker.getBlobs()[0]?.id
+    expect(firstId).toBeDefined()
+
+    tracker.step(lumaBlock(16, 16, [{ x0: 3, x1: 4, y0: 3, y1: 4 }]), 16, 16, 1, cfg)
+    tracker.step(lumaBlock(16, 16, [{ x0: 4, x1: 5, y0: 4, y1: 5 }]), 16, 16, 2, cfg)
+
+    expect(tracker.getBlobs()).toHaveLength(1)
+    expect(tracker.getBlobs()[0]?.id).toBe(firstId as number)
+  })
+
+  test("despawns an unmatched track after the grace window", () => {
+    const tracker = new BlobTracker()
+    const cfg = config({ persistentTracking: true })
+    const empty = makeGrid(16, 16, () => ({}))
+
+    tracker.step(lumaBlock(16, 16, [{ x0: 2, x1: 3, y0: 2, y1: 3 }]), 16, 16, 0, cfg)
+    expect(tracker.getBlobs()).toHaveLength(1)
+
+    for (let frame = 1; frame <= TRACK_GRACE_FRAMES; frame += 1) {
+      tracker.step(empty, 16, 16, frame, cfg)
+    }
+    expect(tracker.getBlobs()).toHaveLength(1)
+    expect(tracker.getBlobs()[0]?.active).toBe(false)
+
+    tracker.step(empty, 16, 16, TRACK_GRACE_FRAMES + 1, cfg)
+    expect(tracker.getBlobs()).toHaveLength(0)
+  })
+
+  test("EMA smoothing converges toward the detection", () => {
+    const tracker = new BlobTracker()
+    const cfg = config({ persistentTracking: true, smoothing: 0.5 })
+
+    // Establish a track on the left.
+    tracker.step(lumaBlock(20, 20, [{ x0: 1, x1: 2, y0: 9, y1: 10 }]), 20, 20, 0, cfg)
+    const start = tracker.getBlobs()[0]?.cx as number
+
+    // Feed a fixed detection on the right; the track should approach it.
+    const target = lumaBlock(20, 20, [{ x0: 15, x1: 16, y0: 9, y1: 10 }])
+    tracker.step(target, 20, 20, 1, cfg)
+    const afterOne = tracker.getBlobs()[0]?.cx as number
+
+    for (let frame = 2; frame < 20; frame += 1) {
+      tracker.step(target, 20, 20, frame, cfg)
+    }
+    const converged = tracker.getBlobs()[0]?.cx as number
+    const targetCx = (15.5 + 0.5) / 20
+
+    expect(afterOne).toBeGreaterThan(start)
+    expect(afterOne).toBeLessThan(targetCx)
+    expect(converged).toBeCloseTo(targetCx, 3)
+  })
+})
+
+describe("BlobTracker temporal guards", () => {
+  test("advances state at most once per distinct time", () => {
+    const tracker = new BlobTracker()
+    const cfg = config({ persistentTracking: true })
+    const grid = lumaBlock(16, 16, [{ x0: 2, x1: 3, y0: 2, y1: 3 }])
+
+    tracker.step(grid, 16, 16, 5, cfg)
+    tracker.step(grid, 16, 16, 5, cfg) // same time — must no-op
+    expect(tracker.getBlobs()[0]?.history).toHaveLength(1)
+
+    tracker.step(grid, 16, 16, 6, cfg)
+    expect(tracker.getBlobs()[0]?.history).toHaveLength(2)
+  })
+
+  test("reset clears blobs and restarts ids", () => {
+    const tracker = new BlobTracker()
+    const cfg = config({ persistentTracking: true })
+    const grid = lumaBlock(16, 16, [{ x0: 2, x1: 3, y0: 2, y1: 3 }])
+
+    tracker.step(grid, 16, 16, 0, cfg)
+    const firstId = tracker.getBlobs()[0]?.id as number
+
+    tracker.reset()
+    expect(tracker.getBlobs()).toHaveLength(0)
+
+    tracker.step(grid, 16, 16, 0, cfg)
+    expect(tracker.getBlobs()[0]?.id).toBe(firstId)
+  })
+})
+
+describe("BlobTracker auto detection mode", () => {
+  test("falls back to luminance after sustained static frames and re-arms on motion", () => {
+    const tracker = new BlobTracker()
+    const cfg = config({ detectionMode: "auto" })
+    // Static frame: no motion energy, but a luminance blob is present.
+    const staticGrid = makeGrid(16, 16, (x, y) => {
+      const inBlock = x >= 2 && x <= 4 && y >= 2 && y <= 4
+      return inBlock ? { luma: 255 } : {}
+    })
+
+    // Before the fallback threshold: motion mode sees no motion → no blobs.
+    for (let frame = 0; frame < STATIC_STEPS_BEFORE_FALLBACK - 1; frame += 1) {
+      tracker.step(staticGrid, 16, 16, frame, cfg)
+    }
+    expect(tracker.getBlobs()).toHaveLength(0)
+
+    // The threshold step trips the luminance fallback → the blob appears.
+    tracker.step(staticGrid, 16, 16, STATIC_STEPS_BEFORE_FALLBACK - 1, cfg)
+    expect(tracker.getBlobs().length).toBeGreaterThan(0)
+
+    // A frame with motion re-arms motion mode and is detected there.
+    const motionGrid = makeGrid(16, 16, (x, y) => {
+      const inBlock = x >= 8 && x <= 10 && y >= 8 && y <= 10
+      return inBlock ? { motion: 255 } : {}
+    })
+    tracker.step(motionGrid, 16, 16, STATIC_STEPS_BEFORE_FALLBACK, cfg)
+    expect(tracker.getBlobs().length).toBeGreaterThan(0)
+
+    // Proof it re-armed to motion: a luminance-only frame now yields nothing.
+    tracker.step(staticGrid, 16, 16, STATIC_STEPS_BEFORE_FALLBACK + 1, cfg)
+    expect(tracker.getBlobs()).toHaveLength(0)
+  })
+})

--- a/src/lib/blob-tracking/inner-effects.ts
+++ b/src/lib/blob-tracking/inner-effects.ts
@@ -1,0 +1,133 @@
+/**
+ * Inner-effect set for the blob-tracking layer: the effect layer types whose
+ * pass can be rendered inside detected shapes, plus tolerant (de)serialization
+ * of their parameter overrides.
+ *
+ * The set is every effect layer type that has a pass implementation — i.e.
+ * `EFFECT_LAYER_TYPES` minus `"blur"`, which is registered but has no pass in
+ * either renderer tree. `parseInnerEffectParams` is deliberately forgiving so
+ * hand-edited or cross-version `.lab` files never break the import: bad JSON
+ * yields defaults, unknown keys are dropped, and values whose runtime shape
+ * does not match the parameter definition are ignored.
+ */
+
+import { buildParameterValues } from "@/lib/editor/parameter-schema"
+import { getLayerDefinition } from "@/lib/editor/config/layer-registry"
+import {
+  EFFECT_LAYER_TYPES,
+  type EffectLayerType,
+  type LayerParameterValues,
+  type ParameterDefinition,
+  type ParameterValue,
+} from "@/types/editor"
+
+export const INNER_EFFECT_NONE = "none"
+
+/** Effect types renderable as a blob interior (every effect with a pass). */
+export const INNER_EFFECT_TYPES: readonly EffectLayerType[] =
+  EFFECT_LAYER_TYPES.filter((type) => type !== "blur")
+
+export type InnerEffectType = EffectLayerType | typeof INNER_EFFECT_NONE
+
+const INNER_EFFECT_TYPE_SET = new Set<string>([
+  INNER_EFFECT_NONE,
+  ...INNER_EFFECT_TYPES,
+])
+
+export function isInnerEffectType(value: unknown): value is InnerEffectType {
+  return typeof value === "string" && INNER_EFFECT_TYPE_SET.has(value)
+}
+
+function isParameterValue(value: unknown): value is ParameterValue {
+  if (
+    typeof value === "number" ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return true
+  }
+  return (
+    Array.isArray(value) &&
+    (value.length === 2 || value.length === 3) &&
+    value.every((entry) => typeof entry === "number")
+  )
+}
+
+function valueMatchesDefinition(
+  definition: ParameterDefinition,
+  value: ParameterValue
+): boolean {
+  switch (definition.type) {
+    case "number":
+      return typeof value === "number" && Number.isFinite(value)
+    case "boolean":
+      return typeof value === "boolean"
+    case "select":
+    case "color":
+    case "text":
+      return typeof value === "string"
+    case "vec2":
+      return Array.isArray(value) && value.length === 2
+    case "vec3":
+      return Array.isArray(value) && value.length === 3
+    default:
+      return false
+  }
+}
+
+function toRecord(raw: unknown): Record<string, unknown> {
+  if (typeof raw === "string") {
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {}
+    } catch {
+      return {}
+    }
+  }
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>
+  }
+  return {}
+}
+
+/**
+ * Resolve inner-effect parameter overrides for `type` against its definition
+ * defaults. Unknown types throw; `"none"` has no parameters.
+ */
+export function parseInnerEffectParams(
+  type: InnerEffectType,
+  raw: unknown
+): LayerParameterValues {
+  if (!isInnerEffectType(type)) {
+    throw new Error(`Unknown inner effect type: ${String(type)}`)
+  }
+  if (type === INNER_EFFECT_NONE) {
+    return {}
+  }
+
+  const definitions = getLayerDefinition(type).params
+  const values = buildParameterValues(definitions)
+  const definitionByKey = new Map(
+    definitions.map((definition) => [definition.key, definition])
+  )
+  const record = toRecord(raw)
+
+  for (const [key, candidate] of Object.entries(record)) {
+    const definition = definitionByKey.get(key)
+    if (
+      definition &&
+      isParameterValue(candidate) &&
+      valueMatchesDefinition(definition, candidate)
+    ) {
+      values[key] = candidate
+    }
+  }
+
+  return values
+}
+
+export function serializeInnerEffectParams(values: LayerParameterValues): string {
+  return JSON.stringify(values)
+}

--- a/src/lib/blob-tracking/tracker.ts
+++ b/src/lib/blob-tracking/tracker.ts
@@ -1,0 +1,357 @@
+/**
+ * Blob tracker — pure TypeScript, zero DOM/three imports so it runs under
+ * `bun test` and can be mirrored into the published package unchanged.
+ *
+ * It consumes a small analysis grid produced on the GPU and read back to the
+ * CPU: an interleaved RGBA `Uint8Array` where, per texel,
+ *   - R = motion energy (|luma(current) − luma(previous)|), and
+ *   - G = luminance of the current frame.
+ * From that it produces a stable set of tracked blobs (bounding boxes +
+ * centroids) for the compositor to draw shapes and decorations around.
+ *
+ * Temporal rules (mirrors `pixel-trail-pass` determinism precedent):
+ *   - `step()` advances state at most once per distinct `time` — the export
+ *     prewarm renders the same timestamp repeatedly and must not double-step.
+ *   - `reset()` clears everything, called when the timeline scrubs backwards.
+ */
+
+export type DetectionMode = "auto" | "motion" | "luminance"
+
+export interface TrackerConfig {
+  blobAmount: number
+  detectionMode: DetectionMode
+  minBlobSize: number
+  motionThreshold: number
+  persistentTracking: boolean
+  sensitivity: number
+  smoothing: number
+}
+
+export interface BlobPoint {
+  x: number
+  y: number
+}
+
+/** A tracked blob in normalized (0..1) grid coordinates. */
+export interface Blob {
+  active: boolean
+  area: number
+  cx: number
+  cy: number
+  halfHeight: number
+  halfWidth: number
+  history: BlobPoint[]
+  id: number
+}
+
+/** Number of consecutive static steps before `auto` falls back to luminance. */
+export const STATIC_STEPS_BEFORE_FALLBACK = 30
+/** Mean motion energy (0..1) below which a step counts as "static". */
+export const MOTION_ENERGY_EPSILON = 0.01
+/** Frames a persistent track survives unmatched before it despawns. */
+export const TRACK_GRACE_FRAMES = 10
+/** Position-history ring length used for trails. */
+export const HISTORY_LENGTH = 16
+
+type Detection = {
+  area: number
+  cx: number
+  cy: number
+  halfHeight: number
+  halfWidth: number
+}
+
+type Track = {
+  active: boolean
+  area: number
+  cx: number
+  cy: number
+  halfHeight: number
+  halfWidth: number
+  history: BlobPoint[]
+  id: number
+  missedFrames: number
+}
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+
+export class BlobTracker {
+  private currentBlobs: Blob[] = []
+  private lastSteppedTime: number | null = null
+  private luminanceFallbackActive = false
+  private nextId = 1
+  private staticStepCount = 0
+  private tracks: Track[] = []
+
+  reset(): void {
+    this.currentBlobs = []
+    this.lastSteppedTime = null
+    this.luminanceFallbackActive = false
+    this.nextId = 1
+    this.staticStepCount = 0
+    this.tracks = []
+  }
+
+  getBlobs(): Blob[] {
+    return this.currentBlobs
+  }
+
+  /**
+   * Advance the tracker for `time`. No-ops when `time` equals the previous
+   * stepped time (idempotent per distinct timestamp).
+   */
+  step(
+    grid: Uint8Array,
+    gridWidth: number,
+    gridHeight: number,
+    time: number,
+    config: TrackerConfig
+  ): void {
+    if (this.lastSteppedTime !== null && time === this.lastSteppedTime) {
+      return
+    }
+    this.lastSteppedTime = time
+
+    const mode = this.resolveMode(grid, gridWidth, gridHeight, config)
+    const binary = this.binarize(grid, gridWidth, gridHeight, mode, config)
+    const detections = this.detect(binary, gridWidth, gridHeight, config)
+
+    this.currentBlobs = config.persistentTracking
+      ? this.trackPersistent(detections, config)
+      : this.trackStateless(detections)
+  }
+
+  private resolveMode(
+    grid: Uint8Array,
+    gridWidth: number,
+    gridHeight: number,
+    config: TrackerConfig
+  ): "luminance" | "motion" {
+    if (config.detectionMode !== "auto") {
+      return config.detectionMode
+    }
+
+    const cellCount = gridWidth * gridHeight
+    let motionSum = 0
+    for (let index = 0; index < cellCount; index += 1) {
+      motionSum += (grid[index * 4] ?? 0) / 255
+    }
+    const meanMotion = cellCount > 0 ? motionSum / cellCount : 0
+
+    if (meanMotion < MOTION_ENERGY_EPSILON) {
+      this.staticStepCount += 1
+      if (this.staticStepCount >= STATIC_STEPS_BEFORE_FALLBACK) {
+        this.luminanceFallbackActive = true
+      }
+    } else {
+      this.staticStepCount = 0
+      this.luminanceFallbackActive = false
+    }
+
+    return this.luminanceFallbackActive ? "luminance" : "motion"
+  }
+
+  private binarize(
+    grid: Uint8Array,
+    gridWidth: number,
+    gridHeight: number,
+    mode: "luminance" | "motion",
+    config: TrackerConfig
+  ): Uint8Array {
+    const channelOffset = mode === "motion" ? 0 : 1
+    const threshold =
+      (mode === "motion" ? config.motionThreshold : config.sensitivity) * 255
+    const cellCount = gridWidth * gridHeight
+    const binary = new Uint8Array(cellCount)
+
+    for (let index = 0; index < cellCount; index += 1) {
+      const value = grid[index * 4 + channelOffset] ?? 0
+      binary[index] = value >= threshold ? 1 : 0
+    }
+
+    return binary
+  }
+
+  private detect(
+    binary: Uint8Array,
+    gridWidth: number,
+    gridHeight: number,
+    config: TrackerConfig
+  ): Detection[] {
+    const labels = new Int32Array(binary.length).fill(-1)
+    const detections: Detection[] = []
+    const stack: number[] = []
+
+    for (let startY = 0; startY < gridHeight; startY += 1) {
+      for (let startX = 0; startX < gridWidth; startX += 1) {
+        const startIndex = startY * gridWidth + startX
+        if (binary[startIndex] !== 1 || labels[startIndex] !== -1) {
+          continue
+        }
+
+        // Flood-fill this 4-connected component.
+        let area = 0
+        let sumX = 0
+        let sumY = 0
+        let minX = startX
+        let maxX = startX
+        let minY = startY
+        let maxY = startY
+
+        labels[startIndex] = detections.length
+        stack.push(startIndex)
+
+        while (stack.length > 0) {
+          const index = stack.pop() as number
+          const x = index % gridWidth
+          const y = (index - x) / gridWidth
+
+          area += 1
+          sumX += x
+          sumY += y
+          minX = Math.min(minX, x)
+          maxX = Math.max(maxX, x)
+          minY = Math.min(minY, y)
+          maxY = Math.max(maxY, y)
+
+          const neighbors = [
+            x > 0 ? index - 1 : -1,
+            x < gridWidth - 1 ? index + 1 : -1,
+            y > 0 ? index - gridWidth : -1,
+            y < gridHeight - 1 ? index + gridWidth : -1,
+          ]
+          for (const neighbor of neighbors) {
+            if (
+              neighbor >= 0 &&
+              binary[neighbor] === 1 &&
+              labels[neighbor] === -1
+            ) {
+              labels[neighbor] = detections.length
+              stack.push(neighbor)
+            }
+          }
+        }
+
+        if (area < config.minBlobSize) {
+          continue
+        }
+
+        const boxWidth = maxX - minX + 1
+        const boxHeight = maxY - minY + 1
+        detections.push({
+          area,
+          cx: clamp01((sumX / area + 0.5) / gridWidth),
+          cy: clamp01((sumY / area + 0.5) / gridHeight),
+          halfHeight: boxHeight / 2 / gridHeight,
+          halfWidth: boxWidth / 2 / gridWidth,
+        })
+      }
+    }
+
+    detections.sort((left, right) => right.area - left.area)
+    const limit = Math.max(0, Math.floor(config.blobAmount))
+    return detections.slice(0, limit)
+  }
+
+  private trackStateless(detections: Detection[]): Blob[] {
+    this.tracks = []
+    return detections.map((detection, index) => ({
+      active: true,
+      area: detection.area,
+      cx: detection.cx,
+      cy: detection.cy,
+      halfHeight: detection.halfHeight,
+      halfWidth: detection.halfWidth,
+      history: [{ x: detection.cx, y: detection.cy }],
+      id: index,
+    }))
+  }
+
+  private trackPersistent(
+    detections: Detection[],
+    config: TrackerConfig
+  ): Blob[] {
+    const blend = 1 - clamp01(config.smoothing)
+    const available = this.tracks.slice()
+    const matchedTrackIds = new Set<number>()
+
+    // Greedy nearest-neighbor matching: each detection claims the closest
+    // still-unmatched track.
+    for (const detection of detections) {
+      let bestTrack: Track | null = null
+      let bestDistance = Number.POSITIVE_INFINITY
+
+      for (const track of available) {
+        if (matchedTrackIds.has(track.id)) {
+          continue
+        }
+        const dx = track.cx - detection.cx
+        const dy = track.cy - detection.cy
+        const distance = dx * dx + dy * dy
+        if (distance < bestDistance) {
+          bestDistance = distance
+          bestTrack = track
+        }
+      }
+
+      if (bestTrack) {
+        matchedTrackIds.add(bestTrack.id)
+        bestTrack.cx += (detection.cx - bestTrack.cx) * blend
+        bestTrack.cy += (detection.cy - bestTrack.cy) * blend
+        bestTrack.halfWidth +=
+          (detection.halfWidth - bestTrack.halfWidth) * blend
+        bestTrack.halfHeight +=
+          (detection.halfHeight - bestTrack.halfHeight) * blend
+        bestTrack.area = detection.area
+        bestTrack.active = true
+        bestTrack.missedFrames = 0
+        bestTrack.history.push({ x: bestTrack.cx, y: bestTrack.cy })
+        if (bestTrack.history.length > HISTORY_LENGTH) {
+          bestTrack.history.shift()
+        }
+      } else {
+        this.tracks.push({
+          active: true,
+          area: detection.area,
+          cx: detection.cx,
+          cy: detection.cy,
+          halfHeight: detection.halfHeight,
+          halfWidth: detection.halfWidth,
+          history: [{ x: detection.cx, y: detection.cy }],
+          id: this.nextId,
+          missedFrames: 0,
+        })
+        matchedTrackIds.add(this.nextId)
+        this.nextId += 1
+      }
+    }
+
+    // Age unmatched tracks; despawn past the grace window.
+    const survivors: Track[] = []
+    for (const track of this.tracks) {
+      if (matchedTrackIds.has(track.id)) {
+        survivors.push(track)
+        continue
+      }
+      track.missedFrames += 1
+      track.active = false
+      if (track.missedFrames <= TRACK_GRACE_FRAMES) {
+        survivors.push(track)
+      }
+    }
+    this.tracks = survivors
+
+    return this.tracks.map((track) => ({
+      active: track.active,
+      area: track.area,
+      cx: track.cx,
+      cy: track.cy,
+      halfHeight: track.halfHeight,
+      halfWidth: track.halfWidth,
+      history: track.history.slice(),
+      id: track.id,
+    }))
+  }
+}


### PR DESCRIPTION
Addresses #91 (Plan 008). This lands the **pure, fully unit-tested foundation** the plan deliberately isolates as independently shippable; the GPU/DOM stages are scoped as a documented follow-up (rationale below).

## What's in

- **`src/lib/blob-tracking/tracker.ts`** (S1.2) — the CPU tracker: zero DOM/three imports (runs under `bun test`, mirrors into the package unchanged). Motion/luminance binarization with `auto` fallback (30 static steps → luminance, re-arms on motion), 4-connected component labeling, top-N by area, persistent greedy-NN matching + EMA smoothing + 10-frame grace despawn + monotonic ids + 16-entry position-history ring, `reset()`, and the **once-per-distinct-`time` step guard** that makes export prewarm idempotent.
- **`src/lib/blob-tracking/inner-effects.ts`** (S2.1) — the inner-effect set (`EFFECT_LAYER_TYPES` minus `blur`) and tolerant `parseInnerEffectParams`/`serializeInnerEffectParams` (bad JSON → defaults, unknown keys dropped, type-mismatched values ignored).
- **19 tests** covering the full S1.2 + S2.1 case lists (clustering, min-size, top-N, persistent id stability, grace despawn, EMA convergence, reset, step-guard, auto-fallback/re-arm; round-trip, bad JSON, unknown keys/types).

Both modules are **unwired** — no `blob-tracking` layer is registered, so editor behavior is unchanged and no half-working option appears in the picker.

## S1.1 readback spike

`readRenderTargetPixelsAsync(rt, x, y, w, h)` is present in the installed `three@0.183.2` (`Renderer.js:2884`, returns a Promise via `copyTextureToBuffer`) — matches the plan's assumption, STOP condition does not trigger.

## What's deferred, and why

S1.3–S1.5 (registration + `BlobTrackingPass` GPU pass + export-determinism), S2.2–S2.4 (child pass + sidebar + 22-type matrix), S3 (decoration overlay), S4 (package mirror + changeset + README + preview). These are **GPU/DOM-bound and unverifiable in this automated run** — no WebGPU browser is reachable (chrome tooling pinned to Chrome `stable`, not installed). Shipping a readback pass, temporal export stepping, and a decoration canvas **unverified** risks precisely the failure modes the plan flags (nondeterministic export, decorations leaking into the mask, child-pass GPU leaks). The tracker API (`step`/`getBlobs`/`reset`) is shaped to be exactly what `BlobTrackingPass` will consume, so this is genuine unblocking work, not throwaway. Full deferral map in `plans/008-artifacts/status.md`.

## Verification

- `bun test` → 71 pass (19 new) · `bun run typecheck:tsc`, `bun run lint` → exit 0

App-only, no layer registered → no changeset. **Stacked on #93** (Plan 001) → #92. Merge order: #92 → #93 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)