### PR TITLE
Give every author a page, so a name on a card leads somewhere

### DIFF
--- a/src/app/api/community/me/profile/route.ts
+++ b/src/app/api/community/me/profile/route.ts
@@ -1,0 +1,37 @@
+import { connection } from "next/server"
+import { getOptionalSession } from "@/lib/auth/server"
+import { isCommunityEnabled } from "@/lib/community/config"
+import { ensureProfile } from "@/lib/community/profile"
+
+export async function GET() {
+  await connection()
+
+  if (!isCommunityEnabled()) {
+    return Response.json({ error: "Not available." }, { status: 503 })
+  }
+
+  const session = await getOptionalSession()
+
+  if (!session) {
+    return Response.json({ error: "Sign in first." }, { status: 401 })
+  }
+
+  try {
+    const profile = await ensureProfile(session.user.id, {
+      avatarUrl: session.user.image,
+      email: session.user.email,
+      name: session.user.name,
+    })
+
+    return Response.json({
+      avatarUrl: profile.avatarUrl,
+      displayName: profile.displayName,
+      handle: profile.handle,
+    })
+  } catch {
+    return Response.json(
+      { error: "Could not load your profile." },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/community/profiles/[handle]/route.ts
+++ b/src/app/api/community/profiles/[handle]/route.ts
@@ -1,0 +1,40 @@
+import { isCommunityEnabled } from "@/lib/community/config"
+import { isLookupableHandle } from "@/lib/community/handle"
+import { toProfileView } from "@/lib/community/profiles"
+import { getPublicProfile } from "@/lib/community/public-profiles"
+
+const PROFILE_CACHE =
+  "public, s-maxage=60, stale-while-revalidate=300, max-age=0"
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ handle: string }> }
+) {
+  if (!isCommunityEnabled()) {
+    return Response.json({ error: "Not available." }, { status: 503 })
+  }
+
+  const handle = (await params).handle.toLowerCase()
+
+  if (!isLookupableHandle(handle)) {
+    return Response.json({ error: "Profile not found." }, { status: 404 })
+  }
+
+  try {
+    const profile = await getPublicProfile(handle)
+
+    if (!profile) {
+      return Response.json({ error: "Profile not found." }, { status: 404 })
+    }
+
+    return Response.json(
+      { profile: toProfileView(profile) },
+      { headers: { "Cache-Control": PROFILE_CACHE } }
+    )
+  } catch {
+    return Response.json(
+      { error: "Could not load that profile." },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/community/scenes/route.ts
+++ b/src/app/api/community/scenes/route.ts
@@ -1,4 +1,5 @@
 import { isCommunityEnabled } from "@/lib/community/config"
+import { isLookupableHandle } from "@/lib/community/handle"
 import { decodeSceneCursor } from "@/lib/community/scene-cursor"
 import {
   DEFAULT_SCENE_SORT,
@@ -25,9 +26,16 @@ export async function GET(request: Request) {
   const limit = Number.parseInt(url.searchParams.get("limit") ?? "", 10)
   const rawCursor = url.searchParams.get("cursor")
 
+  const requestedAuthor = url.searchParams.get("author")?.toLowerCase() ?? ""
+
+  if (requestedAuthor.length > 0 && !isLookupableHandle(requestedAuthor)) {
+    return Response.json({ nextCursor: null, scenes: [] }, { status: 200 })
+  }
+
   try {
     const query = url.searchParams.get("q")?.slice(0, 80) ?? ""
     const page = await listPublishedScenes({
+      ...(requestedAuthor.length > 0 ? { authorHandle: requestedAuthor } : {}),
       cursor: decodeSceneCursor(rawCursor),
       ...(Number.isFinite(limit) ? { limit } : {}),
       ...(query.trim().length > 0 ? { query } : {}),

--- a/src/app/community/[slug]/page.tsx
+++ b/src/app/community/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { lineageLabel } from "@/lib/community/lineage"
 import {
   editorSceneHref,
   OPEN_IN_EDITOR_PARAM,
+  profilePagePath,
 } from "@/lib/community/scene-links"
 import { getPublicScene } from "@/lib/community/public-scenes"
 import { getLayerLabel } from "@/lib/editor/config/layer-catalog"
@@ -142,21 +143,26 @@ async function SceneBody({ params }: PageProps) {
       <div className="grid grid-cols-1 gap-[var(--ds-space-5)] min-[860px]:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
         <div className="flex min-w-0 flex-col gap-[var(--ds-space-4)]">
           <div className="flex min-w-0 items-center gap-[var(--ds-space-2)]">
-            <AuthorAvatar
-              avatarUrl={scene.authorAvatarUrl}
-              name={authorName}
-              size={24}
-            />
-            <div className="flex min-w-0 flex-col">
-              <Typography as="span" variant="label">
-                {authorName}
-              </Typography>
-              {publishedAt ? (
-                <Typography as="span" tone="tertiary" variant="monoXs">
-                  {publishedAt}
+            <Link
+              className="inline-flex min-w-0 items-center gap-[var(--ds-space-2)] rounded-[var(--ds-radius-control)] transition-opacity duration-160 hover:opacity-80"
+              href={profilePagePath(scene.authorHandle) as Route}
+            >
+              <AuthorAvatar
+                avatarUrl={scene.authorAvatarUrl}
+                name={authorName}
+                size={24}
+              />
+              <div className="flex min-w-0 flex-col">
+                <Typography as="span" variant="label">
+                  {authorName}
                 </Typography>
-              ) : null}
-            </div>
+                {publishedAt ? (
+                  <Typography as="span" tone="tertiary" variant="monoXs">
+                    {publishedAt}
+                  </Typography>
+                ) : null}
+              </div>
+            </Link>
           </div>
 
           <div className="flex flex-col gap-[var(--ds-space-2)]">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,9 @@
 import type { MetadataRoute } from "next"
 import { APP_BASE_URL } from "@/lib/app"
 import { isCommunityEnabled } from "@/lib/community/config"
+import { listAllProfilesForSitemap } from "@/lib/community/public-profiles"
 import { listAllPublishedScenesForSitemap } from "@/lib/community/public-scenes"
+import { profilePagePath } from "@/lib/community/scene-links"
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const entries: MetadataRoute.Sitemap = [
@@ -34,6 +36,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         : new Date(),
       changeFrequency: "weekly",
       priority: 0.6,
+    })
+  }
+
+  for (const profile of await listAllProfilesForSitemap()) {
+    entries.push({
+      url: `${APP_BASE_URL}${profilePagePath(profile.handle)}`,
+      lastModified: profile.lastPublishedAt
+        ? new Date(profile.lastPublishedAt)
+        : new Date(),
+      changeFrequency: "weekly",
+      priority: 0.4,
     })
   }
 

--- a/src/app/u/[handle]/opengraph-image.tsx
+++ b/src/app/u/[handle]/opengraph-image.tsx
@@ -1,0 +1,89 @@
+import { ImageResponse } from "next/og"
+import { isLookupableHandle } from "@/lib/community/handle"
+import { getPublicProfile } from "@/lib/community/public-profiles"
+
+export const alt = "A Shader Lab community profile"
+export const size = { height: 630, width: 1200 }
+export const contentType = "image/png"
+
+function nameSizeFor(name: string): number {
+  if (name.length > 46) {
+    return 58
+  }
+
+  if (name.length > 30) {
+    return 72
+  }
+
+  return 88
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ handle: string }>
+}) {
+  const handle = (await params).handle.toLowerCase()
+  const profile = isLookupableHandle(handle)
+    ? await getPublicProfile(handle)
+    : null
+  const name = profile?.displayName ?? `@${handle}`
+  const nameSize = nameSizeFor(name)
+  const count = profile?.publishedCount ?? 0
+  const summary = profile
+    ? `${count} ${count === 1 ? "scene" : "scenes"} on Shader Lab`
+    : "Shader Lab"
+
+  return new ImageResponse(
+    <div
+      style={{
+        backgroundColor: "#080808",
+        color: "#f5f5f5",
+        display: "flex",
+        flexDirection: "column",
+        height: size.height,
+        justifyContent: "space-between",
+        padding: 72,
+        width: size.width,
+      }}
+    >
+      <div
+        style={{
+          color: "#e5e5e5",
+          display: "flex",
+          fontSize: 22,
+          fontWeight: 500,
+          letterSpacing: 1.6,
+        }}
+      >
+        SHADER LAB
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <div
+          style={{
+            display: "flex",
+            fontSize: nameSize,
+            fontWeight: 600,
+            letterSpacing: nameSize * -0.035,
+            lineHeight: 0.98,
+            maxWidth: 940,
+          }}
+        >
+          {name}
+        </div>
+        <div
+          style={{
+            color: "#9b9b9b",
+            display: "flex",
+            fontSize: 30,
+            letterSpacing: -0.5,
+          }}
+        >
+          {profile ? `@${profile.handle} · ${summary}` : summary}
+        </div>
+      </div>
+    </div>,
+    size
+  )
+}

--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -1,0 +1,185 @@
+import type { Metadata, Route } from "next"
+import Link from "next/link"
+import { notFound, redirect } from "next/navigation"
+import { Suspense } from "react"
+import { ProfileHeader } from "@/components/community/profile-header"
+import { ProfileOwnerActions } from "@/components/community/profile-owner-actions"
+import { PublicSceneGrid } from "@/components/community/public-scene-grid"
+import { Typography } from "@/components/ui/typography"
+import { APP_BASE_URL } from "@/lib/app"
+import { isCommunityEnabled } from "@/lib/community/config"
+import { isLookupableHandle } from "@/lib/community/handle"
+import {
+  getPublicProfile,
+  getPublicProfileScenes,
+  resolveHandleRedirect,
+} from "@/lib/community/public-profiles"
+import { profilePagePath } from "@/lib/community/scene-links"
+import type { PublicProfile } from "@/lib/community/profiles"
+
+type PageProps = { params: Promise<{ handle: string }> }
+
+function describe(profile: PublicProfile): string {
+  const label = profile.displayName ?? `@${profile.handle}`
+  const count = profile.publishedCount
+
+  if (count === 0) {
+    return `${label} on Shader Lab.`
+  }
+
+  return `${count} ${count === 1 ? "scene" : "scenes"} published by ${label} on Shader Lab. Open any one of them and remix it in your browser.`
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const handle = (await params).handle.toLowerCase()
+  const profile = isLookupableHandle(handle)
+    ? await getPublicProfile(handle)
+    : null
+
+  if (!profile) {
+    return {
+      robots: { follow: false, index: false },
+      title: "Profile not found",
+    }
+  }
+
+  const label = profile.displayName ?? `@${profile.handle}`
+  const description = describe(profile)
+
+  return {
+    alternates: { canonical: profilePagePath(profile.handle) },
+    description,
+    openGraph: {
+      description,
+      title: label,
+      type: "profile",
+      url: `${APP_BASE_URL}${profilePagePath(profile.handle)}`,
+    },
+    ...(profile.publishedCount === 0
+      ? { robots: { follow: true, index: false } }
+      : {}),
+    title: label,
+    twitter: { card: "summary_large_image", description, title: label },
+  }
+}
+
+export default function ProfilePage({ params }: PageProps) {
+  if (!isCommunityEnabled()) {
+    notFound()
+  }
+
+  return (
+    <Suspense fallback={<ProfileSkeleton />}>
+      <ProfileRoute params={params} />
+    </Suspense>
+  )
+}
+
+async function ProfileRoute({ params }: PageProps) {
+  const requested = (await params).handle
+  const handle = requested.toLowerCase()
+
+  if (requested !== handle) {
+    redirect(profilePagePath(handle) as Route)
+  }
+
+  if (!isLookupableHandle(handle)) {
+    notFound()
+  }
+
+  const profile = await getPublicProfile(handle)
+
+  if (!profile) {
+    const current = await resolveHandleRedirect(handle)
+
+    if (current) {
+      redirect(profilePagePath(current) as Route)
+    }
+
+    notFound()
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-[1180px] flex-col gap-[var(--ds-space-6)] px-4 py-10 sm:px-6">
+      <div className="flex flex-col gap-[var(--ds-space-3)]">
+        <Link
+          className="w-fit underline decoration-dotted underline-offset-2"
+          href="/community"
+        >
+          <Typography as="span" tone="tertiary" variant="caption">
+            All scenes
+          </Typography>
+        </Link>
+
+        <ProfileHeader profile={profile} />
+        <ProfileOwnerActions handle={profile.handle} />
+      </div>
+
+      <Suspense fallback={<GridSkeleton />}>
+        <ProfileScenes handle={profile.handle} label={profile.displayName ?? `@${profile.handle}`} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function ProfileScenes({
+  handle,
+  label,
+}: {
+  handle: string
+  label: string
+}) {
+  const page = await getPublicProfileScenes(handle)
+
+  return (
+    <PublicSceneGrid
+      author={handle}
+      emptyLabel={`${label} has not published a scene yet.`}
+      initialNextCursor={page.nextCursor}
+      initialScenes={page.scenes}
+      sort="latest"
+    />
+  )
+}
+
+function ProfileSkeleton() {
+  return (
+    <main className="mx-auto flex w-full max-w-[1180px] flex-col gap-[var(--ds-space-6)] px-4 py-10 sm:px-6">
+      <div className="flex animate-pulse items-center gap-[var(--ds-space-3)]">
+        <div className="size-[56px] shrink-0 rounded-full bg-[var(--ds-color-surface-subtle)]" />
+        <div className="flex flex-col gap-[var(--ds-space-2)]">
+          <div className="h-7 w-[220px] rounded-[4px] bg-[var(--ds-color-surface-subtle)]" />
+          <div className="h-3 w-[160px] rounded-[4px] bg-[var(--ds-color-surface-subtle)]" />
+        </div>
+      </div>
+
+      <GridSkeleton />
+    </main>
+  )
+}
+
+const SKELETON_CARDS = [
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "g",
+  "h",
+] as const
+
+function GridSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-[var(--ds-space-4)] min-[760px]:grid-cols-4">
+      {SKELETON_CARDS.map((id) => (
+        <div className="flex animate-pulse flex-col gap-[5px]" key={id}>
+          <div className="aspect-[16/10] w-full rounded-[8px] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)]" />
+          <div className="h-4 w-3/5 rounded-[4px] bg-[var(--ds-color-surface-subtle)]" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/community/author-link.tsx
+++ b/src/components/community/author-link.tsx
@@ -1,0 +1,45 @@
+import type { Route } from "next"
+import Link from "next/link"
+import { AuthorAvatar } from "@/components/community/author-avatar"
+import { Typography } from "@/components/ui/typography"
+import { profilePagePath } from "@/lib/community/scene-links"
+import { cn } from "@/lib/cn"
+
+export function AuthorLink({
+  avatarSize = 20,
+  avatarUrl,
+  className,
+  handle,
+  name,
+  newTab = false,
+}: {
+  avatarSize?: number
+  avatarUrl: string | null
+  className?: string
+  handle: string
+  name: string | null
+  newTab?: boolean
+}) {
+  const label = name ?? `@${handle}`
+
+  return (
+    <Link
+      className={cn(
+        "inline-flex min-w-0 items-center gap-1.5 rounded-[var(--ds-radius-control)] transition-opacity duration-160 hover:opacity-80 focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2",
+        className
+      )}
+      href={profilePagePath(handle) as Route}
+      {...(newTab ? { rel: "noopener noreferrer", target: "_blank" } : {})}
+    >
+      <AuthorAvatar avatarUrl={avatarUrl} name={label} size={avatarSize} />
+      <Typography
+        as="span"
+        className="overflow-hidden text-ellipsis whitespace-nowrap"
+        tone="tertiary"
+        variant="caption"
+      >
+        {label}
+      </Typography>
+    </Link>
+  )
+}

--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { AuthMenu } from "@/components/community/auth-menu"
 import { MyScenesGrid } from "@/components/community/my-scenes-grid"
+import { ProfilePanel } from "@/components/community/profile-panel"
 import { SceneCard } from "@/components/community/scene-card"
 import { SceneDetail } from "@/components/community/scene-detail"
 import { SceneEmptyState } from "@/components/community/scene-empty-state"
@@ -85,6 +86,7 @@ export function CommunityModal({
   })
   const items = explore.scenes
   const [selected, setSelected] = useState<CommunitySceneSummary | null>(null)
+  const [selectedHandle, setSelectedHandle] = useState<string | null>(null)
   const [detail, setDetail] = useState<CommunitySceneDetail | null>(null)
   const [remixing, setRemixing] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -117,6 +119,20 @@ export function CommunityModal({
       setUpvoted(new Set())
     }
   }, [session?.user])
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedHandle(null)
+    }
+  }, [open])
+
+  const backToProfileLabel = selectedHandle ? `@${selectedHandle}` : "All scenes"
+
+  const openProfile = useCallback((handle: string) => {
+    setSelected(null)
+    setDetail(null)
+    setSelectedHandle(handle)
+  }, [])
 
   useEffect(() => {
     if (!(open && session?.user)) {
@@ -457,17 +473,25 @@ export function CommunityModal({
 
                 <div className="flex h-[48px] shrink-0 items-center justify-between gap-[var(--ds-space-3)] overflow-hidden border-b border-[var(--ds-border-divider)] px-4">
                   <div className="flex min-w-0 items-center gap-1.5">
-                    {selected ? (
+                    {selected || selectedHandle ? (
                       <Button
                         onClick={() => {
-                          setSelected(null)
-                          setDetail(null)
+                          if (selected) {
+                            setSelected(null)
+                            setDetail(null)
+
+                            return
+                          }
+
+                          setSelectedHandle(null)
                         }}
                         size="compact"
                         variant="ghost"
                       >
                         <ArrowLeftIcon height={14} width={14} />
-                        All scenes
+                        {selected && selectedHandle
+                          ? backToProfileLabel
+                          : "All scenes"}
                       </Button>
                     ) : (
                       <>
@@ -532,7 +556,7 @@ export function CommunityModal({
                     )}
                   </div>
 
-                  {selected || tab === "mine" ? null : (
+                  {selected || selectedHandle || tab !== "explore" ? null : (
                     <label className="inline-flex h-7 min-w-0 shrink-0 items-center gap-1.5 rounded-[var(--ds-radius-control)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] px-2 transition-[border-color] duration-160 ease-[var(--ease-out-cubic)] focus-within:border-[var(--ds-border-active)]">
                       <span className="text-[var(--ds-color-text-tertiary)]">
                         <MagnifyingGlassIcon height={13} width={13} />
@@ -566,6 +590,7 @@ export function CommunityModal({
                       detail={detail}
                       isOwn={ownedSlugs.has(selected.slug)}
                       onDeleted={forgetScene}
+                      onOpenAuthor={openProfile}
                       onOpenSlug={openSceneBySlug}
                       onRemix={remix}
                       onUpvoteChange={(next) =>
@@ -577,7 +602,14 @@ export function CommunityModal({
                     />
                   ) : null}
 
-                  {!selected && tab === "mine" ? (
+                  {!selected && selectedHandle ? (
+                    <ProfilePanel
+                      handle={selectedHandle}
+                      onSelect={openScene}
+                    />
+                  ) : null}
+
+                  {!(selected || selectedHandle) && tab === "mine" ? (
                     <div className="h-full overflow-y-auto p-4">
                       {mine === null && !error ? (
                         <div className="grid grid-cols-2 gap-[var(--ds-space-4)] min-[720px]:grid-cols-4">
@@ -623,7 +655,7 @@ export function CommunityModal({
                     </div>
                   ) : null}
 
-                  {!selected && tab === "explore" ? (
+                  {!(selected || selectedHandle) && tab === "explore" ? (
                     <div className="h-full overflow-y-auto p-4">
                       {items === null && !error ? (
                         <div className="grid grid-cols-2 gap-[var(--ds-space-4)] min-[720px]:grid-cols-4">

--- a/src/components/community/profile-header.tsx
+++ b/src/components/community/profile-header.tsx
@@ -1,0 +1,71 @@
+import { AuthorAvatar } from "@/components/community/author-avatar"
+import { Typography } from "@/components/ui/typography"
+import type { PublicProfile } from "@/lib/community/profiles"
+
+function joinedLabel(joinedAt: string): string | null {
+  const date = new Date(joinedAt)
+
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toLocaleDateString("en-US", { month: "long", year: "numeric" })
+}
+
+export function ProfileHeader({ profile }: { profile: PublicProfile }) {
+  const label = profile.displayName ?? `@${profile.handle}`
+  const joined = joinedLabel(profile.joinedAt)
+
+  return (
+    <header className="flex flex-col gap-[var(--ds-space-4)]">
+      <div className="flex min-w-0 items-center gap-[var(--ds-space-3)]">
+        <AuthorAvatar
+          avatarUrl={profile.avatarUrl}
+          name={label}
+          size={56}
+        />
+
+        <div className="flex min-w-0 flex-col gap-[2px]">
+          <Typography as="h1" variant="heading">
+            {label}
+          </Typography>
+          <Typography as="span" tone="tertiary" variant="monoXs">
+            @{profile.handle}
+            {joined ? ` · publishing since ${joined}` : ""}
+          </Typography>
+        </div>
+      </div>
+
+      <dl className="flex flex-wrap gap-[var(--ds-space-4)]">
+        <ProfileStat
+          label={profile.publishedCount === 1 ? "scene" : "scenes"}
+          value={profile.publishedCount}
+        />
+        <ProfileStat
+          label={profile.upvoteCount === 1 ? "upvote" : "upvotes"}
+          value={profile.upvoteCount}
+        />
+        <ProfileStat
+          label={profile.remixCount === 1 ? "remix" : "remixes"}
+          value={profile.remixCount}
+        />
+      </dl>
+    </header>
+  )
+}
+
+function ProfileStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <dt className="sr-only">{label}</dt>
+      <dd className="flex items-baseline gap-1.5">
+        <Typography as="span" className="tabular-nums" variant="label">
+          {value}
+        </Typography>
+        <Typography as="span" tone="tertiary" variant="caption">
+          {label}
+        </Typography>
+      </dd>
+    </div>
+  )
+}

--- a/src/components/community/profile-header.tsx
+++ b/src/components/community/profile-header.tsx
@@ -1,6 +1,6 @@
 import { AuthorAvatar } from "@/components/community/author-avatar"
 import { Typography } from "@/components/ui/typography"
-import type { PublicProfile } from "@/lib/community/profiles"
+import type { PublicProfileView } from "@/lib/community/profiles"
 
 function joinedLabel(joinedAt: string): string | null {
   const date = new Date(joinedAt)
@@ -12,7 +12,13 @@ function joinedLabel(joinedAt: string): string | null {
   return date.toLocaleDateString("en-US", { month: "long", year: "numeric" })
 }
 
-export function ProfileHeader({ profile }: { profile: PublicProfile }) {
+export function ProfileHeader({
+  avatarSize = 56,
+  profile,
+}: {
+  avatarSize?: number
+  profile: PublicProfileView
+}) {
   const label = profile.displayName ?? `@${profile.handle}`
   const joined = joinedLabel(profile.joinedAt)
 
@@ -22,7 +28,7 @@ export function ProfileHeader({ profile }: { profile: PublicProfile }) {
         <AuthorAvatar
           avatarUrl={profile.avatarUrl}
           name={label}
-          size={56}
+          size={avatarSize}
         />
 
         <div className="flex min-w-0 flex-col gap-[2px]">

--- a/src/components/community/profile-owner-actions.tsx
+++ b/src/components/community/profile-owner-actions.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Typography } from "@/components/ui/typography"
+import { authClient } from "@/lib/auth/client"
+
+export function ProfileOwnerActions({ handle }: { handle: string }) {
+  const { data: session } = authClient.useSession()
+  const [isOwner, setIsOwner] = useState(false)
+
+  useEffect(() => {
+    if (!session?.user) {
+      setIsOwner(false)
+
+      return
+    }
+
+    let cancelled = false
+
+    fetch("/api/community/me/profile")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { handle?: string } | null) => {
+        if (!cancelled) {
+          setIsOwner(data?.handle === handle)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setIsOwner(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [handle, session?.user])
+
+  if (!isOwner) {
+    return null
+  }
+
+  return (
+    <span className="inline-flex w-fit items-center rounded-[var(--ds-radius-control)] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)] px-2 py-[3px]">
+      <Typography as="span" tone="secondary" variant="monoXs">
+        This is you
+      </Typography>
+    </span>
+  )
+}

--- a/src/components/community/profile-panel.tsx
+++ b/src/components/community/profile-panel.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { ProfileHeader } from "@/components/community/profile-header"
+import { SceneCard } from "@/components/community/scene-card"
+import { SceneLoadMore } from "@/components/community/scene-load-more"
+import { Typography } from "@/components/ui/typography"
+import type { PublicProfileView } from "@/lib/community/profiles"
+import type { CommunitySceneSummary } from "@/lib/community/scenes"
+import { useScenePages } from "@/lib/community/use-scene-pages"
+
+const SKELETON_KEYS = ["a", "b", "c", "d"] as const
+
+export function ProfilePanel({
+  handle,
+  onSelect,
+}: {
+  handle: string
+  onSelect: (scene: CommunitySceneSummary) => void
+}) {
+  const [profile, setProfile] = useState<PublicProfileView | null>(null)
+  const [failed, setFailed] = useState(false)
+  const { error, hasMore, loadMore, loading, scenes } = useScenePages({
+    author: handle,
+    sort: "latest",
+  })
+
+  useEffect(() => {
+    let cancelled = false
+
+    setProfile(null)
+    setFailed(false)
+
+    fetch(`/api/community/profiles/${encodeURIComponent(handle)}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((data: { profile: PublicProfileView }) => {
+        if (!cancelled) {
+          setProfile(data.profile)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFailed(true)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [handle])
+
+  const label = profile?.displayName ?? `@${handle}`
+
+  return (
+    <div className="h-full overflow-y-auto p-4">
+      {profile ? (
+        <div className="mb-[var(--ds-space-5)]">
+          <ProfileHeader avatarSize={44} profile={profile} />
+        </div>
+      ) : null}
+
+      {profile || failed ? null : (
+        <div className="mb-[var(--ds-space-5)] flex animate-pulse items-center gap-[var(--ds-space-3)]">
+          <div className="size-[44px] shrink-0 rounded-full bg-[var(--ds-color-surface-subtle)]" />
+          <div className="flex flex-col gap-[var(--ds-space-2)]">
+            <div className="h-5 w-[180px] rounded-[4px] bg-[var(--ds-color-surface-subtle)]" />
+            <div className="h-[10px] w-[130px] rounded-[3px] bg-[var(--ds-color-surface-subtle)]" />
+          </div>
+        </div>
+      )}
+
+      {failed ? (
+        <Typography as="p" tone="tertiary" variant="caption">
+          Could not load that profile.
+        </Typography>
+      ) : null}
+
+      {scenes === null && !error ? (
+        <div className="grid grid-cols-2 gap-[var(--ds-space-4)] min-[720px]:grid-cols-4">
+          {SKELETON_KEYS.map((key) => (
+            <div
+              className="flex animate-pulse flex-col gap-[var(--ds-space-2)]"
+              key={key}
+            >
+              <div className="aspect-[16/10] w-full rounded-[8px] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)]" />
+              <div className="h-[10px] w-3/5 rounded-[3px] bg-[var(--ds-color-surface-subtle)]" />
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {scenes?.length === 0 ? (
+        <Typography as="p" tone="tertiary" variant="caption">
+          {label} has not published a scene yet.
+        </Typography>
+      ) : null}
+
+      {scenes && scenes.length > 0 ? (
+        <div className="grid grid-cols-2 gap-[var(--ds-space-4)] min-[720px]:grid-cols-4">
+          {scenes.map((scene) => (
+            <SceneCard key={scene.id} onSelect={onSelect} scene={scene} />
+          ))}
+        </div>
+      ) : null}
+
+      {scenes && scenes.length > 0 ? (
+        <SceneLoadMore
+          error={error}
+          hasMore={hasMore}
+          loadMore={loadMore}
+          loading={loading}
+          total={scenes.length}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/community/public-scene-card.tsx
+++ b/src/components/community/public-scene-card.tsx
@@ -1,7 +1,7 @@
 import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
-import { AuthorAvatar } from "@/components/community/author-avatar"
+import { AuthorLink } from "@/components/community/author-link"
 import { Typography } from "@/components/ui/typography"
 import type { CommunitySceneSummary } from "@/lib/community/scenes"
 
@@ -13,47 +13,39 @@ export function PublicSceneCard({
   scene: CommunitySceneSummary
 }) {
   return (
-    <Link
-      className="group flex flex-col gap-[var(--ds-space-2)] rounded-[10px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2"
-      href={`/community/${scene.slug}` as Route}
-    >
-      <div className="relative aspect-[16/10] w-full overflow-hidden rounded-[8px] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)] transition-[border-color] duration-160 ease-[var(--ease-out-cubic)] group-hover:border-[var(--ds-border-hover)]">
-        {scene.thumbnailUrl ? (
-          <Image
-            alt={scene.title}
-            className="object-cover"
-            fill
-            priority={priority}
-            sizes="(min-width: 760px) 280px, 45vw"
-            src={scene.thumbnailUrl}
-          />
-        ) : null}
-      </div>
+    <div className="group flex min-w-0 flex-col gap-[5px]">
+      <Link
+        className="flex min-w-0 flex-col gap-[var(--ds-space-2)] rounded-[10px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2"
+        href={`/community/${scene.slug}` as Route}
+      >
+        <div className="relative aspect-[16/10] w-full overflow-hidden rounded-[8px] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)] transition-[border-color] duration-160 ease-[var(--ease-out-cubic)] group-hover:border-[var(--ds-border-hover)]">
+          {scene.thumbnailUrl ? (
+            <Image
+              alt={scene.title}
+              className="object-cover"
+              fill
+              priority={priority}
+              sizes="(min-width: 760px) 280px, 45vw"
+              src={scene.thumbnailUrl}
+            />
+          ) : null}
+        </div>
 
-      <div className="flex min-w-0 flex-col gap-[5px] px-[2px]">
         <Typography
           as="span"
-          className="overflow-hidden text-ellipsis whitespace-nowrap transition-colors duration-160 group-hover:text-white"
+          className="overflow-hidden text-ellipsis whitespace-nowrap px-[2px] transition-colors duration-160 group-hover:text-white"
           variant="label"
         >
           {scene.title}
         </Typography>
+      </Link>
 
-        <span className="flex min-w-0 items-center gap-1.5">
-          <AuthorAvatar
-            avatarUrl={scene.authorAvatarUrl}
-            name={scene.authorName ?? scene.authorHandle}
-          />
-          <Typography
-            as="span"
-            className="overflow-hidden text-ellipsis whitespace-nowrap"
-            tone="tertiary"
-            variant="caption"
-          >
-            {scene.authorName ?? `@${scene.authorHandle}`}
-          </Typography>
-        </span>
-      </div>
-    </Link>
+      <AuthorLink
+        avatarUrl={scene.authorAvatarUrl}
+        className="px-[2px]"
+        handle={scene.authorHandle}
+        name={scene.authorName}
+      />
+    </div>
   )
 }

--- a/src/components/community/public-scene-grid.tsx
+++ b/src/components/community/public-scene-grid.tsx
@@ -3,19 +3,26 @@
 import { PublicSceneCard } from "@/components/community/public-scene-card"
 import { SceneLoadMore } from "@/components/community/scene-load-more"
 import { Typography } from "@/components/ui/typography"
-import type { CommunitySceneSummary } from "@/lib/community/scenes"
+import type { CommunitySceneSummary, SceneSort } from "@/lib/community/scenes"
 import { useScenePages } from "@/lib/community/use-scene-pages"
 
 export function PublicSceneGrid({
+  author,
+  emptyLabel = "No scenes published yet.",
   initialNextCursor,
   initialScenes,
+  sort = "popular",
 }: {
+  author?: string | null
+  emptyLabel?: string
   initialNextCursor: string | null
   initialScenes: CommunitySceneSummary[]
+  sort?: SceneSort
 }) {
   const { error, hasMore, loadMore, loading, scenes } = useScenePages({
+    author: author ?? null,
     initial: { nextCursor: initialNextCursor, scenes: initialScenes },
-    sort: "popular",
+    sort,
   })
 
   const shown = scenes ?? initialScenes
@@ -23,7 +30,7 @@ export function PublicSceneGrid({
   if (shown.length === 0) {
     return (
       <Typography as="p" tone="tertiary" variant="caption">
-        No scenes published yet.
+        {emptyLabel}
       </Typography>
     )
   }

--- a/src/components/community/scene-detail.tsx
+++ b/src/components/community/scene-detail.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import type { Route } from "next"
 import Image from "next/image"
-import Link from "next/link"
 import { AuthorAvatar } from "@/components/community/author-avatar"
 import { DeleteSceneControl } from "@/components/community/delete-scene-control"
 import { RemixCredit } from "@/components/community/remix-credit"
@@ -12,7 +10,6 @@ import { UpvoteButton } from "@/components/community/upvote-button"
 import { Button } from "@/components/ui/button"
 import { Typography } from "@/components/ui/typography"
 import { lineageLabel } from "@/lib/community/lineage"
-import { profilePagePath } from "@/lib/community/scene-links"
 import type {
   CommunitySceneDetail,
   CommunitySceneSummary,
@@ -35,6 +32,7 @@ export function SceneDetail({
   detail,
   isOwn,
   onDeleted,
+  onOpenAuthor,
   onOpenSlug,
   onRemix,
   onUpvoteChange,
@@ -45,6 +43,7 @@ export function SceneDetail({
   detail: CommunitySceneDetail | null
   isOwn: boolean
   onDeleted: (slug: string) => void
+  onOpenAuthor: (handle: string) => void
   onOpenSlug: (slug: string) => void
   onRemix: (scene: CommunitySceneDetail) => void
   onUpvoteChange: (next: { count: number; upvoted: boolean }) => void
@@ -58,11 +57,11 @@ export function SceneDetail({
     <div className="grid h-full grid-cols-1 gap-4 overflow-y-auto p-4 min-[760px]:grid-cols-[minmax(0,1fr)_minmax(0,1.3fr)] min-[760px]:overflow-hidden">
       <div className="flex min-w-0 flex-col gap-[var(--ds-space-3)]">
         <div className="flex min-w-0 items-center gap-[var(--ds-space-2)]">
-          <Link
-            className="inline-flex min-w-0 items-center gap-[var(--ds-space-2)] rounded-[var(--ds-radius-control)] transition-opacity duration-160 hover:opacity-80"
-            href={profilePagePath(scene.authorHandle) as Route}
-            rel="noopener noreferrer"
-            target="_blank"
+          <button
+            aria-label={`View scenes by @${scene.authorHandle}`}
+            className="inline-flex min-w-0 cursor-pointer items-center gap-[var(--ds-space-2)] rounded-[var(--ds-radius-control)] text-left transition-opacity duration-160 hover:opacity-80 focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2"
+            onClick={() => onOpenAuthor(scene.authorHandle)}
+            type="button"
           >
             <AuthorAvatar
               avatarUrl={scene.authorAvatarUrl}
@@ -81,7 +80,7 @@ export function SceneDetail({
                 {formatPublishedAt(scene.publishedAt)}
               </Typography>
             </div>
-          </Link>
+          </button>
         </div>
 
         <div className="flex flex-col gap-[var(--ds-space-2)]">

--- a/src/components/community/scene-detail.tsx
+++ b/src/components/community/scene-detail.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import type { Route } from "next"
 import Image from "next/image"
+import Link from "next/link"
 import { AuthorAvatar } from "@/components/community/author-avatar"
 import { DeleteSceneControl } from "@/components/community/delete-scene-control"
 import { RemixCredit } from "@/components/community/remix-credit"
@@ -10,6 +12,7 @@ import { UpvoteButton } from "@/components/community/upvote-button"
 import { Button } from "@/components/ui/button"
 import { Typography } from "@/components/ui/typography"
 import { lineageLabel } from "@/lib/community/lineage"
+import { profilePagePath } from "@/lib/community/scene-links"
 import type {
   CommunitySceneDetail,
   CommunitySceneSummary,
@@ -55,23 +58,30 @@ export function SceneDetail({
     <div className="grid h-full grid-cols-1 gap-4 overflow-y-auto p-4 min-[760px]:grid-cols-[minmax(0,1fr)_minmax(0,1.3fr)] min-[760px]:overflow-hidden">
       <div className="flex min-w-0 flex-col gap-[var(--ds-space-3)]">
         <div className="flex min-w-0 items-center gap-[var(--ds-space-2)]">
-          <AuthorAvatar
-            avatarUrl={scene.authorAvatarUrl}
-            name={scene.authorName ?? scene.authorHandle}
-            size={24}
-          />
-          <div className="flex min-w-0 flex-col">
-            <Typography
-              as="span"
-              className="overflow-hidden text-ellipsis whitespace-nowrap"
-              variant="label"
-            >
-              {scene.authorName ?? `@${scene.authorHandle}`}
-            </Typography>
-            <Typography as="span" tone="tertiary" variant="monoXs">
-              {formatPublishedAt(scene.publishedAt)}
-            </Typography>
-          </div>
+          <Link
+            className="inline-flex min-w-0 items-center gap-[var(--ds-space-2)] rounded-[var(--ds-radius-control)] transition-opacity duration-160 hover:opacity-80"
+            href={profilePagePath(scene.authorHandle) as Route}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <AuthorAvatar
+              avatarUrl={scene.authorAvatarUrl}
+              name={scene.authorName ?? scene.authorHandle}
+              size={24}
+            />
+            <div className="flex min-w-0 flex-col">
+              <Typography
+                as="span"
+                className="overflow-hidden text-ellipsis whitespace-nowrap"
+                variant="label"
+              >
+                {scene.authorName ?? `@${scene.authorHandle}`}
+              </Typography>
+              <Typography as="span" tone="tertiary" variant="monoXs">
+                {formatPublishedAt(scene.publishedAt)}
+              </Typography>
+            </div>
+          </Link>
         </div>
 
         <div className="flex flex-col gap-[var(--ds-space-2)]">

--- a/src/lib/community/__tests__/use-scene-pages.test.ts
+++ b/src/lib/community/__tests__/use-scene-pages.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+import { sceneListKey, sceneListUrl } from "@/lib/community/use-scene-pages"
+
+function paramsOf(url: string): URLSearchParams {
+  return new URL(url, "http://localhost").searchParams
+}
+
+describe("sceneListUrl", () => {
+  test("omits author when there is none", () => {
+    expect(paramsOf(sceneListUrl({ sort: "popular" })).has("author")).toBe(false)
+  })
+
+  test("carries the author through", () => {
+    const params = paramsOf(
+      sceneListUrl({ author: "tobi-moccagatta", sort: "latest" })
+    )
+
+    expect(params.get("author")).toBe("tobi-moccagatta")
+    expect(params.get("sort")).toBe("latest")
+  })
+
+  test("keeps author, cursor and query together", () => {
+    const params = paramsOf(
+      sceneListUrl({
+        author: "tobi-moccagatta",
+        cursor: "WyIyMDI2Il0",
+        query: "  crt  ",
+        sort: "latest",
+      })
+    )
+
+    expect(params.get("author")).toBe("tobi-moccagatta")
+    expect(params.get("cursor")).toBe("WyIyMDI2Il0")
+    expect(params.get("q")).toBe("crt")
+  })
+
+  test("a null author is treated as absent", () => {
+    expect(paramsOf(sceneListUrl({ author: null, sort: "popular" })).has("author")).toBe(
+      false
+    )
+  })
+})
+
+describe("sceneListKey", () => {
+  test("separates two authors on the same sort", () => {
+    expect(sceneListKey("latest", "", "alice")).not.toBe(
+      sceneListKey("latest", "", "bob")
+    )
+  })
+
+  test("separates an author-scoped list from the global one", () => {
+    expect(sceneListKey("latest", "", "alice")).not.toBe(
+      sceneListKey("latest", "")
+    )
+  })
+
+  test("treats a missing and a null author the same", () => {
+    expect(sceneListKey("popular", "")).toBe(sceneListKey("popular", "", null))
+  })
+
+  test("still separates sort and query", () => {
+    expect(sceneListKey("latest", "", "alice")).not.toBe(
+      sceneListKey("popular", "", "alice")
+    )
+    expect(sceneListKey("latest", "crt", "alice")).not.toBe(
+      sceneListKey("latest", "", "alice")
+    )
+  })
+})

--- a/src/lib/community/profiles.ts
+++ b/src/lib/community/profiles.ts
@@ -58,6 +58,39 @@ export async function getProfileByHandle(
   }
 }
 
+export interface SitemapProfile {
+  handle: string
+  lastPublishedAt: string | null
+}
+
+export async function listProfilesForSitemap(
+  limit = 5000
+): Promise<SitemapProfile[]> {
+  const rows = await getDatabase()
+    .select({
+      handle: profiles.handle,
+      lastPublishedAt: sql<
+        string | null
+      >`max(${scenes.publishedAt})::text`,
+    })
+    .from(profiles)
+    .innerJoin(
+      scenes,
+      and(
+        eq(scenes.authorId, profiles.userId),
+        eq(scenes.status, "published"),
+        isNull(scenes.deletedAt)
+      )
+    )
+    .groupBy(profiles.handle)
+    .limit(limit)
+
+  return rows.map((row) => ({
+    handle: row.handle,
+    lastPublishedAt: row.lastPublishedAt,
+  }))
+}
+
 export async function findCurrentHandleFor(
   handle: string
 ): Promise<string | null> {

--- a/src/lib/community/profiles.ts
+++ b/src/lib/community/profiles.ts
@@ -58,6 +58,20 @@ export async function getProfileByHandle(
   }
 }
 
+export type PublicProfileView = Omit<PublicProfile, "userId">
+
+export function toProfileView(profile: PublicProfile): PublicProfileView {
+  return {
+    avatarUrl: profile.avatarUrl,
+    displayName: profile.displayName,
+    handle: profile.handle,
+    joinedAt: profile.joinedAt,
+    publishedCount: profile.publishedCount,
+    remixCount: profile.remixCount,
+    upvoteCount: profile.upvoteCount,
+  }
+}
+
 export interface SitemapProfile {
   handle: string
   lastPublishedAt: string | null

--- a/src/lib/community/public-profiles.ts
+++ b/src/lib/community/public-profiles.ts
@@ -1,0 +1,100 @@
+import { cacheTag } from "next/cache"
+import {
+  authorTag,
+  COMMUNITY_FEED_TAG,
+  profileHandleTag,
+} from "@/lib/community/cache-tags"
+import { isCommunityEnabled } from "@/lib/community/config"
+import {
+  findCurrentHandleFor,
+  getProfileByHandle,
+  listProfilesForSitemap,
+  type PublicProfile,
+  type SitemapProfile,
+} from "@/lib/community/profiles"
+import { listPublishedScenes, type SceneListPage } from "@/lib/community/scenes"
+
+export const PROFILE_GRID_LIMIT = 24
+
+export async function getPublicProfile(
+  handle: string
+): Promise<PublicProfile | null> {
+  "use cache"
+
+  cacheTag(profileHandleTag(handle))
+
+  if (!isCommunityEnabled()) {
+    return null
+  }
+
+  try {
+    const profile = await getProfileByHandle(handle)
+
+    if (!profile) {
+      return null
+    }
+
+    cacheTag(authorTag(profile.userId))
+
+    return profile
+  } catch {
+    return null
+  }
+}
+
+export async function getPublicProfileScenes(
+  handle: string
+): Promise<SceneListPage> {
+  "use cache"
+
+  cacheTag(profileHandleTag(handle))
+  cacheTag(COMMUNITY_FEED_TAG)
+
+  if (!isCommunityEnabled()) {
+    return { nextCursor: null, scenes: [] }
+  }
+
+  try {
+    return await listPublishedScenes({
+      authorHandle: handle,
+      limit: PROFILE_GRID_LIMIT,
+      sort: "latest",
+    })
+  } catch {
+    return { nextCursor: null, scenes: [] }
+  }
+}
+
+export async function resolveHandleRedirect(
+  handle: string
+): Promise<string | null> {
+  "use cache"
+
+  cacheTag(profileHandleTag(handle))
+
+  if (!isCommunityEnabled()) {
+    return null
+  }
+
+  try {
+    return await findCurrentHandleFor(handle)
+  } catch {
+    return null
+  }
+}
+
+export async function listAllProfilesForSitemap(): Promise<SitemapProfile[]> {
+  "use cache"
+
+  cacheTag(COMMUNITY_FEED_TAG)
+
+  if (!isCommunityEnabled()) {
+    return []
+  }
+
+  try {
+    return await listProfilesForSitemap()
+  } catch {
+    return []
+  }
+}

--- a/src/lib/community/scene-links.ts
+++ b/src/lib/community/scene-links.ts
@@ -11,3 +11,7 @@ export function scenePagePath(slug: string): string {
 export function sceneSharePath(slug: string): string {
   return `${scenePagePath(slug)}?${OPEN_IN_EDITOR_PARAM}=1`
 }
+
+export function profilePagePath(handle: string): string {
+  return `/u/${handle}`
+}

--- a/src/lib/community/use-scene-pages.ts
+++ b/src/lib/community/use-scene-pages.ts
@@ -18,11 +18,16 @@ interface CachedPage {
   scenes: CommunitySceneSummary[]
 }
 
-export function sceneListKey(sort: SceneSort, query: string): string {
-  return `${sort}|${query.trim().toLowerCase()}`
+export function sceneListKey(
+  sort: SceneSort,
+  query: string,
+  author?: string | null
+): string {
+  return `${author ?? ""}|${sort}|${query.trim().toLowerCase()}`
 }
 
 export function sceneListUrl(input: {
+  author?: string | null
   cursor?: string | null
   limit?: number
   query?: string
@@ -37,6 +42,10 @@ export function sceneListUrl(input: {
 
   if (query.length > 0) {
     params.set("q", query)
+  }
+
+  if (input.author) {
+    params.set("author", input.author)
   }
 
   if (input.cursor) {
@@ -69,6 +78,7 @@ export interface ScenePagesState {
 }
 
 export function useScenePages(input: {
+  author?: string | null
   enabled?: boolean
   initial?: CachedPage | null
   query?: string
@@ -77,7 +87,8 @@ export function useScenePages(input: {
   const enabled = input.enabled ?? true
   const query = input.query ?? ""
   const { sort } = input
-  const key = sceneListKey(sort, query)
+  const author = input.author ?? null
+  const key = sceneListKey(sort, query, author)
 
   const cache = useRef(new Map<string, CachedPage>())
   const inFlight = useRef<string | null>(null)
@@ -135,7 +146,7 @@ export function useScenePages(input: {
     let request = pending.current.get(key)
 
     if (!request) {
-      request = fetchScenePage(sceneListUrl({ query, sort }))
+      request = fetchScenePage(sceneListUrl({ author, query, sort }))
         .then((page) => {
           remember(key, page)
 
@@ -164,7 +175,7 @@ export function useScenePages(input: {
     return () => {
       cancelled = true
     }
-  }, [enabled, key, query, remember, sort])
+  }, [author, enabled, key, query, remember, sort])
 
   const loadMore = useCallback(() => {
     if (!(enabled && nextCursor) || inFlight.current === nextCursor) {
@@ -175,7 +186,9 @@ export function useScenePages(input: {
     setLoading(true)
     setError(false)
 
-    void fetchScenePage(sceneListUrl({ cursor: nextCursor, query, sort }))
+    void fetchScenePage(
+      sceneListUrl({ author, cursor: nextCursor, query, sort })
+    )
       .then((page) => {
         setScenes((current) => {
           const merged = mergeScenePages(current ?? [], page.scenes)
@@ -191,7 +204,7 @@ export function useScenePages(input: {
         inFlight.current = null
         setLoading(false)
       })
-  }, [enabled, key, nextCursor, query, remember, sort])
+  }, [author, enabled, key, nextCursor, query, remember, sort])
 
   const patch = useCallback(
     (slug: string, changes: Partial<CommunitySceneSummary>) => {


### PR DESCRIPTION
Stacked on #121. **First user-visible change in the stack** — `/u/<handle>` collects an author's published scenes, and the author names that were already on every card now link to it.

### Staying cacheable is the whole design

The page never reads the session. Reading it would make the route dynamic and put a DB query behind every visit to a page linked from *every card on the site*. So "This is you" is a client component that renders `null` for everyone else, and the prerendered shell carries no author identity — verified against a build, not assumed.

Build confirms `◐ /u/[handle]` (Partial Prerender), same as `/community/[slug]`, and `/community` still `○ Static`.

### Details worth flagging

- **Published scenes only**, so the page can't expose a takedown or a soft-deleted scene.
- **A profile with nothing published still resolves** rather than 404ing — it's a real person, just not a publisher yet. Those get `robots: index: false` so empty pages aren't indexed, and they're omitted from the sitemap.
- **An `author` param that isn't a lookupable handle returns an empty page**, not the unfiltered feed. The naive version would have quietly handed back everyone's scenes to a caller that asked for one person's.
- **`GET /api/community/me/profile` moved forward from PR 5.** The plan put `profile-owner-actions.tsx` here and the route in PR 5, but ownership can't be determined from the session alone (it carries no handle), so the component would have shipped dead. PR 5 now only adds the `PATCH` and the dialog.

### The card had to be restructured

`PublicSceneCard`'s outermost element was a `<Link>` wrapping the whole card, so an author link inside it would have nested an anchor in an anchor. The scene link now covers image + title, the author link is a sibling, and `group` moved to the wrapper so hover transitions still work. Spacing preserved exactly (image→title `space-2`, title→author `5px`).

Two author sites deliberately left alone:
- `scene-card.tsx` (editor modal) — the tile is a `<button>`; a link inside a button is the same invalid-markup problem
- `remix-credit.tsx` — its call site already wraps it in a `Link`

The detail-panel author link opens in a **new tab**, because navigating the editor away would discard whatever's on the canvas.

## Verification

`bun test` 585 pass / 0 fail (+8); typecheck clean; lint 2 warnings, both pre-existing, same as base.

17 assertions against a production build on real data, all passing: handle and display name render, one card per scene the API returns, mixed-case URL redirects to lowercase, unknown / too-short / invalid-charset handles render no profile, zero-scene profile renders with an empty state, OG image returns `image/png`, sitemap lists publishers and omits non-publishers, and the prerendered shell leaks no author identity.

Separately confirmed **no nested anchors** on `/community`, a scene page, or either profile page.

### Four times the verification lied before it told the truth

Worth recording, because each is a reusable trap:

1. **`@tobi-moccagatta` was "missing" from the HTML.** React splits adjacent text expressions with comment separators, so it emits `@<!-- -->tobi-moccagatta`. Fix: strip `<!-- -->` before matching.
2. **A card looked unrendered.** `scene-9v_a1v` contains an underscore — `buildSceneSlug` appends `nanoid(6)` *after* slugification, so slugs are not `[a-z0-9-]` only.
3. **"Nested anchors" on the scene page.** My detector was matching minified JS inside `<script>` (`if(x<a.length)`, `<a?2300-a:…`). Strip scripts first.
4. **Asserting HTTP status on a PPR route is meaningless.** The shell flushes `200` before `notFound()`/`redirect()` run in the streaming boundary, so an unknown profile is a **soft 404** and a case-variant URL is not an HTTP redirect. Both are handled correctly for users and crawlers (streamed redirect, `noindex` metadata, lowercase canonical), and both match the existing behaviour of `/community/[slug]` — but the assertions had to move from status codes to rendered content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
