### PR TITLE
Record every handle a profile has held, so renaming one cannot orphan a url

### DIFF
--- a/drizzle/0003_handle_claims.sql
+++ b/drizzle/0003_handle_claims.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "handle_claims" (
+	"claimed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"handle" text PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "handle_claims" ADD CONSTRAINT "handle_claims_user_id_profiles_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "handle_claims_user_idx" ON "handle_claims" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "scenes_author_published_idx" ON "scenes" USING btree ("author_id","status","published_at" DESC NULLS LAST);--> statement-breakpoint
+INSERT INTO "handle_claims" ("handle", "user_id", "claimed_at") SELECT "handle", "user_id", "created_at" FROM "profiles" ON CONFLICT DO NOTHING;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,999 @@
+{
+  "id": "f917e5b3-ae1f-403a-a401-bb4206c1768f",
+  "prevId": "40f8e94c-3ace-4035-84f5-34b3025cd730",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.handle_claims": {
+      "name": "handle_claims",
+      "schema": "",
+      "columns": {
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "handle_claims_user_idx": {
+          "name": "handle_claims_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "handle_claims_user_id_profiles_user_id_fk": {
+          "name": "handle_claims_user_id_profiles_user_id_fk",
+          "tableFrom": "handle_claims",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "likes_scene_idx": {
+          "name": "likes_scene_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "likes_scene_id_scenes_id_fk": {
+          "name": "likes_scene_id_scenes_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_user_id_profiles_user_id_fk": {
+          "name": "likes_user_id_profiles_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_scene_id_pk": {
+          "name": "likes_user_id_scene_id_pk",
+          "columns": [
+            "user_id",
+            "scene_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_handle_unique": {
+          "name": "profiles_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remixes": {
+      "name": "remixes",
+      "schema": "",
+      "columns": {
+        "actor_key": {
+          "name": "actor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "day_bucket": {
+          "name": "day_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remixes_scene_idx": {
+          "name": "remixes_scene_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remixes_scene_id_scenes_id_fk": {
+          "name": "remixes_scene_id_scenes_id_fk",
+          "tableFrom": "remixes",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "remixes_actor_day_unique": {
+          "name": "remixes_actor_day_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id",
+            "actor_key",
+            "day_bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "reports_scene_idx": {
+          "name": "reports_scene_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_open_idx": {
+          "name": "reports_open_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_profiles_user_id_fk": {
+          "name": "reports_reporter_id_profiles_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reports_resolved_by_profiles_user_id_fk": {
+          "name": "reports_resolved_by_profiles_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reports_scene_id_scenes_id_fk": {
+          "name": "reports_scene_id_scenes_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scene_assets": {
+      "name": "scene_assets",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "asset_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scene_assets_scene_idx": {
+          "name": "scene_assets_scene_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_assets_sha256_idx": {
+          "name": "scene_assets_sha256_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_assets_scene_id_scenes_id_fk": {
+          "name": "scene_assets_scene_id_scenes_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_assets_scene_asset_unique": {
+          "name": "scene_assets_scene_asset_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id",
+            "asset_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scenes": {
+      "name": "scenes",
+      "schema": "",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composition_height": {
+          "name": "composition_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composition_width": {
+          "name": "composition_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "featured_at": {
+          "name": "featured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forked_from_id": {
+          "name": "forked_from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_custom_shader": {
+          "name": "has_custom_shader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_key": {
+          "name": "lab_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_version": {
+          "name": "lab_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layer_types": {
+          "name": "layer_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_video_uid": {
+          "name": "preview_video_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remix_count": {
+          "name": "remix_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "thumbnail_image_id": {
+          "name": "thumbnail_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scenes_latest_idx": {
+          "name": "scenes_latest_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_popular_idx": {
+          "name": "scenes_popular_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "like_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_author_idx": {
+          "name": "scenes_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_author_published_idx": {
+          "name": "scenes_author_published_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_featured_idx": {
+          "name": "scenes_featured_idx",
+          "columns": [
+            {
+              "expression": "featured_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_forked_from_idx": {
+          "name": "scenes_forked_from_idx",
+          "columns": [
+            {
+              "expression": "forked_from_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_layer_types_idx": {
+          "name": "scenes_layer_types_idx",
+          "columns": [
+            {
+              "expression": "layer_types",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scenes_author_id_profiles_user_id_fk": {
+          "name": "scenes_author_id_profiles_user_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scenes_forked_from_id_scenes_id_fk": {
+          "name": "scenes_forked_from_id_scenes_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "forked_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scenes_slug_unique": {
+          "name": "scenes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_quota": {
+      "name": "upload_quota",
+      "schema": "",
+      "columns": {
+        "bytes_used": {
+          "name": "bytes_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "day_bucket": {
+          "name": "day_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenes_today": {
+          "name": "scenes_today",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "upload_quota_user_id_profiles_user_id_fk": {
+          "name": "upload_quota_user_id_profiles_user_id_fk",
+          "tableFrom": "upload_quota",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_provider": {
+      "name": "asset_provider",
+      "schema": "public",
+      "values": [
+        "cf-images",
+        "cf-stream",
+        "r2"
+      ]
+    },
+    "public.scene_status": {
+      "name": "scene_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "processing",
+        "published",
+        "takendown"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1786635276435,
       "tag": "0002_crazy_tattoo",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1786980505053,
+      "tag": "0003_handle_claims",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/community/__tests__/cache-tags.test.ts
+++ b/src/lib/community/__tests__/cache-tags.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import {
+  authorTag,
+  COMMUNITY_FEED_TAG,
+  profileHandleTag,
+  sceneTag,
+} from "@/lib/community/cache-tags"
+
+describe("cache tags", () => {
+  test("keeps the exact strings the revalidate calls depend on", () => {
+    expect(COMMUNITY_FEED_TAG).toBe("community-feed")
+    expect(authorTag("6c1f0a2e")).toBe("author:6c1f0a2e")
+    expect(profileHandleTag("tobi-moccagatta")).toBe(
+      "profile-handle:tobi-moccagatta"
+    )
+    expect(sceneTag("basement-vme0ud")).toBe("scene:basement-vme0ud")
+  })
+
+  test("never collides across tag families for the same value", () => {
+    const value = "overlap"
+    const tags = [authorTag(value), profileHandleTag(value), sceneTag(value)]
+
+    expect(new Set(tags).size).toBe(tags.length)
+    expect(tags).not.toContain(COMMUNITY_FEED_TAG)
+  })
+
+  test("distinguishes two handles that differ only by suffix", () => {
+    expect(profileHandleTag("tobi")).not.toBe(profileHandleTag("tobi-2"))
+  })
+})

--- a/src/lib/community/__tests__/handle.test.ts
+++ b/src/lib/community/__tests__/handle.test.ts
@@ -3,6 +3,7 @@ import {
   buildHandleCandidates,
   deriveHandleSeed,
   HANDLE_MAX_LENGTH,
+  isLookupableHandle,
   isReservedHandle,
   isValidHandle,
   slugifyHandle,
@@ -64,6 +65,38 @@ describe("isValidHandle", () => {
       expect(isReservedHandle(reserved)).toBe(true)
       expect(isValidHandle(reserved)).toBe(false)
     }
+  })
+
+  test("reserves the words the profile routes need", () => {
+    for (const reserved of ["account", "drafts", "profile", "profiles", "u"]) {
+      expect(isReservedHandle(reserved)).toBe(true)
+      expect(isValidHandle(reserved)).toBe(false)
+    }
+  })
+})
+
+describe("isLookupableHandle", () => {
+  test("agrees with isValidHandle on shape", () => {
+    for (const good of ["tobi-moccagatta", "abc", "a1b2"]) {
+      expect(isLookupableHandle(good)).toBe(true)
+    }
+
+    for (const bad of ["ab", "-abc", "abc-", "AbC", "a b", "a_b", ""]) {
+      expect(isLookupableHandle(bad)).toBe(false)
+    }
+
+    expect(isLookupableHandle("a".repeat(HANDLE_MAX_LENGTH + 1))).toBe(false)
+  })
+
+  test("still resolves a handle that has since become reserved", () => {
+    for (const reserved of ["account", "drafts", "profile", "settings"]) {
+      expect(isValidHandle(reserved)).toBe(false)
+      expect(isLookupableHandle(reserved)).toBe(true)
+    }
+  })
+
+  test("is too short to match the profile route prefix", () => {
+    expect(isLookupableHandle("u")).toBe(false)
   })
 })
 

--- a/src/lib/community/cache-tags.ts
+++ b/src/lib/community/cache-tags.ts
@@ -1,0 +1,13 @@
+export const COMMUNITY_FEED_TAG = "community-feed"
+
+export function authorTag(userId: string): string {
+  return `author:${userId}`
+}
+
+export function profileHandleTag(handle: string): string {
+  return `profile-handle:${handle}`
+}
+
+export function sceneTag(slug: string): string {
+  return `scene:${slug}`
+}

--- a/src/lib/community/handle.ts
+++ b/src/lib/community/handle.ts
@@ -3,11 +3,13 @@ export const HANDLE_MAX_LENGTH = 30
 
 const RESERVED_HANDLES = new Set([
   "about",
+  "account",
   "admin",
   "api",
   "auth",
   "community",
   "docs",
+  "drafts",
   "edit",
   "explore",
   "featured",
@@ -20,6 +22,8 @@ const RESERVED_HANDLES = new Set([
   "new",
   "popular",
   "privacy",
+  "profile",
+  "profiles",
   "remix",
   "root",
   "scene",
@@ -33,6 +37,7 @@ const RESERVED_HANDLES = new Set([
   "support",
   "terms",
   "tools",
+  "u",
   "user",
   "users",
 ])
@@ -53,16 +58,18 @@ export function isReservedHandle(handle: string): boolean {
   return RESERVED_HANDLES.has(handle)
 }
 
-export function isValidHandle(handle: string): boolean {
-  if (
-    handle.length < HANDLE_MIN_LENGTH ||
-    handle.length > HANDLE_MAX_LENGTH ||
-    isReservedHandle(handle)
-  ) {
-    return false
-  }
+const HANDLE_SHAPE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 
-  return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(handle)
+export function isLookupableHandle(handle: string): boolean {
+  return (
+    handle.length >= HANDLE_MIN_LENGTH &&
+    handle.length <= HANDLE_MAX_LENGTH &&
+    HANDLE_SHAPE.test(handle)
+  )
+}
+
+export function isValidHandle(handle: string): boolean {
+  return isLookupableHandle(handle) && !isReservedHandle(handle)
 }
 
 function emailLocalPart(email: string | null | undefined): string {

--- a/src/lib/community/profile.ts
+++ b/src/lib/community/profile.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm"
 import { buildHandleCandidates } from "@/lib/community/handle"
 import { getDatabase } from "@/lib/db"
-import { profiles } from "@/lib/db/schema"
+import { handleClaims, profiles } from "@/lib/db/schema"
 
 export interface ProfileSeed {
   avatarUrl?: string | null
@@ -94,15 +94,18 @@ export async function ensureProfile(
 
   for (const handle of buildHandleCandidates(seed)) {
     try {
-      const inserted = await db
-        .insert(profiles)
-        .values({
-          avatarUrl: seed.avatarUrl ?? null,
-          displayName: seed.name ?? null,
-          handle,
-          userId,
-        })
-        .returning(RETURNING)
+      const [inserted] = await db.batch([
+        db
+          .insert(profiles)
+          .values({
+            avatarUrl: seed.avatarUrl ?? null,
+            displayName: seed.name ?? null,
+            handle,
+            userId,
+          })
+          .returning(RETURNING),
+        db.insert(handleClaims).values({ handle, userId }),
+      ])
 
       const row = inserted[0]
 

--- a/src/lib/community/profiles.ts
+++ b/src/lib/community/profiles.ts
@@ -1,0 +1,74 @@
+import { and, eq, isNull, sql } from "drizzle-orm"
+import { getDatabase } from "@/lib/db"
+import { handleClaims, profiles, scenes } from "@/lib/db/schema"
+
+export interface PublicProfile {
+  avatarUrl: string | null
+  displayName: string | null
+  handle: string
+  joinedAt: string
+  publishedCount: number
+  remixCount: number
+  upvoteCount: number
+  userId: string
+}
+
+export async function getProfileByHandle(
+  handle: string
+): Promise<PublicProfile | null> {
+  const rows = await getDatabase()
+    .select({
+      avatarUrl: profiles.avatarUrl,
+      displayName: profiles.displayName,
+      handle: profiles.handle,
+      joinedAt: profiles.createdAt,
+      publishedCount: sql<number>`count(${scenes.id})::int`,
+      remixCount: sql<number>`coalesce(sum(${scenes.remixCount}), 0)::int`,
+      upvoteCount: sql<number>`coalesce(sum(${scenes.likeCount}), 0)::int`,
+      userId: profiles.userId,
+    })
+    .from(profiles)
+    .leftJoin(
+      scenes,
+      and(
+        eq(scenes.authorId, profiles.userId),
+        eq(scenes.status, "published"),
+        isNull(scenes.deletedAt)
+      )
+    )
+    .where(eq(profiles.handle, handle))
+    .groupBy(profiles.userId)
+    .limit(1)
+
+  const row = rows[0]
+
+  if (!row) {
+    return null
+  }
+
+  return {
+    avatarUrl: row.avatarUrl,
+    displayName: row.displayName,
+    handle: row.handle,
+    joinedAt: row.joinedAt.toISOString(),
+    publishedCount: Number(row.publishedCount),
+    remixCount: Number(row.remixCount),
+    upvoteCount: Number(row.upvoteCount),
+    userId: row.userId,
+  }
+}
+
+export async function findCurrentHandleFor(
+  handle: string
+): Promise<string | null> {
+  const rows = await getDatabase()
+    .select({ current: profiles.handle })
+    .from(handleClaims)
+    .innerJoin(profiles, eq(profiles.userId, handleClaims.userId))
+    .where(eq(handleClaims.handle, handle))
+    .limit(1)
+
+  const current = rows[0]?.current ?? null
+
+  return current === handle ? null : current
+}

--- a/src/lib/community/scenes.ts
+++ b/src/lib/community/scenes.ts
@@ -166,6 +166,7 @@ export interface SceneListPage {
 }
 
 export async function listPublishedScenes(options?: {
+  authorHandle?: string | null
   cursor?: SceneCursor | null
   limit?: number
   query?: string
@@ -180,6 +181,10 @@ export async function listPublishedScenes(options?: {
 
   if (sort === "featured") {
     filters.push(sql`${scenes.featuredAt} is not null`)
+  }
+
+  if (options?.authorHandle) {
+    filters.push(eq(profiles.handle, options.authorHandle))
   }
 
   if (options?.cursor) {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -32,6 +32,20 @@ export const profiles = pgTable("profiles", {
   userId: uuid("user_id").primaryKey(),
 })
 
+export const handleClaims = pgTable(
+  "handle_claims",
+  {
+    claimedAt: timestamp("claimed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    handle: text("handle").primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => profiles.userId, { onDelete: "cascade" }),
+  },
+  (table) => [index("handle_claims_user_idx").on(table.userId)]
+)
+
 export const sceneStatus = pgEnum("scene_status", [
   "draft",
   "processing",
@@ -84,6 +98,11 @@ export const scenes = pgTable(
     index("scenes_latest_idx").on(table.status, table.publishedAt.desc()),
     index("scenes_popular_idx").on(table.status, table.likeCount.desc()),
     index("scenes_author_idx").on(table.authorId),
+    index("scenes_author_published_idx").on(
+      table.authorId,
+      table.status,
+      table.publishedAt.desc()
+    ),
     index("scenes_featured_idx").on(table.featuredAt.desc()),
     index("scenes_forked_from_idx").on(table.forkedFromId),
     index("scenes_layer_types_idx").using("gin", table.layerTypes),


### PR DESCRIPTION
Stacked on #119. Groundwork for public profile pages and editable handles — **nothing here is reachable from the UI yet.**

### `handle_claims`

`profiles.handle` stays the single source of truth for the *current* handle, so every existing query is untouched. The new table records each handle a user has ever held, which is what makes a rename survivable — it does three jobs at once:

- a url carrying an old handle can be **redirected instead of 404ing** (this is the correctness guarantee for renames; cache tags are only cleanup)
- a released handle **cannot be squatted** by someone else
- the rename rate limit falls out of the claim history, **no extra column**

The migration backfills a claim for every profile that already exists.

### `ensureProfile` writes both rows atomically

Via `db.batch`. The neon-http driver has no interactive transactions — `db.transaction` throws outright (`drizzle-orm/neon-http/session.js:152`) — but `batch` maps to a real Neon transaction in one round trip, so a collision on either table rolls both back and still arrives as 23505, which the existing candidate loop already retries.

### `authorHandle` on `listPublishedScenes`

A filter, not a sibling function. The `profiles` join already exists and the filter goes into the same array as the keyset predicate, so cursor format is unchanged and paging works inside the author subset.

`scenes_author_published_idx` covers the implied ordering. **At 9 live rows the planner will still seq-scan** — it's there for scale, not for today.

### `isLookupableHandle`

Checks length and shape but deliberately **not** the reserved list: reserving a word must never break the page of someone who already holds it. `isValidHandle` becomes that plus the reserved test, which is the same condition it expressed before.

## Verification

- `bun test` — **577 pass, 0 fail** (570 on base, +7 new)
- `bun run typecheck` clean; `bun run lint` 2 warnings, both pre-existing in `properties-sidebar.tsx`, same count as base
- Migration applied to the Neon dev DB. Purely additive — `CREATE TABLE`, one FK, two indexes, one `INSERT ... ON CONFLICT DO NOTHING` into the new table. Before/after: profiles 6 → 6, published scenes unchanged, `handle_claims` 0 → 6, **profiles missing a claim: none**.
- `getProfileByHandle` checked against independently computed SQL for all 6 profiles: **0 mismatches** on published / upvote / remix counts. A profile with **zero** published scenes still resolves (the `LEFT JOIN` case — real data happened to contain one). Unknown handle → `null`.
- `authorHandle` filter returns exactly that author's 5 scenes, all matching; unfiltered returns 9, so the filter demonstrably narrows.
- Keyset paging inside the author scope: `limit: 1` yields a cursor, page 2 is a different scene and still the same author.

One thing worth knowing that came out of this: of 22 rows with `status='published'`, **13 are soft-deleted** — only 9 are live. Every query here correctly excludes them, but a raw `count(*) where status='published'` overstates the catalogue by more than 2×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
