### PR TITLE
Decouple timeline duration from video layers

### DIFF
--- a/src/components/editor/audio-source-control.tsx
+++ b/src/components/editor/audio-source-control.tsx
@@ -8,6 +8,7 @@ import { useBandValueElement } from "@/hooks/use-band-value-element"
 import { cn } from "@/lib/cn"
 import { MIN_RELEASE_MS } from "@/lib/editor/audio/bands"
 import { AUDIO_FILE_ACCEPT } from "@/lib/editor/media-file"
+import { getSeedableMediaDuration } from "@/lib/editor/timeline-duration"
 import { useAssetStore, useAudioStore, useTimelineStore } from "@/store"
 import { AUDIO_BAND_IDS, type AudioBandId } from "@/types/editor"
 import { IconButton } from "@/components/ui/icon-button"
@@ -246,16 +247,17 @@ export function AudioSourceControl({
       const asset = await loadAsset(file)
       setSource({ assetId: asset.id, kind: "asset" })
 
-      if (asset.duration && asset.duration > 0) {
-        useTimelineStore.getState().setDuration(asset.duration)
-      }
+      const assetDuration = getSeedableMediaDuration(asset)
+      useTimelineStore.getState().seedDurationFromMedia(assetDuration)
 
       await analyze(asset.url)
 
-      const analyzed = useAudioStore.getState().spectrogram
-
-      if (analyzed && !(asset.duration && asset.duration > 0)) {
-        useTimelineStore.getState().setDuration(analyzed.durationSeconds)
+      if (assetDuration === null) {
+        useTimelineStore
+          .getState()
+          .seedDurationFromMedia(
+            useAudioStore.getState().spectrogram?.durationSeconds ?? null
+          )
       }
     } catch (caught) {
       setLoadError(

--- a/src/components/editor/editor-canvas-viewport.tsx
+++ b/src/components/editor/editor-canvas-viewport.tsx
@@ -23,9 +23,11 @@ import {
   getWheelZoomFactor,
 } from "@/lib/editor/view-transform"
 import { getCompositionFrame } from "@/lib/editor/composition"
+import { getSeedableMediaDuration } from "@/lib/editor/timeline-duration"
 import { useAssetStore } from "@/store/asset-store"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
+import { useTimelineStore } from "@/store/timeline-store"
 
 export function EditorCanvasViewport() {
   const { canvasRef, isReady, viewportRef } = useEditorRenderer()
@@ -68,6 +70,9 @@ export function EditorCanvasViewport() {
   const [isPointerPanning, setIsPointerPanning] = useState(false)
   const addLayer = useLayerStore((state) => state.addLayer)
   const setLayerAsset = useLayerStore((state) => state.setLayerAsset)
+  const seedDurationFromMedia = useTimelineStore(
+    (state) => state.seedDurationFromMedia
+  )
   const loadAsset = useAssetStore((state) => state.loadAsset)
   const pointerPanRef = useRef<{
     pointerId: number
@@ -110,13 +115,14 @@ export function EditorCanvasViewport() {
             const asset = await loadAsset(file)
             const layerId = addLayer(kind)
             setLayerAsset(layerId, asset.id)
+            seedDurationFromMedia(getSeedableMediaDuration(asset))
           } catch {
             return
           }
         }
       }
     },
-    [addLayer, loadAsset, setLayerAsset]
+    [addLayer, loadAsset, seedDurationFromMedia, setLayerAsset]
   )
 
   useEffect(() => {

--- a/src/components/editor/editor-export-dialog.tsx
+++ b/src/components/editor/editor-export-dialog.tsx
@@ -61,10 +61,6 @@ import {
 } from "@/lib/editor/shader-export"
 import { generateShaderExportSnippet } from "@/lib/editor/shader-export-snippet"
 import {
-  getEffectiveTimelineDuration,
-  getLongestVideoLayerDuration,
-} from "@/lib/editor/timeline-duration"
-import {
   type AudioAnalysisStatus,
   selectAudioModulationInput,
 } from "@/store/audio-store"
@@ -329,20 +325,10 @@ export function EditorExportDialog({
       ),
     [layers]
   )
-  const derivedVideoDuration = useMemo(
-    () => getLongestVideoLayerDuration(layers, assets),
-    [assets, layers]
-  )
   const defaultVideoDuration = useMemo(
     () =>
-      roundDurationForExport(
-        getEffectiveTimelineDuration(
-          layers,
-          assets,
-          timelineDuration || DEFAULT_VIDEO_EXPORT_DURATION
-        )
-      ),
-    [assets, layers, timelineDuration]
+      roundDurationForExport(timelineDuration || DEFAULT_VIDEO_EXPORT_DURATION),
+    [timelineDuration]
   )
   const shaderSnippet = useMemo(() => {
     if (shaderExportIssues.length > 0) {
@@ -1095,7 +1081,6 @@ export function EditorExportDialog({
                           onVideoWidthChange={updateVideoWidth}
                           videoAspect={videoAspect}
                           videoDuration={videoDuration}
-                          videoDurationReadOnly={derivedVideoDuration !== null}
                           videoFormat={videoFormat}
                           videoFps={videoFps}
                           videoProgress={videoProgress}
@@ -1182,9 +1167,6 @@ export function EditorExportDialog({
                             onVideoWidthChange={updateVideoWidth}
                             videoAspect={videoAspect}
                             videoDuration={videoDuration}
-                            videoDurationReadOnly={
-                              derivedVideoDuration !== null
-                            }
                             videoFormat={videoFormat}
                             videoFps={videoFps}
                             videoProgress={videoProgress}
@@ -1423,7 +1405,6 @@ function VideoTabContent({
   onVideoWidthChange,
   videoAspect,
   videoDuration,
-  videoDurationReadOnly,
   videoFormat,
   videoFps,
   videoProgress,
@@ -1452,7 +1433,6 @@ function VideoTabContent({
   onVideoWidthChange: (value: number) => void
   videoAspect: ExportAspectPreset
   videoDuration: number
-  videoDurationReadOnly: boolean
   videoFormat: VideoExportFormat
   videoFps: number
   videoProgress: { label: string; value: number } | null
@@ -1569,10 +1549,7 @@ function VideoTabContent({
 
         <FieldLabel label="Duration">
           <NumberInput
-            disabled={videoDurationReadOnly}
-            formatValue={(value) =>
-              videoDurationReadOnly ? value.toFixed(2) : value.toString()
-            }
+            formatValue={(value) => value.toString()}
             min={0.25}
             onChange={onVideoDurationChange}
             step={0.25}
@@ -1912,12 +1889,6 @@ function buildRenderProjectState() {
   const layers = useLayerStore.getState().layers
   const timelineState = useTimelineStore.getState()
   const editorState = useEditorStore.getState()
-  const effectiveDuration = getEffectiveTimelineDuration(
-    layers,
-    assets,
-    timelineState.duration
-  )
-
   return {
     assets,
     audio: selectAudioModulationInput(useAudioStore.getState()),
@@ -1926,7 +1897,7 @@ function buildRenderProjectState() {
     sceneConfig: editorState.sceneConfig,
     timeline: {
       currentTime: timelineState.currentTime,
-      duration: effectiveDuration,
+      duration: timelineState.duration,
       isPlaying: timelineState.isPlaying,
       loop: timelineState.loop,
       selectedKeyframeId: timelineState.selectedKeyframeId,

--- a/src/components/editor/editor-timeline-overlay.tsx
+++ b/src/components/editor/editor-timeline-overlay.tsx
@@ -332,7 +332,6 @@ function TimelineTransport({
   autoKey,
   currentTime,
   duration,
-  durationReadOnly,
   expanded,
   isPlaying,
   loop,
@@ -348,7 +347,6 @@ function TimelineTransport({
   autoKey: boolean
   currentTime: number
   duration: number
-  durationReadOnly: boolean
   expanded: boolean
   isPlaying: boolean
   loop: boolean
@@ -454,11 +452,7 @@ function TimelineTransport({
         <NumberInput
           aria-label="Timeline duration in seconds"
           size={5}
-          className={cn(
-            "min-h-7 appearance-none rounded-[var(--ds-radius-icon)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] px-[10px] text-center font-[var(--ds-font-mono)] text-[12px] leading-4 text-[var(--ds-color-text-primary)] outline-none transition-[background-color,border-color] duration-160 ease-[var(--ease-out-cubic)] focus:border-[var(--ds-border-hover)]",
-            durationReadOnly && "cursor-not-allowed text-white/55 opacity-60"
-          )}
-          disabled={durationReadOnly}
+          className="min-h-7 appearance-none rounded-[var(--ds-radius-icon)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] px-[10px] text-center font-[var(--ds-font-mono)] text-[12px] leading-4 text-[var(--ds-color-text-primary)] outline-none transition-[background-color,border-color] duration-160 ease-[var(--ease-out-cubic)] focus:border-[var(--ds-border-hover)]"
           formatValue={(value) =>
             Number.isInteger(value) ? value.toString() : value.toFixed(1)
           }
@@ -608,12 +602,10 @@ export function EditorTimelineOverlay() {
     (state) => state.toggleSelectedKeyframes
   )
   const togglePlaying = useTimelineStore((state) => state.togglePlaying)
-  const derivedVideoDuration = useMemo(
-    () => getLongestVideoLayerDuration(layers, assets),
+  const hasVideoLayer = useMemo(
+    () => getLongestVideoLayerDuration(layers, assets) !== null,
     [assets, layers]
   )
-  const hasDerivedVideoDuration = derivedVideoDuration !== null
-  const effectiveDuration = derivedVideoDuration ?? duration
 
   const [monitorEnabled, setMonitorEnabled] = useState(true)
   useAudioMonitor(monitorEnabled)
@@ -636,15 +628,15 @@ export function EditorTimelineOverlay() {
   const [focusedPropertyId, setFocusedPropertyId] = useState<string | null>(
     null
   )
-  const previousHasDerivedVideoDurationRef = useRef<boolean | null>(null)
+  const previousHasVideoLayerRef = useRef<boolean | null>(null)
   const scrubSurfaceRef = useRef<HTMLDivElement | null>(null)
   const trackCanvasRef = useRef<HTMLDivElement | null>(null)
   const keyframeButtonRefs = useRef(new Map<string, HTMLButtonElement>())
   const [dragState, setDragState] = useState<DragState | null>(null)
   const [viewportSize, setViewportSize] = useState({ height: 900, width: 1440 })
   const tickPositions = useMemo(
-    () => createTickPositions(effectiveDuration),
-    [effectiveDuration]
+    () => createTickPositions(duration),
+    [duration]
   )
   const selectedKeyframeIdSet = useMemo(
     () => new Set(selectedKeyframeIds),
@@ -695,27 +687,14 @@ export function EditorTimelineOverlay() {
   )
 
   useEffect(() => {
-    if (!(hasDerivedVideoDuration && derivedVideoDuration !== duration)) {
-      return
-    }
+    const previousHasVideoLayer = previousHasVideoLayerRef.current
 
-    setDuration(derivedVideoDuration)
-  }, [derivedVideoDuration, duration, hasDerivedVideoDuration, setDuration])
-
-  useEffect(() => {
-    const previousHasDerivedVideoDuration =
-      previousHasDerivedVideoDurationRef.current
-
-    if (
-      hasDerivedVideoDuration &&
-      previousHasDerivedVideoDuration !== true &&
-      !isPlaying
-    ) {
+    if (hasVideoLayer && previousHasVideoLayer !== true && !isPlaying) {
       setPlaying(true)
     }
 
-    previousHasDerivedVideoDurationRef.current = hasDerivedVideoDuration
-  }, [hasDerivedVideoDuration, isPlaying, setPlaying])
+    previousHasVideoLayerRef.current = hasVideoLayer
+  }, [hasVideoLayer, isPlaying, setPlaying])
 
   useEffect(() => {
     if (!(timelinePanelOpen && selectedLayer)) {
@@ -1145,7 +1124,7 @@ export function EditorTimelineOverlay() {
     const rect = surface.getBoundingClientRect()
     const progress =
       rect.width > 0 ? clamp((clientX - rect.left) / rect.width, 0, 1) : 0
-    return progress * effectiveDuration
+    return progress * duration
   })
 
   const handleDragMove = useEffectEvent((event: PointerEvent) => {
@@ -1214,7 +1193,7 @@ export function EditorTimelineOverlay() {
   const selectedTrack =
     layerTracks.find((track) => track.id === selectedTrackId) ?? null
   const progress =
-    effectiveDuration > 0 ? clamp(currentTime / effectiveDuration, 0, 1) : 0
+    duration > 0 ? clamp(currentTime / duration, 0, 1) : 0
   const shellWidth = timelinePanelOpen
     ? Math.min(EXPANDED_SHELL_WIDTH, Math.max(640, viewportSize.width - 96))
     : Math.min(COLLAPSED_SHELL_WIDTH, Math.max(360, viewportSize.width - 48))
@@ -1349,8 +1328,7 @@ export function EditorTimelineOverlay() {
               <TimelineTransport
                 autoKey={timelineAutoKey}
                 currentTime={currentTime}
-                duration={effectiveDuration}
-                durationReadOnly={hasDerivedVideoDuration}
+                duration={duration}
                 expanded={timelinePanelOpen}
                 isPlaying={isPlaying}
                 loop={loop}
@@ -1515,7 +1493,7 @@ export function EditorTimelineOverlay() {
                         className="absolute bottom-0 h-[10px] w-px bg-white/6"
                         key={`minor-${tick}`}
                         style={{
-                          left: `${(tick / effectiveDuration) * 100}%`,
+                          left: `${(tick / duration) * 100}%`,
                         }}
                       />
                     ))}
@@ -1526,7 +1504,7 @@ export function EditorTimelineOverlay() {
                         className="absolute bottom-0 h-[18px] w-px bg-white/14"
                         key={`major-${tick}`}
                         style={{
-                          left: `${(tick / effectiveDuration) * 100}%`,
+                          left: `${(tick / duration) * 100}%`,
                         }}
                       />
                     ))}
@@ -1539,10 +1517,10 @@ export function EditorTimelineOverlay() {
                         tone="muted"
                         variant="monoXs"
                         style={{
-                          left: `${(tick / effectiveDuration) * 100}%`,
+                          left: `${(tick / duration) * 100}%`,
                         }}
                       >
-                        {formatTickLabel(tick, effectiveDuration)}
+                        {formatTickLabel(tick, duration)}
                       </Typography>
                     ))}
                   </div>
@@ -1578,7 +1556,7 @@ export function EditorTimelineOverlay() {
                             {entry.audioLink?.enabled ? (
                               <AudioEnvelopeBackdrop
                                 bandId={entry.audioLink.band}
-                                durationSeconds={effectiveDuration}
+                                durationSeconds={duration}
                               />
                             ) : null}
                             <div
@@ -1667,7 +1645,7 @@ export function EditorTimelineOverlay() {
                                     keyframeButtonRefs.current.delete(keyframe.id)
                                   }}
                                   style={{
-                                    left: `${(keyframe.time / effectiveDuration) * 100}%`,
+                                    left: `${(keyframe.time / duration) * 100}%`,
                                   }}
                                   type="button"
                                 >

--- a/src/components/editor/layer-sidebar.tsx
+++ b/src/components/editor/layer-sidebar.tsx
@@ -37,9 +37,11 @@ import { Typography } from "@/components/ui/typography"
 import { playUISound } from "@/lib/audio/shader-lab-sounds"
 import { cn } from "@/lib/cn"
 import { AUDIO_FILE_ACCEPT, inferFileAssetKind } from "@/lib/editor/media-file"
+import { getSeedableMediaDuration } from "@/lib/editor/timeline-duration"
 import { useAssetStore } from "@/store/asset-store"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
+import { useTimelineStore } from "@/store/timeline-store"
 import type { AssetKind, EditorAsset, EditorLayer } from "@/types/editor"
 
 type LayerAction = "delete" | "reset"
@@ -437,6 +439,9 @@ export function LayerSidebar() {
   const setLayersVisibility = useLayerStore(
     (state) => state.setLayersVisibility
   )
+  const seedDurationFromMedia = useTimelineStore(
+    (state) => state.seedDurationFromMedia
+  )
   const assets = useAssetStore((state) => state.assets)
   const loadAsset = useAssetStore((state) => state.loadAsset)
   const removeAsset = useAssetStore((state) => state.removeAsset)
@@ -497,6 +502,7 @@ export function LayerSidebar() {
       const asset = await loadAsset(file)
       const layerId = addLayer(layerType)
       setLayerAsset(layerId, asset.id)
+      seedDurationFromMedia(getSeedableMediaDuration(asset))
       playUISound("action.addLayer")
     } catch {
       return
@@ -599,6 +605,7 @@ export function LayerSidebar() {
       }
 
       setLayerAsset(target.layerId, asset.id)
+      seedDurationFromMedia(getSeedableMediaDuration(asset))
       playUISound("action.relinkAsset")
     } catch (error) {
       setLayerRuntimeError(

--- a/src/lib/agent-bridge/commands.ts
+++ b/src/lib/agent-bridge/commands.ts
@@ -2,8 +2,10 @@ import { subscribeToCustomShaderCompiles } from "@/lib/agent-bridge/compile-even
 import { pumpAgentFrame } from "@/lib/agent-bridge/frame-pump"
 import { getLayerDefinition, getLayerDefinitions } from "@/lib/editor/config/layer-registry"
 import { isParameterAnimatable } from "@/lib/editor/parameter-schema"
+import { getSeedableMediaDuration } from "@/lib/editor/timeline-duration"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
+import { useTimelineStore } from "@/store/timeline-store"
 import type {
   BlendMode,
   EditorLayer,
@@ -605,6 +607,9 @@ async function addMediaLayer(payload: CommandPayload) {
   const layerId = store.addLayer(layerType, insertIndex)
 
   store.setLayerAsset(layerId, asset.id)
+  useTimelineStore
+    .getState()
+    .seedDurationFromMedia(getSeedableMediaDuration(asset))
 
   if (name) {
     store.renameLayer(layerId, name)

--- a/src/lib/agent-bridge/screenshot.ts
+++ b/src/lib/agent-bridge/screenshot.ts
@@ -1,4 +1,3 @@
-import { getEffectiveTimelineDuration } from "@/lib/editor/timeline-duration"
 import { useAssetStore } from "@/store/asset-store"
 import { selectAudioModulationInput, useAudioStore } from "@/store/audio-store"
 import { useEditorStore } from "@/store/editor-store"
@@ -17,11 +16,6 @@ function buildRenderProjectState() {
   const layers = useLayerStore.getState().layers
   const timelineState = useTimelineStore.getState()
   const editorState = useEditorStore.getState()
-  const effectiveDuration = getEffectiveTimelineDuration(
-    layers,
-    assets,
-    timelineState.duration
-  )
 
   return {
     assets,
@@ -31,7 +25,7 @@ function buildRenderProjectState() {
     sceneConfig: editorState.sceneConfig,
     timeline: {
       currentTime: timelineState.currentTime,
-      duration: effectiveDuration,
+      duration: timelineState.duration,
       isPlaying: timelineState.isPlaying,
       loop: timelineState.loop,
       selectedKeyframeId: timelineState.selectedKeyframeId,

--- a/src/lib/editor/__tests__/timeline-duration.test.ts
+++ b/src/lib/editor/__tests__/timeline-duration.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test"
 import {
   clampDuration,
   DEFAULT_DURATION,
-  getEffectiveTimelineDuration,
   getLongestVideoLayerDuration,
+  getSeedableMediaDuration,
   MAX_DURATION,
   MIN_DURATION,
 } from "@/lib/editor/timeline-duration"
@@ -81,15 +81,35 @@ describe("getLongestVideoLayerDuration", () => {
   })
 })
 
-describe("getEffectiveTimelineDuration", () => {
-  test("prefers video, falls back to the manual duration", () => {
+describe("getSeedableMediaDuration", () => {
+  test("reads video and audio durations", () => {
+    expect(getSeedableMediaDuration(videoAsset("a", 42))).toBe(42)
+    expect(getSeedableMediaDuration({ duration: 247.5, kind: "audio" })).toBe(
+      247.5
+    )
+  })
+
+  test("ignores media without a usable duration", () => {
+    expect(getSeedableMediaDuration(videoAsset("a", undefined))).toBeNull()
+    expect(getSeedableMediaDuration({ duration: 0, kind: "video" })).toBeNull()
     expect(
-      getEffectiveTimelineDuration(
-        [videoLayer("a", "asset-a")],
-        [videoAsset("asset-a", 42)],
-        180
-      )
-    ).toBe(42)
-    expect(getEffectiveTimelineDuration([], [], 180)).toBe(180)
+      getSeedableMediaDuration({ duration: Number.NaN, kind: "audio" })
+    ).toBeNull()
+    expect(
+      getSeedableMediaDuration({
+        duration: Number.POSITIVE_INFINITY,
+        kind: "audio",
+      })
+    ).toBeNull()
+  })
+
+  test("never seeds from a still image", () => {
+    expect(getSeedableMediaDuration({ duration: 10, kind: "image" })).toBeNull()
+  })
+
+  test("clamps out-of-range media", () => {
+    expect(
+      getSeedableMediaDuration({ duration: MAX_DURATION * 3, kind: "video" })
+    ).toBe(MAX_DURATION)
   })
 })

--- a/src/lib/editor/timeline-duration.ts
+++ b/src/lib/editor/timeline-duration.ts
@@ -12,6 +12,24 @@ export function clampDuration(duration: number): number {
   return Math.min(MAX_DURATION, Math.max(MIN_DURATION, duration))
 }
 
+export function getSeedableMediaDuration(
+  asset: Pick<EditorAsset, "duration" | "kind">
+): number | null {
+  if (!(asset.kind === "video" || asset.kind === "audio")) {
+    return null
+  }
+
+  const { duration } = asset
+
+  if (
+    !(typeof duration === "number" && Number.isFinite(duration) && duration > 0)
+  ) {
+    return null
+  }
+
+  return clampDuration(duration)
+}
+
 export function getLongestVideoLayerDuration(
   layers: readonly EditorLayer[],
   assets: readonly EditorAsset[]
@@ -40,12 +58,4 @@ export function getLongestVideoLayerDuration(
   }
 
   return longestDuration > 0 ? clampDuration(longestDuration) : null
-}
-
-export function getEffectiveTimelineDuration(
-  layers: readonly EditorLayer[],
-  assets: readonly EditorAsset[],
-  manualDuration: number
-): number {
-  return getLongestVideoLayerDuration(layers, assets) ?? manualDuration
 }

--- a/src/renderer/media-pass.ts
+++ b/src/renderer/media-pass.ts
@@ -163,15 +163,12 @@ export class MediaPass extends PassNode {
     return this.videoTexture !== null
   }
 
-  override async prepareForExportFrame(
-    time: number,
-    loop: boolean
-  ): Promise<void> {
+  override async prepareForExportFrame(time: number): Promise<void> {
     if (!this.videoHandle) {
       return
     }
 
-    this.videoHandle.setLoop(loop)
+    this.videoHandle.setLoop(true)
     await this.videoHandle.prepareFrame(time)
   }
 

--- a/src/store/__tests__/timeline-duration.test.ts
+++ b/src/store/__tests__/timeline-duration.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, test } from "bun:test"
-import { MAX_DURATION, MIN_DURATION } from "@/lib/editor/timeline-duration"
+import {
+  getSeedableMediaDuration,
+  MAX_DURATION,
+  MIN_DURATION,
+} from "@/lib/editor/timeline-duration"
 import { useTimelineStore } from "@/store/timeline-store"
 
 function keyframeTimes(): number[] {
@@ -64,5 +68,40 @@ describe("setDuration", () => {
     useTimelineStore.getState().setCurrentTime(150)
     useTimelineStore.getState().setDuration(30)
     expect(useTimelineStore.getState().currentTime).toBe(30)
+  })
+})
+
+describe("seedDurationFromMedia", () => {
+  beforeEach(() => {
+    useTimelineStore.getState().setDuration(6)
+  })
+
+  test("ignores media that carries no usable duration", () => {
+    for (const value of [null, undefined, 0, -1, Number.NaN]) {
+      useTimelineStore.getState().seedDurationFromMedia(value)
+      expect(useTimelineStore.getState().duration).toBe(6)
+    }
+  })
+
+  test("the last import wins", () => {
+    const video = getSeedableMediaDuration({ duration: 10, kind: "video" })
+    const song = getSeedableMediaDuration({ duration: 120, kind: "audio" })
+
+    useTimelineStore.getState().seedDurationFromMedia(video)
+    expect(useTimelineStore.getState().duration).toBe(10)
+
+    useTimelineStore.getState().seedDurationFromMedia(song)
+    expect(useTimelineStore.getState().duration).toBe(120)
+  })
+
+  test("a short video no longer overrides a manual choice", () => {
+    useTimelineStore
+      .getState()
+      .seedDurationFromMedia(
+        getSeedableMediaDuration({ duration: 120, kind: "audio" })
+      )
+    useTimelineStore.getState().setDuration(30)
+
+    expect(useTimelineStore.getState().duration).toBe(30)
   })
 })

--- a/src/store/timeline-store.ts
+++ b/src/store/timeline-store.ts
@@ -84,6 +84,7 @@ export interface TimelineStoreActions {
   ) => void
   removeKeyframe: (trackId: string, keyframeId: string) => void
   removeSelectedKeyframes: () => void
+  seedDurationFromMedia: (durationSeconds: number | null | undefined) => void
   setCurrentTime: (time: number) => void
   setDuration: (duration: number) => void
   setLoop: (loop: boolean) => void
@@ -384,6 +385,20 @@ export const useTimelineStore = create<TimelineStore>((set, get) => ({
 
   setLoop: (loop) => {
     set({ loop })
+  },
+
+  seedDurationFromMedia: (durationSeconds) => {
+    if (
+      !(
+        typeof durationSeconds === "number" &&
+        Number.isFinite(durationSeconds) &&
+        durationSeconds > 0
+      )
+    ) {
+      return
+    }
+
+    get().setDuration(durationSeconds)
   },
 
   setDuration: (duration) => {


### PR DESCRIPTION
A video layer used to own the timeline — `getEffectiveTimelineDuration` returned `videoDuration ?? manual`, an effect re-asserted it on every render, and the Dur field was disabled — so loading a 2 minute song into a project with a 10s clip gave a locked 10 second timeline, which the audio-reactive work in #109 made actively wrong. The composition now owns time and media only seeds it on import with the last import winning, matching After Effects comps and Premiere's first-clip-seeds-sequence; seeds ride the existing debounced history snapshot, so Cmd+Z reverts the duration together with the import that caused it. Timeline loop and clip loop are now separate concepts: `MediaPass` no longer forwards the timeline's loop flag to the video handle, because a short clip over a longer timeline would freeze on its last frame whenever timeline loop was off.

Verified end-to-end in the browser — a 10s clip seeds 10s, a manual 30s sticks, importing a 120s song then takes the timeline to 120s, and the clip wraps on its own length with timeline loop off (timeline 12.00s → clip 2.00s, 15.02s → clip 5.02s) — alongside a clean typecheck, 363 passing tests, and no new lint warnings. Two things are deliberately out of scope and worth a follow-up: the agent bridge still has no command to set timeline duration, so MCP-driven authoring can seed a duration but not change it, and audio envelopes hold their final value past the end of a track while the audio itself goes silent.