### PR TITLE
Let someone change the handle they were assigned

### DIFF
--- a/src/app/api/community/me/handle/route.ts
+++ b/src/app/api/community/me/handle/route.ts
@@ -1,0 +1,80 @@
+import { revalidateTag } from "next/cache"
+import { connection } from "next/server"
+import { getOptionalSession } from "@/lib/auth/server"
+import {
+  authorTag,
+  COMMUNITY_FEED_TAG,
+  profileHandleTag,
+} from "@/lib/community/cache-tags"
+import { isCommunityEnabled } from "@/lib/community/config"
+import { MAX_HANDLE_CLAIMS, renameHandle } from "@/lib/community/handle-rename"
+
+export async function PATCH(request: Request) {
+  await connection()
+
+  if (!isCommunityEnabled()) {
+    return Response.json({ error: "Not available." }, { status: 503 })
+  }
+
+  const session = await getOptionalSession()
+
+  if (!session) {
+    return Response.json({ error: "Sign in first." }, { status: 401 })
+  }
+
+  let payload: { handle?: unknown }
+
+  try {
+    payload = (await request.json()) as { handle?: unknown }
+  } catch {
+    return Response.json({ error: "Invalid request body." }, { status: 400 })
+  }
+
+  const outcome = await renameHandle({
+    next: payload.handle,
+    userId: session.user.id,
+  })
+
+  if (outcome.kind === "missing") {
+    return Response.json({ error: "Publish a scene first." }, { status: 404 })
+  }
+
+  if (outcome.kind === "invalid") {
+    return Response.json({ error: outcome.reason }, { status: 400 })
+  }
+
+  if (outcome.kind === "taken") {
+    return Response.json(
+      { error: "That handle is already taken." },
+      { status: 409 }
+    )
+  }
+
+  if (outcome.kind === "exhausted") {
+    return Response.json(
+      {
+        error: `You have used all ${MAX_HANDLE_CLAIMS - 1} handle changes on this account.`,
+      },
+      { status: 429 }
+    )
+  }
+
+  if (outcome.kind === "cooldown") {
+    return Response.json(
+      {
+        error: "You changed your handle recently. Try again later.",
+        retryAfter: outcome.retryAfter,
+      },
+      { status: 429 }
+    )
+  }
+
+  if (outcome.kind === "renamed") {
+    revalidateTag(profileHandleTag(outcome.previous), { expire: 0 })
+    revalidateTag(profileHandleTag(outcome.handle), { expire: 0 })
+    revalidateTag(authorTag(session.user.id), { expire: 0 })
+    revalidateTag(COMMUNITY_FEED_TAG, { expire: 0 })
+  }
+
+  return Response.json({ handle: outcome.handle })
+}

--- a/src/app/api/community/me/profile/route.ts
+++ b/src/app/api/community/me/profile/route.ts
@@ -1,6 +1,7 @@
 import { connection } from "next/server"
 import { getOptionalSession } from "@/lib/auth/server"
 import { isCommunityEnabled } from "@/lib/community/config"
+import { getRenameStatus } from "@/lib/community/handle-rename"
 import { ensureProfile } from "@/lib/community/profile"
 
 export async function GET() {
@@ -23,10 +24,14 @@ export async function GET() {
       name: session.user.name,
     })
 
