### PR TITLE
Community scenes, Phase 0: remote asset references + layer catalog

### DIFF
--- a/.changeset/remote-asset-references.md
+++ b/.changeset/remote-asset-references.md
@@ -1,0 +1,7 @@
+---
+"@basementstudio/shader-lab": patch
+---
+
+Set `crossOrigin="anonymous"` on video textures so media served from a CDN can be
+uploaded as a WebGPU texture without tainting the canvas. Previously a
+cross-origin video would render but break any subsequent canvas readback.

--- a/packages/shader-lab-react/src/renderer/media-texture.ts
+++ b/packages/shader-lab-react/src/renderer/media-texture.ts
@@ -26,6 +26,7 @@ export function loadImageTexture(url: string): Promise<THREE.Texture> {
 export function createVideoTexture(url: string): Promise<VideoHandle> {
   return new Promise((resolve, reject) => {
     const video = document.createElement("video")
+    video.crossOrigin = "anonymous"
     video.loop = true
     video.muted = true
     video.playsInline = true

--- a/src/components/editor/layer-picker.tsx
+++ b/src/components/editor/layer-picker.tsx
@@ -25,6 +25,12 @@ import { createPortal } from "react-dom"
 import { GlassPanel } from "@/components/ui/glass-panel"
 import { IconButton } from "@/components/ui/icon-button"
 import { cn } from "@/lib/cn"
+import {
+  getLayerCatalogEntry,
+  getLayerLabel,
+  type LayerCatalogCategory,
+  type LayerCatalogEntry,
+} from "@/lib/editor/config/layer-catalog"
 
 export type AddLayerAction =
   | "ascii"
@@ -60,7 +66,7 @@ export type AddLayerAction =
   | "video"
   | "voxel"
 
-type LayerPickerCategory = "all" | "core" | "distort"
+type LayerPickerCategory = "all" | LayerCatalogCategory
 
 type SourceItem = {
   icon: ElementType
@@ -68,11 +74,7 @@ type SourceItem = {
   value: AddLayerAction
 }
 
-type EffectItem = {
-  category: Exclude<LayerPickerCategory, "all">
-  description?: string
-  label: string
-  previewSrc?: string
+type EffectItem = LayerCatalogEntry & {
   value: AddLayerAction
 }
 
@@ -90,199 +92,56 @@ const CATEGORY_OPTIONS: readonly {
   { label: "Distort", value: "distort" },
 ] as const
 
-const SOURCE_ITEMS: readonly SourceItem[] = [
-  { icon: ImageIcon, label: "Image", value: "image" },
-  { icon: VideoIcon, label: "Video", value: "video" },
-  { icon: CameraIcon, label: "Camera", value: "live" },
-  { icon: TextIcon, label: "Text", value: "text" },
-  { icon: CursorArrowIcon, label: "Fluid", value: "fluid" },
-  { icon: CursorArrowIcon, label: "Pixel Trail", value: "pixel-trail" },
-  { icon: CursorArrowIcon, label: "Magnify Lens", value: "magnify-lens" },
-  { icon: MagicWandIcon, label: "Mesh Gradient", value: "gradient" },
-  { icon: CodeIcon, label: "Custom Shader", value: "custom-shader" },
+const SOURCE_ICONS: readonly { icon: ElementType; value: AddLayerAction }[] = [
+  { icon: ImageIcon, value: "image" },
+  { icon: VideoIcon, value: "video" },
+  { icon: CameraIcon, value: "live" },
+  { icon: TextIcon, value: "text" },
+  { icon: CursorArrowIcon, value: "fluid" },
+  { icon: CursorArrowIcon, value: "pixel-trail" },
+  { icon: CursorArrowIcon, value: "magnify-lens" },
+  { icon: MagicWandIcon, value: "gradient" },
+  { icon: CodeIcon, value: "custom-shader" },
 ] as const
 
-const EFFECT_ITEMS: readonly EffectItem[] = [
-  {
-    category: "core",
-    description:
-      "Turns the image into text glyphs for a classic terminal look.",
-    label: "ASCII",
-    previewSrc: "/examples/ascii.webp",
-    value: "ascii",
-  },
-  {
-    category: "core",
-    description: "Adds smeared glow and fluid bleed for neon ink-like edges.",
-    label: "Ink",
-    previewSrc: "/examples/ink.webp",
-    value: "ink",
-  },
-  {
-    category: "core",
-    description: "Maps the source into repeatable woven and graphic textures.",
-    label: "Pattern",
-    previewSrc: "/examples/pattern.webp",
-    value: "pattern",
-  },
-  {
-    category: "core",
-    description: "Adds scanlines, phosphor bloom, and display-era noise.",
-    label: "CRT",
-    previewSrc: "/examples/crt.webp",
-    value: "crt",
-  },
-  {
-    category: "core",
-    description: "Reduces color resolution into ordered or textured dithering.",
-    label: "Dithering",
-    previewSrc: "/examples/dithering.webp",
-    value: "dithering",
-  },
-  {
-    category: "core",
-    description:
-      "Converts the frame into graphic dot screens and print textures.",
-    label: "Halftone",
-    previewSrc: "/examples/halftone.webp",
-    value: "halftone",
-  },
-  {
-    category: "core",
-    description: "Breaks the image into a glowing particle matrix.",
-    label: "Particle Grid",
-    previewSrc: "/examples/particle-grid.webp",
-    value: "particle-grid",
-  },
-  {
-    category: "core",
-    description:
-      "Groups neighboring pixels into larger blocks for a low-res look.",
-    label: "Pixelation",
-    previewSrc: "/examples/pixelation.webp",
-    value: "pixelation",
-  },
-  {
-    category: "core",
-    description:
-      "Quantizes the frame into isometric cubes; depth raises columns by luminance.",
-    label: "Voxel",
-    previewSrc: "/examples/voxel.webp",
-    value: "voxel",
-  },
-  {
-    category: "core",
-    description:
-      "Compresses tones into fewer steps while keeping the image graphic.",
-    label: "Posterize",
-    previewSrc: "/examples/posterize.webp",
-    value: "posterize",
-  },
-  {
-    category: "core",
-    description:
-      "Turns the frame into stark black and white with controllable cutoff and grain.",
-    label: "Threshold",
-    previewSrc: "/examples/threshold.webp",
-    value: "threshold",
-  },
-  {
-    category: "core",
-    description:
-      "Adds a standalone highlight bloom pass to the incoming frame.",
-    label: "Bloom",
-    value: "bloom",
-    // previewSrc: "/examples/bloom.webp",
-  },
-  {
-    category: "core",
-    description:
-      "Pen-plotter aesthetic with hatching, crosshatching, and ink simulation.",
-    label: "Plotter",
-    previewSrc: "/examples/plotter.webp",
-    value: "plotter",
-  },
-  {
-    category: "distort",
-    description:
-      "Tracks moving regions and frames them with CCTV-style shapes, labels, and an inner effect.",
-    label: "Blob Tracking",
-    previewSrc: "/examples/blob-tracking.webp",
-    value: "blob-tracking",
-  },
-  {
-    category: "distort",
-    description:
-      "Renders luma-gated scanlines and bends them around a pull or push attractor.",
-    label: "Circuit Bent",
-    previewSrc: "/examples/circuit-bent.webp",
-    value: "circuit-bent",
-  },
-  {
-    category: "distort",
-    description:
-      "Smears pixels linearly or radially for motion, focus, or depth.",
-    label: "Directional Blur",
-    previewSrc: "/examples/directional-blur.webp",
-    value: "directional-blur",
-  },
-  {
-    category: "distort",
-    description:
-      "Sorts neighboring pixels into streaks based on luma or color.",
-    label: "Pixel Sorting",
-    previewSrc: "/examples/pixel-sorting.webp",
-    value: "pixel-sorting",
-  },
-  {
-    category: "distort",
-    description:
-      "Offsets horizontal slices into blocky glitch bands and streaks.",
-    label: "Slice",
-    previewSrc: "/examples/slice.webp",
-    value: "slice",
-  },
-  {
-    category: "distort",
-    description:
-      "Extracts contrast edges and turns them into graphic outlines.",
-    label: "Edge Detect",
-    previewSrc: "/examples/edge-detect.webp",
-    value: "edge-detect",
-  },
-  {
-    category: "distort",
-    description:
-      "Pushes pixels along luminance to create warped displacement fields.",
-    label: "Displacement Map",
-    previewSrc: "/examples/displacement-map.webp",
-    value: "displacement-map",
-  },
-  {
-    category: "distort",
-    description:
-      "Offsets color channels for fringing and lens-separation effects.",
-    label: "Chromatic Aberration",
-    previewSrc: "/examples/chromatic-aberration.webp",
-    value: "chromatic-aberration",
-  },
-  {
-    category: "distort",
-    description:
-      "Blur that ramps from sharp to soft across a controllable range.",
-    label: "Progressive Blur",
-    previewSrc: "/examples/progressive-blur.webp",
-    value: "smear",
-  },
-  {
-    category: "distort",
-    description:
-      "Ribbed lenticular glass distortion with subtle chromatic split.",
-    label: "Fluted Glass",
-    previewSrc: "/examples/fluted-glass.webp",
-    value: "fluted-glass",
-  },
+const SOURCE_ITEMS: readonly SourceItem[] = SOURCE_ICONS.map(
+  ({ icon, value }) => ({
+    icon,
+    label: getLayerLabel(value),
+    value,
+  })
+)
+
+const EFFECT_ORDER: readonly AddLayerAction[] = [
+  "ascii",
+  "ink",
+  "pattern",
+  "crt",
+  "dithering",
+  "halftone",
+  "particle-grid",
+  "pixelation",
+  "voxel",
+  "posterize",
+  "threshold",
+  "bloom",
+  "plotter",
+  "blob-tracking",
+  "circuit-bent",
+  "directional-blur",
+  "pixel-sorting",
+  "slice",
+  "edge-detect",
+  "displacement-map",
+  "chromatic-aberration",
+  "smear",
+  "fluted-glass",
 ] as const
+
+const EFFECT_ITEMS: readonly EffectItem[] = EFFECT_ORDER.map((value) => ({
+  ...getLayerCatalogEntry(value),
+  value,
+}))
 
 function LayerPickerInfoButton({
   description,

--- a/src/lib/editor/__tests__/project-file.test.ts
+++ b/src/lib/editor/__tests__/project-file.test.ts
@@ -279,4 +279,97 @@ describe("parseLabProjectFile", () => {
     expect(parsed.layers).toHaveLength(1)
     expect(parsed.layers[0]?.params).toEqual({ futureParam: "kept", speed: 1 })
   })
+
+  test("accepts a v3 asset reference that carries no remote fields", () => {
+    const fixture = {
+      ...createValidProjectFile(),
+      assets: [{ fileName: "photo.png", id: "asset-1", kind: "image" }],
+      version: 3,
+    }
+
+    const parsed = parseLabProjectFile(JSON.stringify(fixture))
+
+    expect(parsed.assets).toHaveLength(1)
+    expect(parsed.assets[0]?.url).toBeUndefined()
+  })
+
+  test("round-trips the v4 remote asset fields", () => {
+    const fixture = {
+      ...createValidProjectFile(),
+      assets: [
+        {
+          duration: 12.5,
+          fileName: "clip.mp4",
+          height: 1080,
+          id: "asset-1",
+          kind: "video",
+          mimeType: "video/mp4",
+          sha256: "abc123",
+          sizeBytes: 2048,
+          url: "https://videodelivery.net/uid/clip.mp4",
+          width: 1920,
+        },
+      ],
+      version: CURRENT_PROJECT_FILE_VERSION,
+    }
+
+    const parsed = parseLabProjectFile(JSON.stringify(fixture))
+
+    expect(parsed.assets[0]).toEqual(fixture.assets[0])
+  })
+
+  test("accepts a null width or duration on an audio asset reference", () => {
+    const fixture = {
+      ...createValidProjectFile(),
+      assets: [
+        {
+          duration: 30,
+          fileName: "track.opus",
+          height: null,
+          id: "asset-1",
+          kind: "audio",
+          url: "https://videodelivery.net/uid/track.opus",
+          width: null,
+        },
+      ],
+      version: CURRENT_PROJECT_FILE_VERSION,
+    }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).not.toThrow()
+  })
+
+  test("reports the asset list when a remote asset field has the wrong type", () => {
+    const fixture = {
+      ...createValidProjectFile(),
+      assets: [
+        {
+          fileName: "clip.mp4",
+          id: "asset-1",
+          kind: "video",
+          url: 42,
+        },
+      ],
+      version: CURRENT_PROJECT_FILE_VERSION,
+    }
+
+    expect(() => parseLabProjectFile(JSON.stringify(fixture))).toThrow(
+      "Project file has an unreadable asset list."
+    )
+  })
+
+  test("v5 adds remote assets on top of the v4 ascii migration", () => {
+    expect(CURRENT_PROJECT_FILE_VERSION).toBe(5)
+
+    for (const version of [4, 5]) {
+      const fixture = { ...createValidProjectFile(), version }
+
+      expect(parseLabProjectFile(JSON.stringify(fixture)).version).toBe(version)
+    }
+
+    const future = { ...createValidProjectFile(), version: 6 }
+
+    expect(() => parseLabProjectFile(JSON.stringify(future))).toThrow(
+      "Unsupported Shader Lab project version."
+    )
+  })
 })

--- a/src/lib/editor/__tests__/remote-asset.test.ts
+++ b/src/lib/editor/__tests__/remote-asset.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  collectRemoteAssets,
+  createRemoteAsset,
+  isAllowedAssetOrigin,
+} from "@/lib/editor/remote-asset"
+import type { PresetAssetReference } from "@/types/editor"
+
+const HOSTS_ENV = "NEXT_PUBLIC_COMMUNITY_ASSET_HOSTS"
+
+function withAllowedHosts(value: string) {
+  process.env[HOSTS_ENV] = value
+}
+
+afterEach(() => {
+  delete process.env[HOSTS_ENV]
+})
+
+describe("isAllowedAssetOrigin", () => {
+  test("rejects a host that is not on the allowlist", () => {
+    expect(isAllowedAssetOrigin("https://evil.test/pixel.png")).toBe(false)
+  })
+
+  test("accepts the built-in Cloudflare Stream hosts", () => {
+    expect(isAllowedAssetOrigin("https://videodelivery.net/uid/x.mp4")).toBe(
+      true
+    )
+    expect(isAllowedAssetOrigin("https://cloudflarestream.com/uid/x.mp4")).toBe(
+      true
+    )
+  })
+
+  test("accepts a subdomain of an allowlisted host", () => {
+    expect(
+      isAllowedAssetOrigin(
+        "https://customer-abc123.cloudflarestream.com/uid/downloads/default.mp4"
+      )
+    ).toBe(true)
+  })
+
+  test("rejects lookalike hosts that merely contain an allowlisted host", () => {
+    const lookalikes = [
+      "https://evil-cloudflarestream.com/x.mp4",
+      "https://cloudflarestream.com.evil.test/x.mp4",
+      "https://notvideodelivery.net/x.mp4",
+    ]
+
+    for (const url of lookalikes) {
+      expect(isAllowedAssetOrigin(url)).toBe(false)
+    }
+  })
+
+  test("rejects a plaintext downgrade on a remote allowlisted host", () => {
+    expect(isAllowedAssetOrigin("http://videodelivery.net/uid/x.mp4")).toBe(
+      false
+    )
+  })
+
+  test("allows http only for an explicitly allowlisted loopback host", () => {
+    expect(isAllowedAssetOrigin("http://localhost:3000/a.png")).toBe(false)
+
+    withAllowedHosts("localhost")
+
+    expect(isAllowedAssetOrigin("http://localhost:3000/a.png")).toBe(true)
+    expect(isAllowedAssetOrigin("http://127.0.0.1:3000/a.png")).toBe(false)
+  })
+
+  test("rejects non-http schemes even when the host list is permissive", () => {
+    withAllowedHosts("localhost,videodelivery.net")
+
+    const hostile = [
+      "data:image/png;base64,iVBORw0KGgo=",
+      "javascript:alert(1)",
+      "blob:https://videodelivery.net/abc",
+      "file:///etc/passwd",
+    ]
+
+    for (const url of hostile) {
+      expect(isAllowedAssetOrigin(url)).toBe(false)
+    }
+  })
+
+  test("rejects strings that are not absolute URLs", () => {
+    for (const url of ["", "not a url", "/relative/path.png", "//cdn/x.png"]) {
+      expect(isAllowedAssetOrigin(url)).toBe(false)
+    }
+  })
+
+  test("reads additional hosts from the environment as a comma list", () => {
+    withAllowedHosts(" cdn.example.test , other.test ")
+
+    expect(isAllowedAssetOrigin("https://cdn.example.test/a.png")).toBe(true)
+    expect(isAllowedAssetOrigin("https://other.test/a.png")).toBe(true)
+    expect(isAllowedAssetOrigin("https://third.test/a.png")).toBe(false)
+  })
+})
+
+describe("createRemoteAsset", () => {
+  function reference(
+    overrides: Partial<PresetAssetReference> = {}
+  ): PresetAssetReference {
+    return {
+      fileName: "clip.mp4",
+      id: "asset-1",
+      kind: "video",
+      ...overrides,
+    }
+  }
+
+  test("returns null for a reference with no url", () => {
+    expect(createRemoteAsset(reference())).toBeNull()
+  })
+
+  test("returns null for a url on a disallowed origin", () => {
+    expect(
+      createRemoteAsset(reference({ url: "https://evil.test/clip.mp4" }))
+    ).toBeNull()
+  })
+
+  test("returns null for an unrecognised asset kind", () => {
+    expect(
+      createRemoteAsset(
+        reference({
+          kind: "executable" as PresetAssetReference["kind"],
+          url: "https://videodelivery.net/uid/clip.mp4",
+        })
+      )
+    ).toBeNull()
+  })
+
+  test("builds a ready remote asset carrying the reference metadata", () => {
+    const asset = createRemoteAsset(
+      reference({
+        duration: 12.5,
+        height: 1080,
+        mimeType: "video/mp4",
+        sizeBytes: 2048,
+        url: "https://videodelivery.net/uid/clip.mp4",
+        width: 1920,
+      })
+    )
+
+    expect(asset).not.toBeNull()
+    expect(asset?.source).toBe("remote")
+    expect(asset?.status).toBe("ready")
+    expect(asset?.error).toBeNull()
+    expect(asset?.url).toBe("https://videodelivery.net/uid/clip.mp4")
+    expect(asset?.duration).toBe(12.5)
+    expect(asset?.width).toBe(1920)
+    expect(asset?.height).toBe(1080)
+    expect(asset?.mimeType).toBe("video/mp4")
+    expect(asset?.sizeBytes).toBe(2048)
+  })
+
+  test("defaults metadata that the reference omits", () => {
+    const asset = createRemoteAsset(
+      reference({ url: "https://videodelivery.net/uid/clip.mp4" })
+    )
+
+    expect(asset?.duration).toBeNull()
+    expect(asset?.width).toBeNull()
+    expect(asset?.height).toBeNull()
+    expect(asset?.mimeType).toBe("")
+    expect(asset?.sizeBytes).toBe(0)
+  })
+})
+
+describe("collectRemoteAssets", () => {
+  const allowed = "https://videodelivery.net/uid/clip.mp4"
+
+  test("ignores references that are already loaded locally", () => {
+    const collected = collectRemoteAssets(
+      [{ fileName: "clip.mp4", id: "asset-1", kind: "video", url: allowed }],
+      new Set(["asset-1"])
+    )
+
+    expect(collected).toEqual([])
+  })
+
+  test("skips local-only references so relinking still applies to them", () => {
+    const collected = collectRemoteAssets(
+      [{ fileName: "photo.png", id: "asset-1", kind: "image" }],
+      new Set()
+    )
+
+    expect(collected).toEqual([])
+  })
+
+  test("drops disallowed references but keeps the allowed ones", () => {
+    const collected = collectRemoteAssets(
+      [
+        { fileName: "a.mp4", id: "good", kind: "video", url: allowed },
+        {
+          fileName: "b.mp4",
+          id: "bad",
+          kind: "video",
+          url: "https://evil.test/b.mp4",
+        },
+      ],
+      new Set()
+    )
+
+    expect(collected).toHaveLength(1)
+    expect(collected[0]?.id).toBe("good")
+  })
+
+  test("does not emit the same asset id twice", () => {
+    const collected = collectRemoteAssets(
+      [
+        { fileName: "a.mp4", id: "dup", kind: "video", url: allowed },
+        { fileName: "a.mp4", id: "dup", kind: "video", url: allowed },
+      ],
+      new Set()
+    )
+
+    expect(collected).toHaveLength(1)
+  })
+})

--- a/src/lib/editor/config/__tests__/layer-catalog.test.ts
+++ b/src/lib/editor/config/__tests__/layer-catalog.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import {
+  getLayerCatalogEntry,
+  getLayerLabel,
+  LAYER_CATALOG,
+  LAYER_CATALOG_CATEGORIES,
+} from "@/lib/editor/config/layer-catalog"
+import type { LayerType } from "@/types/editor"
+import {
+  EFFECT_LAYER_TYPES,
+  MODEL_LAYER_TYPES,
+  SOURCE_LAYER_TYPES,
+} from "@/types/editor"
+
+const ALL_LAYER_TYPES: readonly LayerType[] = [
+  ...SOURCE_LAYER_TYPES,
+  ...EFFECT_LAYER_TYPES,
+  ...MODEL_LAYER_TYPES,
+]
+
+describe("LAYER_CATALOG", () => {
+  test("covers every layer type exactly once", () => {
+    expect(Object.keys(LAYER_CATALOG).sort()).toEqual(
+      [...ALL_LAYER_TYPES].sort()
+    )
+  })
+
+  test("every entry has a non-empty label", () => {
+    for (const type of ALL_LAYER_TYPES) {
+      expect(getLayerCatalogEntry(type).label.trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  test("labels are unique so scene chips are unambiguous", () => {
+    const labels = ALL_LAYER_TYPES.map((type) => getLayerLabel(type))
+
+    expect(new Set(labels).size).toBe(labels.length)
+  })
+
+  test("only effect types carry a picker category", () => {
+    for (const type of [...SOURCE_LAYER_TYPES, ...MODEL_LAYER_TYPES]) {
+      expect(LAYER_CATALOG[type].category).toBeUndefined()
+    }
+
+    for (const type of ALL_LAYER_TYPES) {
+      const { category } = LAYER_CATALOG[type]
+
+      if (category) {
+        expect(EFFECT_LAYER_TYPES).toContain(type)
+        expect(LAYER_CATALOG_CATEGORIES).toContain(category)
+      }
+    }
+  })
+
+  test("a description always comes with a category", () => {
+    for (const type of ALL_LAYER_TYPES) {
+      const entry = LAYER_CATALOG[type]
+
+      if (entry.description) {
+        expect(entry.category).toBeDefined()
+      }
+    }
+  })
+
+  test("every previewSrc points at a file that exists in public/", async () => {
+    const missing: string[] = []
+
+    for (const type of ALL_LAYER_TYPES) {
+      const { previewSrc } = LAYER_CATALOG[type]
+
+      if (!previewSrc) {
+        continue
+      }
+
+      expect(previewSrc.startsWith("/")).toBe(true)
+
+      if (!(await Bun.file(`public${previewSrc}`).exists())) {
+        missing.push(`${type} -> ${previewSrc}`)
+      }
+    }
+
+    expect(missing).toEqual([])
+  })
+
+  test("getLayerLabel falls back to the raw type for an unknown layer", () => {
+    expect(getLayerLabel("not-a-layer" as LayerType)).toBe("not-a-layer")
+  })
+})

--- a/src/lib/editor/config/layer-catalog.ts
+++ b/src/lib/editor/config/layer-catalog.ts
@@ -1,0 +1,210 @@
+import type { LayerType } from "@/types/editor"
+
+export const LAYER_CATALOG_CATEGORIES = ["core", "distort"] as const
+export type LayerCatalogCategory = (typeof LAYER_CATALOG_CATEGORIES)[number]
+
+export interface LayerCatalogEntry {
+  category?: LayerCatalogCategory
+  description?: string
+  label: string
+  previewSrc?: string
+}
+
+export const LAYER_CATALOG: Record<LayerType, LayerCatalogEntry> = {
+  ascii: {
+    category: "core",
+    description:
+      "Turns the image into text glyphs for a classic terminal look.",
+    label: "ASCII",
+    previewSrc: "/examples/ascii.webp",
+  },
+  "blob-tracking": {
+    category: "distort",
+    description:
+      "Tracks moving regions and frames them with CCTV-style shapes, labels, and an inner effect.",
+    label: "Blob Tracking",
+    previewSrc: "/examples/blob-tracking.webp",
+  },
+  bloom: {
+    category: "core",
+    description:
+      "Adds a standalone highlight bloom pass to the incoming frame.",
+    label: "Bloom",
+  },
+  blur: {
+    label: "Blur",
+  },
+  "chromatic-aberration": {
+    category: "distort",
+    description:
+      "Offsets color channels for fringing and lens-separation effects.",
+    label: "Chromatic Aberration",
+    previewSrc: "/examples/chromatic-aberration.webp",
+  },
+  "circuit-bent": {
+    category: "distort",
+    description:
+      "Renders luma-gated scanlines and bends them around a pull or push attractor.",
+    label: "Circuit Bent",
+    previewSrc: "/examples/circuit-bent.webp",
+  },
+  crt: {
+    category: "core",
+    description: "Adds scanlines, phosphor bloom, and display-era noise.",
+    label: "CRT",
+    previewSrc: "/examples/crt.webp",
+  },
+  "custom-shader": {
+    label: "Custom Shader",
+  },
+  "directional-blur": {
+    category: "distort",
+    description:
+      "Smears pixels linearly or radially for motion, focus, or depth.",
+    label: "Directional Blur",
+    previewSrc: "/examples/directional-blur.webp",
+  },
+  "displacement-map": {
+    category: "distort",
+    description:
+      "Pushes pixels along luminance to create warped displacement fields.",
+    label: "Displacement Map",
+    previewSrc: "/examples/displacement-map.webp",
+  },
+  dithering: {
+    category: "core",
+    description: "Reduces color resolution into ordered or textured dithering.",
+    label: "Dithering",
+    previewSrc: "/examples/dithering.webp",
+  },
+  "edge-detect": {
+    category: "distort",
+    description:
+      "Extracts contrast edges and turns them into graphic outlines.",
+    label: "Edge Detect",
+    previewSrc: "/examples/edge-detect.webp",
+  },
+  fluid: {
+    label: "Fluid",
+  },
+  "fluted-glass": {
+    category: "distort",
+    description:
+      "Ribbed lenticular glass distortion with subtle chromatic split.",
+    label: "Fluted Glass",
+    previewSrc: "/examples/fluted-glass.webp",
+  },
+  gradient: {
+    label: "Mesh Gradient",
+  },
+  halftone: {
+    category: "core",
+    description:
+      "Converts the frame into graphic dot screens and print textures.",
+    label: "Halftone",
+    previewSrc: "/examples/halftone.webp",
+  },
+  image: {
+    label: "Image",
+  },
+  ink: {
+    category: "core",
+    description: "Adds smeared glow and fluid bleed for neon ink-like edges.",
+    label: "Ink",
+    previewSrc: "/examples/ink.webp",
+  },
+  live: {
+    label: "Camera",
+  },
+  "magnify-lens": {
+    label: "Magnify Lens",
+  },
+  model: {
+    label: "3D Model",
+  },
+  "particle-grid": {
+    category: "core",
+    description: "Breaks the image into a glowing particle matrix.",
+    label: "Particle Grid",
+    previewSrc: "/examples/particle-grid.webp",
+  },
+  pattern: {
+    category: "core",
+    description: "Maps the source into repeatable woven and graphic textures.",
+    label: "Pattern",
+    previewSrc: "/examples/pattern.webp",
+  },
+  "pixel-sorting": {
+    category: "distort",
+    description:
+      "Sorts neighboring pixels into streaks based on luma or color.",
+    label: "Pixel Sorting",
+    previewSrc: "/examples/pixel-sorting.webp",
+  },
+  "pixel-trail": {
+    label: "Pixel Trail",
+  },
+  pixelation: {
+    category: "core",
+    description:
+      "Groups neighboring pixels into larger blocks for a low-res look.",
+    label: "Pixelation",
+    previewSrc: "/examples/pixelation.webp",
+  },
+  plotter: {
+    category: "core",
+    description:
+      "Pen-plotter aesthetic with hatching, crosshatching, and ink simulation.",
+    label: "Plotter",
+    previewSrc: "/examples/plotter.webp",
+  },
+  posterize: {
+    category: "core",
+    description:
+      "Compresses tones into fewer steps while keeping the image graphic.",
+    label: "Posterize",
+    previewSrc: "/examples/posterize.webp",
+  },
+  slice: {
+    category: "distort",
+    description:
+      "Offsets horizontal slices into blocky glitch bands and streaks.",
+    label: "Slice",
+    previewSrc: "/examples/slice.webp",
+  },
+  smear: {
+    category: "distort",
+    description:
+      "Blur that ramps from sharp to soft across a controllable range.",
+    label: "Progressive Blur",
+    previewSrc: "/examples/progressive-blur.webp",
+  },
+  text: {
+    label: "Text",
+  },
+  threshold: {
+    category: "core",
+    description:
+      "Turns the frame into stark black and white with controllable cutoff and grain.",
+    label: "Threshold",
+    previewSrc: "/examples/threshold.webp",
+  },
+  video: {
+    label: "Video",
+  },
+  voxel: {
+    category: "core",
+    description:
+      "Quantizes the frame into isometric cubes; depth raises columns by luminance.",
+    label: "Voxel",
+    previewSrc: "/examples/voxel.webp",
+  },
+}
+
+export function getLayerCatalogEntry(type: LayerType): LayerCatalogEntry {
+  return LAYER_CATALOG[type]
+}
+
+export function getLayerLabel(type: LayerType): string {
+  return LAYER_CATALOG[type]?.label ?? type
+}

--- a/src/lib/editor/project-file.ts
+++ b/src/lib/editor/project-file.ts
@@ -14,11 +14,13 @@ import {
   CUSTOM_EFFECT_STARTER,
   CUSTOM_SHADER_STARTER,
 } from "@/lib/editor/custom-shader/shared"
+import { collectRemoteAssets } from "@/lib/editor/remote-asset"
 import type {
   EditorAsset,
   EditorAudioSnapshot,
   EditorLayer,
   LayerParameterValues,
+  PresetAssetReference,
   ProjectPresetConfig,
   SceneConfig,
   Size,
@@ -41,6 +43,28 @@ export interface LabProjectFile extends ProjectPresetConfig {
   sceneConfig?: SceneConfig
 }
 
+function toAssetReference(asset: EditorAsset): PresetAssetReference {
+  const reference: PresetAssetReference = {
+    fileName: asset.fileName,
+    id: asset.id,
+    kind: asset.kind,
+  }
+
+  if (asset.source !== "remote") {
+    return reference
+  }
+
+  return {
+    ...reference,
+    duration: asset.duration,
+    height: asset.height,
+    mimeType: asset.mimeType,
+    sizeBytes: asset.sizeBytes,
+    url: asset.url,
+    width: asset.width,
+  }
+}
+
 export function buildLabProjectFile(): LabProjectFile {
   const assets = useAssetStore.getState().assets
   const editorState = useEditorStore.getState()
@@ -48,11 +72,7 @@ export function buildLabProjectFile(): LabProjectFile {
   const timelineState = useTimelineStore.getState()
 
   return {
-    assets: assets.map((asset) => ({
-      fileName: asset.fileName,
-      id: asset.id,
-      kind: asset.kind,
-    })),
+    assets: assets.map(toAssetReference),
     audio: structuredClone(useAudioStore.getState().getSnapshot()),
     composition: structuredClone(editorState.outputSize),
     exportedAt: new Date().toISOString(),
@@ -184,9 +204,16 @@ const timelineTrackSchema = z.looseObject({
 })
 
 const assetReferenceSchema = z.looseObject({
+  duration: z.number().nullable().optional(),
   fileName: z.string(),
+  height: z.number().nullable().optional(),
   id: z.string(),
   kind: z.string(),
+  mimeType: z.string().optional(),
+  sha256: z.string().optional(),
+  sizeBytes: z.number().optional(),
+  url: z.string().optional(),
+  width: z.number().nullable().optional(),
 })
 
 const audioBandConfigSchema = z.looseObject({
@@ -214,7 +241,7 @@ const projectAudioSchema = z.looseObject({
   source: z.looseObject({ kind: z.string() }).nullable().optional(),
 })
 
-export const CURRENT_PROJECT_FILE_VERSION = 4
+export const CURRENT_PROJECT_FILE_VERSION = 5
 
 const labProjectFileSchema = z.looseObject({
   assets: z.array(assetReferenceSchema),
@@ -267,6 +294,10 @@ const PARSE_ISSUE_MESSAGES: {
   {
     matches: (path) => path[0] === "audio",
     message: "Project file has an unreadable audio configuration.",
+  },
+  {
+    matches: (path) => path[0] === "assets",
+    message: "Project file has an unreadable asset list.",
   },
 ]
 
@@ -345,7 +376,19 @@ export function applyLabProjectFile(
   projectFile: LabProjectFile,
   currentAssets: EditorAsset[]
 ): { missingAssetCount: number; missingAudioSource: boolean } {
-  const assetIds = new Set(currentAssets.map((asset) => asset.id))
+  const existingIds = new Set(currentAssets.map((asset) => asset.id))
+  const remoteAssets = collectRemoteAssets(projectFile.assets, existingIds)
+
+  if (remoteAssets.length > 0) {
+    useAssetStore
+      .getState()
+      .replaceAssets([...currentAssets, ...remoteAssets])
+  }
+
+  const assetIds = new Set([
+    ...existingIds,
+    ...remoteAssets.map((asset) => asset.id),
+  ])
   const assetRefById = new Map(
     projectFile.assets.map((asset) => [asset.id, asset])
   )

--- a/src/lib/editor/remote-asset.ts
+++ b/src/lib/editor/remote-asset.ts
@@ -1,0 +1,114 @@
+import type { EditorAsset, PresetAssetReference } from "@/types/editor"
+import { ASSET_KINDS } from "@/types/editor"
+
+const BUILT_IN_ASSET_HOSTS = ["cloudflarestream.com", "videodelivery.net"]
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"])
+
+function parseHostList(value: string | undefined): string[] {
+  if (!value) {
+    return []
+  }
+
+  return value
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0)
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    LOOPBACK_HOSTNAMES.has(hostname) || hostname.endsWith(".localhost")
+  )
+}
+
+export function getAllowedAssetHosts(): string[] {
+  return [
+    ...BUILT_IN_ASSET_HOSTS,
+    ...parseHostList(process.env.NEXT_PUBLIC_CF_IMAGES_HOST),
+    ...parseHostList(process.env.NEXT_PUBLIC_R2_PUBLIC_HOST),
+    ...parseHostList(process.env.NEXT_PUBLIC_COMMUNITY_ASSET_HOSTS),
+  ]
+}
+
+export function isAllowedAssetOrigin(rawUrl: string): boolean {
+  let url: URL
+
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return false
+  }
+
+  const hostname = url.hostname.toLowerCase()
+  const isAllowedHost = getAllowedAssetHosts().some(
+    (host) => hostname === host || hostname.endsWith(`.${host}`)
+  )
+
+  if (!isAllowedHost) {
+    return false
+  }
+
+  if (url.protocol === "https:") {
+    return true
+  }
+
+  return url.protocol === "http:" && isLoopbackHostname(hostname)
+}
+
+export function isRemoteAssetReference(
+  ref: PresetAssetReference
+): ref is PresetAssetReference & { url: string } {
+  return typeof ref.url === "string" && ref.url.length > 0
+}
+
+export function collectRemoteAssets(
+  references: readonly PresetAssetReference[],
+  existingIds: ReadonlySet<string>
+): EditorAsset[] {
+  const remoteAssets: EditorAsset[] = []
+  const seenIds = new Set(existingIds)
+
+  for (const reference of references) {
+    if (seenIds.has(reference.id)) {
+      continue
+    }
+
+    const asset = createRemoteAsset(reference)
+
+    if (asset) {
+      seenIds.add(asset.id)
+      remoteAssets.push(asset)
+    }
+  }
+
+  return remoteAssets
+}
+
+export function createRemoteAsset(
+  ref: PresetAssetReference
+): EditorAsset | null {
+  if (!(isRemoteAssetReference(ref) && isAllowedAssetOrigin(ref.url))) {
+    return null
+  }
+
+  if (!ASSET_KINDS.includes(ref.kind)) {
+    return null
+  }
+
+  return {
+    createdAt: new Date().toISOString(),
+    duration: ref.duration ?? null,
+    error: null,
+    fileName: ref.fileName,
+    height: ref.height ?? null,
+    id: ref.id,
+    kind: ref.kind,
+    mimeType: ref.mimeType ?? "",
+    sizeBytes: ref.sizeBytes ?? 0,
+    source: "remote",
+    status: "ready",
+    url: ref.url,
+    width: ref.width ?? null,
+  }
+}

--- a/src/renderer/media-texture.ts
+++ b/src/renderer/media-texture.ts
@@ -124,6 +124,7 @@ function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
 function loadImageElement(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const image = new Image()
+    image.crossOrigin = "anonymous"
     image.decoding = "async"
     image.onload = () => resolve(image)
     image.onerror = () => {
@@ -221,6 +222,7 @@ export function loadImageTexture(
 export function createVideoTexture(url: string): Promise<VideoHandle> {
   return new Promise((resolve, reject) => {
     const video = document.createElement("video")
+    video.crossOrigin = "anonymous"
     video.loop = true
     video.muted = true
     video.playsInline = true

--- a/src/store/asset-store.ts
+++ b/src/store/asset-store.ts
@@ -165,6 +165,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       kind,
       mimeType: file.type,
       sizeBytes: file.size,
+      source: "local" as const,
       status: "ready" as const,
       url,
     }
@@ -217,7 +218,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
   removeAsset: (id) => {
     const asset = get().assets.find((entry) => entry.id === id)
 
-    if (asset) {
+    if (asset?.source === "local") {
       URL.revokeObjectURL(asset.url)
     }
 
@@ -234,7 +235,7 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     const retained = new Set(assets.map((asset) => asset.url))
 
     for (const asset of get().assets) {
-      if (!retained.has(asset.url)) {
+      if (asset.source === "local" && !retained.has(asset.url)) {
         URL.revokeObjectURL(asset.url)
       }
     }

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -295,6 +295,8 @@ export type EditorLayer = SourceLayer | EffectLayer | ModelLayer
 
 export type AssetStatus = "idle" | "loading" | "ready" | "error"
 
+export type AssetSource = "local" | "remote"
+
 export interface EditorAsset {
   createdAt: string
   duration: number | null
@@ -304,6 +306,7 @@ export interface EditorAsset {
   kind: AssetKind
   mimeType: string
   sizeBytes: number
+  source: AssetSource
   status: AssetStatus
   url: string
   width: number | null
@@ -555,6 +558,13 @@ export interface PresetAssetReference {
   fileName: string
   id: string
   kind: AssetKind
+  duration?: number | null
+  height?: number | null
+  mimeType?: string
+  sha256?: string
+  sizeBytes?: number
+  url?: string
+  width?: number | null
 }
 
 export interface ProjectPresetConfig {


### PR DESCRIPTION
Parent PR for the community scene showcase. Child PRs stack on this branch.

## Why

Shader Lab is purely client-side today: no route handlers, no database, no auth, no storage. Scenes live in browser memory and are exchanged as manually downloaded `.lab` files. We want a community — a browsable showcase of user scenes with thumbnail, author, date and "layers used", plus one-click **remix** with lineage attribution. Remixing is the growth loop.

This PR is **Phase 0**: the client-only foundation. No backend, no new env vars required, nothing user-visible changes yet. It exists to de-risk the rest.

## The blocker it removes

`buildLabProjectFile` reduced every asset to `{fileName, id, kind}` — **the bytes were dropped**. Importing a `.lab` with media stamped `Missing asset: x.png` and asked you to relink, so a shared scene containing an image, video or audio file could *never* render for anyone but its author. That, not the UI, is the centre of gravity of this project.

## What's here

Two independent commits (disjoint files, either could land alone):

**1. Layer catalog** — user-facing labels/descriptions/categories/thumbnails moved out of two non-exported arrays inside `layer-picker.tsx` into `src/lib/editor/config/layer-catalog.ts`. Pure data, no React, so it works from server components and DOM-free tests. `Record<LayerType, …>` so the compiler enforces coverage of all 34 types — including `blur` and `model`, which the picker omits but scene chips still need to label.

**2. Remote asset references (schema v5)** — optional `url`/`mimeType`/`sizeBytes`/`width`/`height`/`duration`/`sha256` on `PresetAssetReference`, `CURRENT_PROJECT_FILE_VERSION` → 5. The zod schema is `looseObject` throughout so **older files keep parsing unchanged**.

> **Version 5, not 4.** Rebased onto ASCII layer v2 (#113), which claimed 4 for its own `fontWeight` string→number migration. Git merged the two `= 4` lines with no conflict, which is the dangerous case: both changes are additive and neither branches on the version, so sharing a number would have worked *by accident* while making "what does a v4 file contain" unanswerable. Taking 5 keeps that question answerable.

Three things worth reviewer attention:

- **`applyLabProjectFile` stays synchronous.** The renderer only reads `kind`, `url`, `width`, `height` off an asset, and a v5 reference already carries all of them — so hydration needs no network probe and no loading state. Remote assets are *merged* into the store, not replacing it, so the existing local-asset relink path still works (and it composes with #113's new params migration in `hydrateImportedLayer`).
- **Origin allowlist.** Every asset `url` is validated before hydration. Without it, a hand-crafted `.lab` dropped on the canvas is an arbitrary-outbound-request primitive. Loopback is never implicitly trusted. The same check must run server-side when publish lands.
- **`crossOrigin="anonymous"`** on the `Image` and `video` elements in both copies of `media-texture.ts`. Not cosmetic: `exportStillImage` reads pixels back off the canvas, so a cross-origin texture without CORS **taints** it and `toBlob` throws `SecurityError`. The SVG path is worse — `loadSvgTexture` does its own `drawImage` + `canvasToBlob`, a second readback. (three's `TextureLoader` already defaults `crossOrigin` to `anonymous`, so it needed no change.)

## Verification

Verified on real WebGPU in Chrome Canary, driven over CDP, against a local origin serving identical fixtures on two ports — one sending `Access-Control-Allow-Origin`, one not:

| Case | Result |
|---|---|
| image / SVG / video **+ CORS** | hydrates, renders, PNG export reads back clean, no `SecurityError` |
| image / video **no CORS** | `net::ERR_FAILED`, nothing rendered — proves the attribute is *enforced* rather than silently tainting |
| non-allowlisted origin | blocked before any request, falls back to the existing "Missing asset" relink path |
| local file upload | unchanged, no regression |

The negative controls are the point: without `crossOrigin`, those loads would have **succeeded and silently tainted the canvas**.

The layer-catalog refactor was verified behaviour-preserving by diffing the derived arrays against the originals in git — **23/23 effects and 9/9 sources identical** — plus a visual check of the picker.

`bun test` 409 pass (30 new, rebased onto #113), `tsc` + `tsgo` clean, runtime package typechecks and builds, biome clean (2 pre-existing warnings in an untouched file).

## Known gap, deliberately not fixed here

`pipeline-manager.ts` swallows `setMedia` rejections (`.catch(() => markDirty())`), so a remote asset that fails to load renders **black with no `runtimeError` at all** — the layer looks healthy. For a gallery that's the difference between "this scene is broken, here's why" and "Shader Lab is broken". Must surface before published scenes ship; tracked for the upload/publish child PR.

## Stack

- **this PR** — Phase 0: client foundation *(no keys needed)*
- next: Phase 1 infra — Neon + Drizzle + Better Auth + feature flag
- then: uploads (R2 / Cloudflare Images / Stream) → publish + thumbnails → browse UI + remix → public routes + SEO → likes + moderation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
