### PR TITLE
Show a scene on the grid when it is published, not fifteen minutes later

### DIFF
--- a/src/app/api/community/drafts/[id]/publish/route.ts
+++ b/src/app/api/community/drafts/[id]/publish/route.ts
@@ -1,6 +1,9 @@
 import { and, eq, isNull } from "drizzle-orm"
 import { nanoid } from "nanoid"
+import { revalidateTag } from "next/cache"
+import { connection } from "next/server"
 import { getOptionalSession } from "@/lib/auth/server"
+import { authorTag, COMMUNITY_FEED_TAG } from "@/lib/community/cache-tags"
 import { isCommunityEnabled, isMediaConfigured } from "@/lib/community/config"
 import { ensureProfile } from "@/lib/community/profile"
 import {
@@ -45,6 +48,8 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  await connection()
+
   if (!(isCommunityEnabled() && isMediaConfigured())) {
     return badRequest("Publishing is not configured on this deployment.", 503)
   }
@@ -213,6 +218,9 @@ export async function POST(
     .from(scenes)
     .where(eq(scenes.id, draftId))
     .limit(1)
+
+  revalidateTag(COMMUNITY_FEED_TAG, "max")
+  revalidateTag(authorTag(profile.userId), "max")
 
   return Response.json({
     scene: { id: draftId, slug: created[0]?.slug ?? null },

--- a/src/app/api/community/scenes/[slug]/route.ts
+++ b/src/app/api/community/scenes/[slug]/route.ts
@@ -1,4 +1,11 @@
+import { revalidateTag } from "next/cache"
+import { connection } from "next/server"
 import { getOptionalSession } from "@/lib/auth/server"
+import {
+  authorTag,
+  COMMUNITY_FEED_TAG,
+  sceneTag,
+} from "@/lib/community/cache-tags"
 import { isCommunityEnabled } from "@/lib/community/config"
 import { removeScene } from "@/lib/community/moderation"
 import { getPublishedScene } from "@/lib/community/scenes"
@@ -30,6 +37,8 @@ export async function DELETE(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
+  await connection()
+
   if (!isCommunityEnabled()) {
     return Response.json({ error: "Not available." }, { status: 503 })
   }
@@ -55,6 +64,10 @@ export async function DELETE(
         { status: 403 }
       )
     }
+
+    revalidateTag(COMMUNITY_FEED_TAG, "max")
+    revalidateTag(authorTag(outcome.authorId), "max")
+    revalidateTag(sceneTag(slug), "max")
 
     return Response.json({
       mode: outcome.mode,

--- a/src/lib/community/moderation.ts
+++ b/src/lib/community/moderation.ts
@@ -15,6 +15,7 @@ export type RemovalOutcome =
   | { kind: "forbidden" }
   | { kind: "notFound" }
   | {
+      authorId: string
       kind: "removed"
       mode: "deleted" | "takendown"
       purgedObjects: number
@@ -129,6 +130,7 @@ export async function removeScene(input: {
 
   if (alreadyGone) {
     return {
+      authorId: scene.authorId,
       kind: "removed",
       mode: moderator ? "takendown" : "deleted",
       purgedObjects: 0,
@@ -159,7 +161,13 @@ export async function removeScene(input: {
     purgedObjects = -1
   }
 
-  return { kind: "removed", mode, purgedObjects, retainedObjects }
+  return {
+    authorId: scene.authorId,
+    kind: "removed",
+    mode,
+    purgedObjects,
+    retainedObjects,
+  }
 }
 
 export async function reportScene(input: {

--- a/src/lib/community/public-scenes.ts
+++ b/src/lib/community/public-scenes.ts
@@ -1,3 +1,9 @@
+import { cacheTag } from "next/cache"
+import {
+  authorTag,
+  COMMUNITY_FEED_TAG,
+  sceneTag,
+} from "@/lib/community/cache-tags"
 import { isCommunityEnabled } from "@/lib/community/config"
 import {
   decodeSceneCursor,
@@ -6,7 +12,7 @@ import {
 import {
   type CommunitySceneDetail,
   type CommunitySceneSummary,
-  getPublishedScene,
+  getPublishedSceneWithAuthor,
   listPublishedScenes,
 } from "@/lib/community/scenes"
 
@@ -17,6 +23,8 @@ export async function getPublicScenes(): Promise<{
   scenes: CommunitySceneSummary[]
 }> {
   "use cache"
+
+  cacheTag(COMMUNITY_FEED_TAG)
 
   if (!isCommunityEnabled()) {
     return { nextCursor: null, scenes: [] }
@@ -45,6 +53,8 @@ export async function listAllPublishedScenesForSitemap(): Promise<
   SitemapScene[]
 > {
   "use cache"
+
+  cacheTag(COMMUNITY_FEED_TAG)
 
   if (!isCommunityEnabled()) {
     return []
@@ -90,12 +100,22 @@ export async function getPublicScene(
 ): Promise<CommunitySceneDetail | null> {
   "use cache"
 
+  cacheTag(sceneTag(slug))
+
   if (!isCommunityEnabled()) {
     return null
   }
 
   try {
-    return await getPublishedScene(slug)
+    const authored = await getPublishedSceneWithAuthor(slug)
+
+    if (!authored) {
+      return null
+    }
+
+    cacheTag(authorTag(authored.authorId))
+
+    return authored.detail
   } catch {
     return null
   }

--- a/src/lib/community/scenes.ts
+++ b/src/lib/community/scenes.ts
@@ -250,12 +250,24 @@ export async function listScenesByAuthor(
   return rows.map((row) => ({ ...toSummary(row), status: row.status }))
 }
 
+export interface AuthoredSceneDetail {
+  authorId: string
+  detail: CommunitySceneDetail
+}
+
 export async function getPublishedScene(
   slug: string
 ): Promise<CommunitySceneDetail | null> {
+  return (await getPublishedSceneWithAuthor(slug))?.detail ?? null
+}
+
+export async function getPublishedSceneWithAuthor(
+  slug: string
+): Promise<AuthoredSceneDetail | null> {
   const rows = await getDatabase()
     .select({
       ...summaryColumns,
+      authorId: scenes.authorId,
       description: scenes.description,
       forkedFromId: scenes.forkedFromId,
       labKey: scenes.labKey,
@@ -303,9 +315,12 @@ export async function getPublishedScene(
   }
 
   return {
-    ...toSummary(row),
-    description: row.description,
-    forkedFrom,
-    labUrl: resolveLabUrl(row.labKey),
+    authorId: row.authorId,
+    detail: {
+      ...toSummary(row),
+      description: row.description,
+      forkedFrom,
+      labUrl: resolveLabUrl(row.labKey),
+    },
   }
 }


### PR DESCRIPTION
Stacked on #120. Fixes a pre-existing bug: **nothing ever invalidated the community grid.**

The grid is cached so database load doesn't track traffic, but with no invalidation, publishing a scene left the author staring at a grid that didn't contain it for up to 15 minutes, and a takedown stayed visible just as long. The cache was doing its job — there was simply no way to tell it something had changed.

### What changed

The three cached reads declare tags; the two routes that mutate a scene revalidate them.

| cached read | tags |
|---|---|
| `getPublicScenes()` | `COMMUNITY_FEED_TAG` |
| `listAllPublishedScenesForSitemap()` | `COMMUNITY_FEED_TAG` |
| `getPublicScene(slug)` | `sceneTag(slug)` + `authorTag(authorId)` |

Tagging by **author id** as well as slug is what keeps this tractable: one call reaches every one of an author's scene pages without enumerating them, and it keeps working after a handle changes.

### `revalidateTag` needs care in 16.2.3

All verified against the installed source, not the docs:

- takes a **profile argument** now — the single-arg form logs a deprecation (`revalidate.js:42`)
- throws **E181** inside a `"use cache"` function and **E7** during render, so it must sit in the route handler body (`revalidate.js:114,123`)
- throws **E406** in a prerender context unless `await connection()` ran first (`revalidate.js:143`)
- **`updateTag` is not an option at all** — it refuses to run when `workStore.page.endsWith('/route')`, i.e. every route handler, and there are no server actions in this repo (`revalidate.js:52`)

### `getPublishedSceneWithAuthor`

A sibling that also returns the author id. Deliberately **not** added to `summaryColumns` or `CommunitySceneDetail`: that object is returned verbatim by `GET /api/community/scenes/[slug]` and handed to `scene-detail.tsx` as a prop, so widening it would ship a user uuid to every visitor. `RemovalOutcome` carries the author id for the same reason the tag needs it — on a moderator takedown the actor is not the author.

## Verification

- `bun test` 577 pass / 0 fail; `typecheck` clean; `lint` 2 warnings, both pre-existing in `properties-sidebar.tsx`, same as base
- **End-to-end against a production build** (`bun run build` + `next start`), real Neon data. Changed a scene title directly in the DB, then:
  1. grid still served the cached title ✓ (proves it *was* cached)
  2. `revalidateTag(COMMUNITY_FEED_TAG, "max")` → new title appeared ✓
- **Control:** with `cacheTag(COMMUNITY_FEED_TAG)` removed from `getPublicScenes`, step 2 never happens — the probe title never appears. So the test can fail, and it does when it should.

That control is also the answer to the open question of whether a tag declared inside an inner cached function reaches the prerendered page that consumed it. **It does.**

Two notes on the verification scaffolding, both removed before commit:
- The trigger route was first written as `src/app/api/__verify-revalidate/` and silently never built — Next treats `_`-prefixed folders as private and excludes them from routing.
- Typecheck failed once on a stale `.next/types/validator.ts` still referencing the deleted scratch route; it clears on rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