+    const rename = await getRenameStatus(session.user.id)
+
     return Response.json({
       avatarUrl: profile.avatarUrl,
+      canRenameAt: rename.canRenameAt,
       displayName: profile.displayName,
       handle: profile.handle,
+      renamesUsed: rename.renamesUsed,
     })
   } catch {
     return Response.json(

--- a/src/components/community/auth-menu.tsx
+++ b/src/components/community/auth-menu.tsx
@@ -2,13 +2,16 @@
 
 import { Popover } from "@base-ui/react/popover"
 import { GitHubLogoIcon, PersonIcon } from "@radix-ui/react-icons"
+import type { Route } from "next"
 import Image from "next/image"
-import { useCallback, useState } from "react"
+import Link from "next/link"
+import { useCallback, useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { GlassPanel } from "@/components/ui/glass-panel"
 import { Typography } from "@/components/ui/typography"
 import { authClient } from "@/lib/auth/client"
 import { type SocialProvider, startSignIn } from "@/lib/auth/sign-in"
+import { profilePagePath } from "@/lib/community/scene-links"
 import { cn } from "@/lib/cn"
 
 function describeSignInProblem(problem: "failed" | null): string {
@@ -42,10 +45,44 @@ function GoogleGlyph() {
   )
 }
 
-export function AuthMenu() {
+export function AuthMenu({
+  newTab = false,
+  onViewProfile,
+}: {
+  newTab?: boolean
+  onViewProfile?: (handle: string) => void
+}) {
   const { data: session, isPending } = authClient.useSession()
   const [busy, setBusy] = useState<string | null>(null)
   const [problem, setProblem] = useState<"failed" | null>(null)
+  const [handle, setHandle] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!session?.user) {
+      setHandle(null)
+
+      return
+    }
+
+    let cancelled = false
+
+    fetch("/api/community/me/profile")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { handle?: string } | null) => {
+        if (!cancelled) {
+          setHandle(data?.handle ?? null)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setHandle(null)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [session?.user])
 
   const signIn = useCallback(async (provider: SocialProvider) => {
     setBusy(provider)
@@ -102,20 +139,47 @@ export function AuthMenu() {
             <GlassPanel
               className={cn(
                 "p-[var(--ds-space-2)]",
-                user ? "w-[132px]" : "w-[224px] p-[var(--ds-space-3)]"
+                user ? "w-[168px]" : "w-[224px] p-[var(--ds-space-3)]"
               )}
               variant="panel"
             >
               {user ? (
-                <Button
-                  disabled={busy !== null}
-                  fullWidth
-                  onClick={signOut}
-                  size="compact"
-                  variant="secondary"
-                >
-                  Sign out
-                </Button>
+                <div className="flex flex-col gap-1.5">
+                  {handle && onViewProfile ? (
+                    <Button
+                      fullWidth
+                      onClick={() => onViewProfile(handle)}
+                      size="compact"
+                      variant="secondary"
+                    >
+                      View profile
+                    </Button>
+                  ) : null}
+
+                  {handle && !onViewProfile ? (
+                    <Link
+                      className="inline-flex min-h-7 w-full items-center justify-center rounded-[var(--ds-radius-control)] border border-[var(--ds-border-divider)] bg-[var(--ds-color-surface-control)] px-2 transition-[background-color,border-color] duration-160 ease-[var(--ease-out-cubic)] hover:border-[var(--ds-border-hover)] hover:bg-white/8"
+                      href={profilePagePath(handle) as Route}
+                      {...(newTab
+                        ? { rel: "noopener noreferrer", target: "_blank" }
+                        : {})}
+                    >
+                      <Typography as="span" variant="label">
+                        View profile
+                      </Typography>
+                    </Link>
+                  ) : null}
+
+                  <Button
+                    disabled={busy !== null}
+                    fullWidth
+                    onClick={signOut}
+                    size="compact"
+                    variant="secondary"
+                  >
+                    Sign out
+                  </Button>
+                </div>
               ) : (
                 <div className="flex flex-col gap-[var(--ds-space-3)]">
                   <div className="flex flex-col gap-[2px]">

--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -459,7 +459,7 @@ export function CommunityModal({
                         Sign in to publish
                       </Typography>
                     )}
-                    <AuthMenu />
+                    <AuthMenu onViewProfile={openProfile} />
                     <IconButton
                       aria-label="Close community scenes"
                       className="h-7 w-7"
@@ -605,6 +605,7 @@ export function CommunityModal({
                   {!selected && selectedHandle ? (
                     <ProfilePanel
                       handle={selectedHandle}
+                      onRenamed={setSelectedHandle}
                       onSelect={openScene}
                     />
                   ) : null}

--- a/src/components/community/profile-owner-actions.tsx
+++ b/src/components/community/profile-owner-actions.tsx
@@ -1,49 +1,75 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { Typography } from "@/components/ui/typography"
+import { GearIcon } from "@radix-ui/react-icons"
+import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useState } from "react"
+import {
+  type AccountProfile,
+  UserSettingsDialog,
+} from "@/components/community/user-settings-dialog"
+import { Button } from "@/components/ui/button"
 import { authClient } from "@/lib/auth/client"
+import { profilePagePath } from "@/lib/community/scene-links"
+import type { Route } from "next"
 
-export function ProfileOwnerActions({ handle }: { handle: string }) {
+export function useAccountProfile(handle: string) {
   const { data: session } = authClient.useSession()
-  const [isOwner, setIsOwner] = useState(false)
+  const [profile, setProfile] = useState<AccountProfile | null>(null)
 
-  useEffect(() => {
+  const refresh = useCallback(() => {
     if (!session?.user) {
-      setIsOwner(false)
+      setProfile(null)
 
       return
     }
 
-    let cancelled = false
-
     fetch("/api/community/me/profile")
       .then((res) => (res.ok ? res.json() : null))
-      .then((data: { handle?: string } | null) => {
-        if (!cancelled) {
-          setIsOwner(data?.handle === handle)
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setIsOwner(false)
-        }
-      })
+      .then((data: AccountProfile | null) => setProfile(data))
+      .catch(() => setProfile(null))
+  }, [session?.user])
 
-    return () => {
-      cancelled = true
-    }
-  }, [handle, session?.user])
+  useEffect(() => {
+    refresh()
+  }, [refresh])
 
-  if (!isOwner) {
+  return {
+    isOwner: profile?.handle === handle,
+    profile,
+    refresh,
+  }
+}
+
+export function ProfileOwnerActions({ handle }: { handle: string }) {
+  const router = useRouter()
+  const { isOwner, profile } = useAccountProfile(handle)
+  const [open, setOpen] = useState(false)
+
+  if (!(isOwner && profile)) {
     return null
   }
 
   return (
-    <span className="inline-flex w-fit items-center rounded-[var(--ds-radius-control)] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)] px-2 py-[3px]">
-      <Typography as="span" tone="secondary" variant="monoXs">
-        This is you
-      </Typography>
-    </span>
+    <>
+      <Button
+        className="w-fit"
+        onClick={() => setOpen(true)}
+        size="compact"
+        variant="secondary"
+      >
+        <GearIcon height={13} width={13} />
+        User settings
+      </Button>
+
+      <UserSettingsDialog
+        onOpenChange={setOpen}
+        onRenamed={(next) => {
+          setOpen(false)
+          router.replace(profilePagePath(next) as Route)
+        }}
+        open={open}
+        profile={profile}
+      />
+    </>
   )
 }

--- a/src/components/community/profile-panel.tsx
+++ b/src/components/community/profile-panel.tsx
@@ -1,9 +1,13 @@
 "use client"
 
+import { GearIcon } from "@radix-ui/react-icons"
 import { useEffect, useState } from "react"
 import { ProfileHeader } from "@/components/community/profile-header"
+import { useAccountProfile } from "@/components/community/profile-owner-actions"
 import { SceneCard } from "@/components/community/scene-card"
 import { SceneLoadMore } from "@/components/community/scene-load-more"
+import { UserSettingsDialog } from "@/components/community/user-settings-dialog"
+import { Button } from "@/components/ui/button"
 import { Typography } from "@/components/ui/typography"
 import type { PublicProfileView } from "@/lib/community/profiles"
 import type { CommunitySceneSummary } from "@/lib/community/scenes"
@@ -13,13 +17,17 @@ const SKELETON_KEYS = ["a", "b", "c", "d"] as const
 
 export function ProfilePanel({
   handle,
+  onRenamed,
   onSelect,
 }: {
   handle: string
+  onRenamed: (handle: string) => void
   onSelect: (scene: CommunitySceneSummary) => void
 }) {
   const [profile, setProfile] = useState<PublicProfileView | null>(null)
   const [failed, setFailed] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const account = useAccountProfile(handle)
   const { error, hasMore, loadMore, loading, scenes } = useScenePages({
     author: handle,
     sort: "latest",
@@ -54,8 +62,33 @@ export function ProfilePanel({
   return (
     <div className="h-full overflow-y-auto p-4">
       {profile ? (
-        <div className="mb-[var(--ds-space-5)]">
+        <div className="mb-[var(--ds-space-5)] flex flex-col gap-[var(--ds-space-3)]">
           <ProfileHeader avatarSize={44} profile={profile} />
+
+          {account.isOwner && account.profile ? (
+            <>
+              <Button
+                className="w-fit"
+                onClick={() => setSettingsOpen(true)}
+                size="compact"
+                variant="secondary"
+              >
+                <GearIcon height={13} width={13} />
+                User settings
+              </Button>
+
+              <UserSettingsDialog
+                onOpenChange={setSettingsOpen}
+                onRenamed={(next) => {
+                  setSettingsOpen(false)
+                  account.refresh()
+                  onRenamed(next)
+                }}
+                open={settingsOpen}
+                profile={account.profile}
+              />
+            </>
+          ) : null}
         </div>
       ) : null}
 

--- a/src/components/community/user-settings-dialog.tsx
+++ b/src/components/community/user-settings-dialog.tsx
@@ -1,0 +1,282 @@
+"use client"
+
+import { Cross2Icon } from "@radix-ui/react-icons"
+import { AnimatePresence, motion, useReducedMotion } from "motion/react"
+import { useCallback, useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+import { AuthorAvatar } from "@/components/community/author-avatar"
+import { Button } from "@/components/ui/button"
+import { GlassPanel } from "@/components/ui/glass-panel"
+import { IconButton } from "@/components/ui/icon-button"
+import { numberInputControlClassName } from "@/components/ui/number-input"
+import { Typography } from "@/components/ui/typography"
+import { cn } from "@/lib/cn"
+import {
+  describeHandleInput,
+  HANDLE_MAX_LENGTH,
+} from "@/lib/community/handle"
+import { profilePagePath } from "@/lib/community/scene-links"
+
+export interface AccountProfile {
+  avatarUrl: string | null
+  canRenameAt: string | null
+  displayName: string | null
+  handle: string
+  renamesUsed: number
+}
+
+function cooldownLabel(canRenameAt: string | null): string | null {
+  if (!canRenameAt) {
+    return null
+  }
+
+  const ready = new Date(canRenameAt)
+
+  if (Number.isNaN(ready.getTime()) || ready.getTime() <= Date.now()) {
+    return null
+  }
+
+  const days = Math.ceil((ready.getTime() - Date.now()) / 86_400_000)
+
+  return `You changed your handle recently. You can change it again in ${days} ${days === 1 ? "day" : "days"}.`
+}
+
+export function UserSettingsDialog({
+  onOpenChange,
+  onRenamed,
+  open,
+  profile,
+}: {
+  onOpenChange: (open: boolean) => void
+  onRenamed: (handle: string) => void
+  open: boolean
+  profile: AccountProfile
+}) {
+  const reduceMotion = useReducedMotion() ?? false
+  const [mounted, setMounted] = useState(false)
+  const [draft, setDraft] = useState(profile.handle)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (open) {
+      setDraft(profile.handle)
+      setError(null)
+      setSaved(false)
+      setSaving(false)
+    }
+  }, [open, profile.handle])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onOpenChange(false)
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [onOpenChange, open])
+
+  const described = describeHandleInput(draft)
+  const preview = "handle" in described ? described.handle : null
+  const reason = "reason" in described ? described.reason : null
+  const cooldown = cooldownLabel(profile.canRenameAt)
+  const blocked = preview === profile.handle || Boolean(cooldown) || saving
+  const canSubmit = Boolean(preview) && !blocked
+  const hint = preview ? `shader-lab${profilePagePath(preview)}` : (reason ?? "")
+
+  const submit = useCallback(async () => {
+    if (!preview) {
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+
+    try {
+      const res = await fetch("/api/community/me/handle", {
+        body: JSON.stringify({ handle: preview }),
+        headers: { "content-type": "application/json" },
+        method: "PATCH",
+      })
+      const data = (await res.json()) as { error?: string; handle?: string }
+
+      if (!(res.ok && data.handle)) {
+        setError(data.error ?? "Could not change your handle.")
+
+        return
+      }
+
+      setSaved(true)
+      onRenamed(data.handle)
+    } catch {
+      setError("Could not change your handle.")
+    } finally {
+      setSaving(false)
+    }
+  }, [onRenamed, preview])
+
+  if (!mounted) {
+    return null
+  }
+
+  const label = profile.displayName ?? `@${profile.handle}`
+
+  return createPortal(
+    <AnimatePresence initial={false}>
+      {open ? (
+        <div className="fixed inset-0 z-110" role="presentation">
+          <motion.button
+            animate={{ opacity: 1 }}
+            aria-label="Close user settings"
+            className="absolute inset-0 w-full border-0 bg-[rgb(4_5_7_/_0.56)]"
+            exit={{ opacity: 0 }}
+            initial={{ opacity: 0 }}
+            onClick={() => onOpenChange(false)}
+            tabIndex={-1}
+            transition={{
+              duration: reduceMotion ? 0.12 : 0.18,
+              ease: "easeOut",
+            }}
+            type="button"
+          />
+
+          <div className="absolute top-[96px] left-1/2 w-[min(460px,calc(100vw-32px))] -translate-x-1/2">
+            <motion.div
+              animate={
+                reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1, y: 0 }
+              }
+              exit={
+                reduceMotion
+                  ? { opacity: 0 }
+                  : { opacity: 0, scale: 0.985, y: -10 }
+              }
+              initial={
+                reduceMotion
+                  ? { opacity: 0 }
+                  : { opacity: 0, scale: 0.985, y: 10 }
+              }
+              transition={
+                reduceMotion
+                  ? { duration: 0.12, ease: "easeOut" }
+                  : { duration: 0.22, ease: [0.22, 1, 0.36, 1] }
+              }
+            >
+              <GlassPanel
+                aria-modal="true"
+                className="overflow-hidden p-0"
+                role="dialog"
+                variant="panel"
+              >
+                <div className="flex items-center justify-between border-b border-[var(--ds-border-divider)] px-4 pt-[14px] pb-3">
+                  <Typography as="h2" className="leading-5" variant="title">
+                    User settings
+                  </Typography>
+                  <IconButton
+                    aria-label="Close user settings"
+                    className="h-7 w-7"
+                    onClick={() => onOpenChange(false)}
+                    variant="default"
+                  >
+                    <Cross2Icon height={18} width={18} />
+                  </IconButton>
+                </div>
+
+                {error ? (
+                  <div
+                    className="border-b border-[var(--ds-border-divider)] bg-[rgb(120_28_28_/_0.22)] px-4 py-2"
+                    role="alert"
+                  >
+                    <Typography as="p" variant="caption">
+                      {error}
+                    </Typography>
+                  </div>
+                ) : null}
+
+                <div className="flex flex-col gap-[var(--ds-space-4)] p-4">
+                  <div className="flex min-w-0 items-center gap-[var(--ds-space-3)]">
+                    <AuthorAvatar
+                      avatarUrl={profile.avatarUrl}
+                      name={label}
+                      size={40}
+                    />
+                    <div className="flex min-w-0 flex-col">
+                      <Typography as="span" variant="label">
+                        {label}
+                      </Typography>
+                      <Typography as="span" tone="tertiary" variant="monoXs">
+                        Name and picture come from the account you signed in with
+                      </Typography>
+                    </div>
+                  </div>
+
+                  <label className="flex flex-col gap-1.5">
+                    <Typography as="span" tone="tertiary" variant="overline">
+                      Handle
+                    </Typography>
+                    <input
+                      aria-label="Handle"
+                      autoCapitalize="none"
+                      autoComplete="off"
+                      className={cn(numberInputControlClassName, "px-2")}
+                      maxLength={HANDLE_MAX_LENGTH + 10}
+                      onChange={(event) => setDraft(event.target.value)}
+                      spellCheck={false}
+                      value={draft}
+                    />
+                  </label>
+
+                  <div className="flex flex-col gap-1">
+                    <Typography as="span" tone="tertiary" variant="monoXs">
+                      {hint}
+                    </Typography>
+                    {cooldown ? (
+                      <Typography as="span" tone="tertiary" variant="caption">
+                        {cooldown}
+                      </Typography>
+                    ) : null}
+                    {saved ? (
+                      <Typography as="span" tone="secondary" variant="caption">
+                        Saved. Links to your old handle will redirect here.
+                      </Typography>
+                    ) : null}
+                  </div>
+
+                  <div className="flex items-center justify-end gap-[var(--ds-space-2)]">
+                    <Button
+                      onClick={() => onOpenChange(false)}
+                      size="compact"
+                      variant="secondary"
+                    >
+                      Close
+                    </Button>
+                    <Button
+                      disabled={!canSubmit}
+                      onClick={submit}
+                      size="compact"
+                      variant="primary"
+                    >
+                      {saving ? "Saving…" : "Save handle"}
+                    </Button>
+                  </div>
+                </div>
+              </GlassPanel>
+            </motion.div>
+          </div>
+        </div>
+      ) : null}
+    </AnimatePresence>,
+    document.body
+  )
+}

--- a/src/components/editor/editor-topbar.tsx
+++ b/src/components/editor/editor-topbar.tsx
@@ -614,7 +614,7 @@ export function EditorTopBar() {
               >
                 <GlobeIcon height={16} width={16} />
               </IconButton>
-              <AuthMenu />
+              <AuthMenu newTab />
             </div>
           </GlassPanel>
         )}

--- a/src/lib/community/__tests__/handle-rename.test.ts
+++ b/src/lib/community/__tests__/handle-rename.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test"
+import { describeHandleInput, HANDLE_MAX_LENGTH } from "@/lib/community/handle"
+
+function handleOf(raw: unknown): string | null {
+  const result = describeHandleInput(raw)
+
+  return "handle" in result ? result.handle : null
+}
+
+function reasonOf(raw: unknown): string | null {
+  const result = describeHandleInput(raw)
+
+  return "reason" in result ? result.reason : null
+}
+
+describe("describeHandleInput", () => {
+  test("accepts a plain handle unchanged", () => {
+    expect(handleOf("tobi-moccagatta")).toBe("tobi-moccagatta")
+  })
+
+  test("normalizes what a person would actually type", () => {
+    expect(handleOf("Tobi Moccagatta")).toBe("tobi-moccagatta")
+    expect(handleOf("  spaced  ")).toBe("spaced")
+    expect(handleOf("Renée Étoile")).toBe("renee-etoile")
+    expect(handleOf("a..b__c")).toBe("a-b-c")
+  })
+
+  test("tolerates a leading at sign", () => {
+    expect(handleOf("@tobi")).toBe("tobi")
+    expect(handleOf("@@tobi")).toBe("tobi")
+  })
+
+  test("rejects empty and non-string input", () => {
+    for (const bad of ["", "   ", "@", null, undefined, 42, {}]) {
+      expect(reasonOf(bad)).toBe("Pick a handle.")
+    }
+  })
+
+  test("rejects punctuation-only input rather than returning empty", () => {
+    expect(handleOf("!!!")).toBeNull()
+    expect(reasonOf("!!!")).toContain("3 to 30")
+  })
+
+  test("rejects input that slugifies to something too short", () => {
+    expect(handleOf("ab")).toBeNull()
+    expect(handleOf("a")).toBeNull()
+    expect(handleOf("@@a")).toBeNull()
+  })
+
+  test("counts the dash a separator becomes toward the minimum length", () => {
+    expect(handleOf("a b")).toBe("a-b")
+  })
+
+  test("rejects raw input far longer than a handle", () => {
+    expect(reasonOf("z".repeat(61))).toContain("Keep it under")
+  })
+
+  test("truncates a long but legal name instead of rejecting it", () => {
+    const handle = handleOf("z".repeat(45))
+
+    expect(handle).not.toBeNull()
+    expect((handle as string).length).toBeLessThanOrEqual(HANDLE_MAX_LENGTH)
+  })
+
+  test("rejects reserved words, including the profile route prefix", () => {
+    for (const reserved of ["admin", "settings", "community", "profile", "u"]) {
+      expect(reasonOf(reserved)).toBeTruthy()
+      expect(handleOf(reserved)).toBeNull()
+    }
+  })
+
+  test("never returns a handle with edge dashes", () => {
+    for (const raw of ["---hi---", "-abc-", "  -x-  "]) {
+      const handle = handleOf(raw)
+
+      if (handle) {
+        expect(handle.startsWith("-")).toBe(false)
+        expect(handle.endsWith("-")).toBe(false)
+      }
+    }
+  })
+
+  test("is idempotent on its own output", () => {
+    for (const raw of ["Tobi Moccagatta", "@Renée Étoile", "a..b__c"]) {
+      const once = handleOf(raw)
+
+      expect(once).not.toBeNull()
+      expect(handleOf(once)).toBe(once)
+    }
+  })
+})

--- a/src/lib/community/handle-rename.ts
+++ b/src/lib/community/handle-rename.ts
@@ -1,0 +1,143 @@
+import { desc, eq } from "drizzle-orm"
+import { describeHandleInput } from "@/lib/community/handle"
+import { findProfile, isUniqueViolation } from "@/lib/community/profile"
+import { getDatabase } from "@/lib/db"
+import { handleClaims, profiles } from "@/lib/db/schema"
+
+export const HANDLE_RENAME_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000
+export const MAX_HANDLE_CLAIMS = 10
+
+export type RenameOutcome =
+  | { handle: string; kind: "renamed"; previous: string }
+  | { handle: string; kind: "unchanged" }
+  | { kind: "cooldown"; retryAfter: string }
+  | { kind: "exhausted" }
+  | { kind: "invalid"; reason: string }
+  | { kind: "missing" }
+  | { kind: "taken" }
+
+export interface RenameStatus {
+  canRenameAt: string | null
+  renamesUsed: number
+}
+
+async function readClaims(userId: string): Promise<Date[]> {
+  const rows = await getDatabase()
+    .select({ claimedAt: handleClaims.claimedAt })
+    .from(handleClaims)
+    .where(eq(handleClaims.userId, userId))
+    .orderBy(desc(handleClaims.claimedAt))
+
+  return rows.map((row) => row.claimedAt)
+}
+
+function decideAllowance(
+  claims: Date[],
+  now: Date
+): { canRenameAt: Date | null; exhausted: boolean } {
+  if (claims.length >= MAX_HANDLE_CLAIMS) {
+    return { canRenameAt: null, exhausted: true }
+  }
+
+  const latest = claims[0]
+
+  if (!latest || claims.length === 1) {
+    return { canRenameAt: null, exhausted: false }
+  }
+
+  const ready = new Date(latest.getTime() + HANDLE_RENAME_COOLDOWN_MS)
+
+  return {
+    canRenameAt: ready.getTime() > now.getTime() ? ready : null,
+    exhausted: false,
+  }
+}
+
+export async function getRenameStatus(
+  userId: string,
+  now = new Date()
+): Promise<RenameStatus> {
+  const claims = await readClaims(userId)
+  const { canRenameAt } = decideAllowance(claims, now)
+
+  return {
+    canRenameAt: canRenameAt?.toISOString() ?? null,
+    renamesUsed: Math.max(0, claims.length - 1),
+  }
+}
+
+export async function renameHandle(input: {
+  next: unknown
+  now?: Date
+  userId: string
+}): Promise<RenameOutcome> {
+  const now = input.now ?? new Date()
+  const profile = await findProfile(input.userId)
+
+  if (!profile) {
+    return { kind: "missing" }
+  }
+
+  const described = describeHandleInput(input.next)
+
+  if ("reason" in described) {
+    return { kind: "invalid", reason: described.reason }
+  }
+
+  const { handle } = described
+
+  if (handle === profile.handle) {
+    return { handle, kind: "unchanged" }
+  }
+
+  const claims = await readClaims(input.userId)
+  const { canRenameAt, exhausted } = decideAllowance(claims, now)
+
+  if (exhausted) {
+    return { kind: "exhausted" }
+  }
+
+  if (canRenameAt) {
+    return { kind: "cooldown", retryAfter: canRenameAt.toISOString() }
+  }
+
+  const db = getDatabase()
+  const owner = await db
+    .select({ userId: handleClaims.userId })
+    .from(handleClaims)
+    .where(eq(handleClaims.handle, handle))
+    .limit(1)
+
+  const heldBy = owner[0]?.userId
+
+  if (heldBy && heldBy !== input.userId) {
+    return { kind: "taken" }
+  }
+
+  try {
+    await db.batch([
+      heldBy
+        ? db
+            .update(handleClaims)
+            .set({ claimedAt: now })
+            .where(eq(handleClaims.handle, handle))
+        : db.insert(handleClaims).values({
+            claimedAt: now,
+            handle,
+            userId: input.userId,
+          }),
+      db
+        .update(profiles)
+        .set({ handle, updatedAt: now })
+        .where(eq(profiles.userId, input.userId)),
+    ])
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return { kind: "taken" }
+    }
+
+    throw error
+  }
+
+  return { handle, kind: "renamed", previous: profile.handle }
+}

--- a/src/lib/community/handle.ts
+++ b/src/lib/community/handle.ts
@@ -72,6 +72,41 @@ export function isValidHandle(handle: string): boolean {
   return isLookupableHandle(handle) && !isReservedHandle(handle)
 }
 
+const MAX_RAW_HANDLE_INPUT = 60
+
+export function describeHandleInput(
+  raw: unknown
+): { handle: string } | { reason: string } {
+  if (typeof raw !== "string") {
+    return { reason: "Pick a handle." }
+  }
+
+  const trimmed = raw.trim().replace(/^@+/, "")
+
+  if (trimmed.length === 0) {
+    return { reason: "Pick a handle." }
+  }
+
+  if (trimmed.length > MAX_RAW_HANDLE_INPUT) {
+    return { reason: `Keep it under ${HANDLE_MAX_LENGTH} characters.` }
+  }
+
+  const handle = slugifyHandle(trimmed)
+
+  if (isReservedHandle(handle)) {
+    return { reason: "That handle is reserved." }
+  }
+
+  if (!isLookupableHandle(handle)) {
+    return {
+      reason:
+        "Use 3 to 30 letters, numbers or dashes, starting and ending with a letter or number.",
+    }
+  }
+
+  return { handle }
+}
+
 function emailLocalPart(email: string | null | undefined): string {
   if (!email) {
     return ""


### PR DESCRIPTION
Stacked on #122. Handles were derived from whatever name the OAuth provider returned and were then permanent. Now there's a **User settings** button on your own profile — both the standalone page and the panel inside the editor — and the handle is the one thing in it you can edit.

Name and picture stay synced from the provider, which the dialog states out loud so the absence of a field doesn't read as an oversight.

### Changing a handle doesn't break links to the old one

`handle_claims` (from #120) records what you used to be called, so:
- the old url resolves the claim and **redirects** rather than 404ing
- four revalidations mean the profile, the author's scene pages and the grid all show the new handle **immediately** rather than whenever the cache expires
- a released handle **stays yours** — someone else asking for it is refused, while you can take it back after the cooldown
- the cooldown is 7 days from your most recent claim, so **the first change after signing up is free**

### One bundling trap avoided

`describeHandleInput` lives in `handle.ts`, not next to `renameHandle`. The dialog previews the normalized handle as you type, and `handle-rename.ts` reaches the database — importing it into a client component would have pulled the Neon driver into the browser bundle.

## Verification

`bun test` 597 pass / 0 fail (+12); typecheck clean; lint 2 warnings, both pre-existing, same as base.

**16 checks against a production build, renaming a real handle and putting it back.** Beyond the DB-level outcomes (cooldown, squatting, take-back, no-op, reserved list, unusable input), it verifies all three cached surfaces update: the profile page, `/community`, and a scene page.

### Two things worth recording

**My first version of this test poisoned the shared database.** It simulated elapsed time by passing `now: +8 days` into `renameHandle` — which then *wrote* that future timestamp into `handle_claims.claimed_at`. The cleanup only deleted the extra claims, so the surviving one kept a timestamp in the future, permanently activating the cooldown. The symptom was a later run failing its very first assertion. I wrote `.context/repair-claims.ts` to find and reset any `claimed_at > now()` back to the profile's `created_at`, confirmed the table is clean (6 claims, all matching their profiles, zero future timestamps), and rewrote the test to snapshot every claim up front and restore it exactly — including timestamps. Elapsed time is now simulated by backdating the claim in SQL, never by faking `now` on a write path. Confirmed idempotent across three consecutive runs.

**Calling the lib directly proved nothing about caching.** The first two HTTP assertions failed because `revalidateTag` lives in the route handler, not in `renameHandle`. Verifying the invalidation chain needed a temporary route that mirrors the real one (the `PATCH` needs a real OAuth session, which a script can't get). Removed before commit — the build manifest confirms only `me/handle` and `me/profile` ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
