### PR TITLE
Keep the scene you were building when the page reloads

### DIFF
--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -31,6 +31,8 @@ import type {
 } from "@/lib/community/scenes"
 import { scenePagePath } from "@/lib/community/scene-links"
 import { useScenePages } from "@/lib/community/use-scene-pages"
+import { requestAutosave } from "@/lib/editor/autosave/bus"
+import { withAutosaveSuppressed } from "@/lib/editor/autosave/suppress"
 import { acquirePreviewRenderLock } from "@/lib/editor/preview-render-lock"
 import {
   applyLabProjectFile,
@@ -295,11 +297,15 @@ export function CommunityModal({
           }
         }
 
-        applyLabProjectFile(projectFile, useAssetStore.getState().assets)
-        useRemixOriginStore.getState().setRemixOrigin({
-          slug: scene.slug,
-          title: scene.title,
+        withAutosaveSuppressed(() => {
+          applyLabProjectFile(projectFile, useAssetStore.getState().assets)
+          useRemixOriginStore.getState().setRemixOrigin({
+            slug: scene.slug,
+            title: scene.title,
+          })
         })
+
+        requestAutosave()
 
         void fetch(`/api/community/scenes/${scene.slug}/remix`, {
           body: JSON.stringify({ anonId: getAnonId() }),

--- a/src/components/editor/autosave-mount.tsx
+++ b/src/components/editor/autosave-mount.tsx
@@ -1,0 +1,269 @@
+"use client"
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { GlassPanel } from "@/components/ui/glass-panel"
+import { Typography } from "@/components/ui/typography"
+import {
+  AUTOSAVE_DEBOUNCE_MS,
+  AUTOSAVE_MAX_WAIT_MS,
+  AUTOSAVE_PILL_MS,
+} from "@/lib/editor/autosave/limits"
+import { registerAutosaveRequester } from "@/lib/editor/autosave/bus"
+import { buildAutosaveSignature } from "@/lib/editor/autosave/record"
+import { createAutosaveScheduler } from "@/lib/editor/autosave/scheduler"
+import {
+  findRestorableAutosave,
+  forgetOwnAutosaveRecord,
+  saveAutosaveRecord,
+} from "@/lib/editor/autosave/store"
+import {
+  isAutosaveSuppressed,
+  withAutosaveSuppressed,
+} from "@/lib/editor/autosave/suppress"
+import {
+  audioChanged,
+  editorChanged,
+  layersChanged,
+  releasedInteractiveEdit,
+  timelineChanged,
+} from "@/lib/editor/autosave/triggers"
+import { getDefaultProjectFile } from "@/lib/editor/default-project"
+import {
+  applyLabProjectFile,
+  buildLabProjectFile,
+} from "@/lib/editor/project-file"
+import { getRequestedSceneSlug } from "@/lib/editor/requested-scene-slug"
+import { useAssetStore } from "@/store/asset-store"
+import { useAudioStore } from "@/store/audio-store"
+import { useEditorStore } from "@/store/editor-store"
+import { useLayerStore } from "@/store/layer-store"
+import { useRemixOriginStore } from "@/store/remix-origin-store"
+import { useTimelineStore } from "@/store/timeline-store"
+
+export function AutosaveMount() {
+  const reduceMotion = useReducedMotion() ?? false
+  const [restored, setRestored] = useState(false)
+  const readyRef = useRef(false)
+  const signatureRef = useRef<string | null>(null)
+
+  const persist = useCallback(() => {
+    if (!readyRef.current) {
+      return
+    }
+
+    const projectFile = buildLabProjectFile()
+    const remixOrigin = useRemixOriginStore.getState().origin
+    const signature = buildAutosaveSignature({ projectFile, remixOrigin })
+
+    if (signature === signatureRef.current) {
+      return
+    }
+
+    signatureRef.current = signature
+    void saveAutosaveRecord({ projectFile, remixOrigin })
+  }, [])
+
+  const schedulerRef = useRef<ReturnType<
+    typeof createAutosaveScheduler
+  > | null>(null)
+
+  if (!schedulerRef.current) {
+    schedulerRef.current = createAutosaveScheduler({
+      cancel: (handle) => window.clearTimeout(handle),
+      debounceMs: AUTOSAVE_DEBOUNCE_MS,
+      isSuppressed: () =>
+        isAutosaveSuppressed() ||
+        useEditorStore.getState().interactiveEditDepth > 0,
+      maxWaitMs: AUTOSAVE_MAX_WAIT_MS,
+      now: () => Date.now(),
+      onFlush: persist,
+      schedule: (run, ms) => window.setTimeout(run, ms),
+    })
+  }
+
+  const scheduler = schedulerRef.current
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function boot() {
+      if (getRequestedSceneSlug()) {
+        readyRef.current = true
+
+        return
+      }
+
+      const candidate = await findRestorableAutosave()
+
+      if (cancelled) {
+        return
+      }
+
+      if (!candidate) {
+        readyRef.current = true
+
+        return
+      }
+
+      try {
+        withAutosaveSuppressed(() => {
+          applyLabProjectFile(
+            candidate.projectFile,
+            useAssetStore.getState().assets
+          )
+
+          if (candidate.remixOrigin) {
+            useRemixOriginStore.getState().setRemixOrigin(candidate.remixOrigin)
+          }
+        })
+
+        signatureRef.current = buildAutosaveSignature({
+          projectFile: candidate.projectFile,
+          remixOrigin: candidate.remixOrigin,
+        })
+
+        setRestored(true)
+      } catch {
+        signatureRef.current = null
+      }
+
+      readyRef.current = true
+    }
+
+    void boot()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!restored) {
+      return
+    }
+
+    const timer = window.setTimeout(() => setRestored(false), AUTOSAVE_PILL_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [restored])
+
+  useEffect(() => {
+    registerAutosaveRequester(() => scheduler.request())
+
+    return () => registerAutosaveRequester(null)
+  }, [scheduler])
+
+  useEffect(() => {
+    const request = () => scheduler.request()
+
+    const unsubscribers = [
+      useLayerStore.subscribe((state, previous) => {
+        if (layersChanged(previous, state)) {
+          request()
+        }
+      }),
+      useTimelineStore.subscribe((state, previous) => {
+        if (timelineChanged(previous, state)) {
+          request()
+        }
+      }),
+      useAudioStore.subscribe((state, previous) => {
+        if (audioChanged(previous, state)) {
+          request()
+        }
+      }),
+      useAssetStore.subscribe((state, previous) => {
+        if (state.assets !== previous.assets) {
+          request()
+        }
+      }),
+      useEditorStore.subscribe((state, previous) => {
+        if (editorChanged(previous, state)) {
+          request()
+        }
+
+        if (releasedInteractiveEdit(state, previous)) {
+          scheduler.flush()
+        }
+      }),
+      useRemixOriginStore.subscribe((state, previous) => {
+        if (state.origin !== previous.origin) {
+          request()
+        }
+      }),
+    ]
+
+    return () => {
+      for (const unsubscribe of unsubscribers) {
+        unsubscribe()
+      }
+    }
+  }, [scheduler])
+
+  useEffect(() => {
+    const flush = () => scheduler.flush()
+
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        flush()
+      }
+    }
+
+    document.addEventListener("visibilitychange", onVisibility)
+    window.addEventListener("pagehide", flush)
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility)
+      window.removeEventListener("pagehide", flush)
+      scheduler.cancel()
+    }
+  }, [scheduler])
+
+  const startFresh = useCallback(() => {
+    setRestored(false)
+    scheduler.cancel()
+
+    withAutosaveSuppressed(() => {
+      applyLabProjectFile(
+        getDefaultProjectFile(),
+        useAssetStore.getState().assets
+      )
+      useRemixOriginStore.getState().clearRemixOrigin()
+    })
+
+    signatureRef.current = null
+    void forgetOwnAutosaveRecord()
+  }, [scheduler])
+
+  return (
+    <AnimatePresence initial={false}>
+      {restored ? (
+        <motion.div
+          animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+          className="pointer-events-none fixed bottom-4 left-1/2 z-95 -translate-x-1/2"
+          exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+          initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+          transition={
+            reduceMotion
+              ? { duration: 0.12, ease: "easeOut" }
+              : { duration: 0.22, ease: [0.22, 1, 0.36, 1] }
+          }
+        >
+          <GlassPanel
+            className="pointer-events-auto flex items-center gap-[var(--ds-space-3)] px-3 py-2"
+            variant="panel"
+          >
+            <Typography as="span" tone="secondary" variant="caption">
+              Restored your last session
+            </Typography>
+            <Button onClick={startFresh} size="compact" variant="secondary">
+              Start fresh
+            </Button>
+          </GlassPanel>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  )
+}

--- a/src/components/editor/autosave-mount.tsx
+++ b/src/components/editor/autosave-mount.tsx
@@ -15,6 +15,7 @@ import { buildAutosaveSignature } from "@/lib/editor/autosave/record"
 import { createAutosaveScheduler } from "@/lib/editor/autosave/scheduler"
 import {
   findRestorableAutosave,
+  forgetAutosaveRecord,
   forgetOwnAutosaveRecord,
   saveAutosaveRecord,
 } from "@/lib/editor/autosave/store"
@@ -47,6 +48,8 @@ export function AutosaveMount() {
   const [restored, setRestored] = useState(false)
   const readyRef = useRef(false)
   const signatureRef = useRef<string | null>(null)
+  const restoredFromRef = useRef<string | null>(null)
+  const editedBeforeReadyRef = useRef(false)
 
   const persist = useCallback(() => {
     if (!readyRef.current) {
@@ -107,6 +110,15 @@ export function AutosaveMount() {
         return
       }
 
+      // The editor is usable before this lookup finishes. Anything typed in that
+      // window is real work and outranks the record on disk.
+      if (editedBeforeReadyRef.current) {
+        readyRef.current = true
+        scheduler.request()
+
+        return
+      }
+
       try {
         withAutosaveSuppressed(() => {
           applyLabProjectFile(
@@ -124,6 +136,7 @@ export function AutosaveMount() {
           remixOrigin: candidate.remixOrigin,
         })
 
+        restoredFromRef.current = candidate.sessionId
         setRestored(true)
       } catch {
         signatureRef.current = null
@@ -137,7 +150,7 @@ export function AutosaveMount() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [scheduler])
 
   useEffect(() => {
     if (!restored) {
@@ -156,7 +169,13 @@ export function AutosaveMount() {
   }, [scheduler])
 
   useEffect(() => {
-    const request = () => scheduler.request()
+    const request = () => {
+      if (!(readyRef.current || isAutosaveSuppressed())) {
+        editedBeforeReadyRef.current = true
+      }
+
+      scheduler.request()
+    }
 
     const unsubscribers = [
       useLayerStore.subscribe((state, previous) => {
@@ -234,7 +253,17 @@ export function AutosaveMount() {
     })
 
     signatureRef.current = null
+
+    const restoredFrom = restoredFromRef.current
+
+    restoredFromRef.current = null
+
     void forgetOwnAutosaveRecord()
+
+    // The discarded scene lives under the session that wrote it, not this one.
+    if (restoredFrom) {
+      void forgetAutosaveRecord(restoredFrom)
+    }
   }, [scheduler])
 
   return (

--- a/src/components/editor/editor-export-dialog.tsx
+++ b/src/components/editor/editor-export-dialog.tsx
@@ -55,6 +55,8 @@ import {
   hasImportedCustomShaderCode,
   parseLabProjectFile,
 } from "@/lib/editor/project-file"
+import { requestAutosave } from "@/lib/editor/autosave/bus"
+import { withAutosaveSuppressed } from "@/lib/editor/autosave/suppress"
 import {
   buildShaderExportConfig,
   validateShaderExportSupport,
@@ -851,10 +853,11 @@ export function EditorExportDialog({
         return
       }
 
-      const result = applyLabProjectFile(
-        projectFile,
-        useAssetStore.getState().assets
+      const result = withAutosaveSuppressed(() =>
+        applyLabProjectFile(projectFile, useAssetStore.getState().assets)
       )
+
+      requestAutosave()
 
       const relinkNotes: string[] = []
 

--- a/src/components/pages/shader-lab-page.tsx
+++ b/src/components/pages/shader-lab-page.tsx
@@ -1,4 +1,5 @@
 import { AgentBridgeMount } from "@/components/editor/agent-bridge-mount"
+import { AutosaveMount } from "@/components/editor/autosave-mount"
 import { EditorCanvasViewport } from "@/components/editor/editor-canvas-viewport"
 import { MobileEditorDock } from "@/components/editor/mobile-editor-dock"
 import { EditorShortcuts } from "@/components/editor/editor-shortcuts"
@@ -14,6 +15,7 @@ export function ShaderLabPage() {
       className="relative h-screen w-screen overflow-hidden bg-[var(--ds-color-canvas)]"
     >
       <AgentBridgeMount />
+      <AutosaveMount />
       <EditorShortcuts />
       <EditorCanvasViewport />
       <EditorTimelineOverlay />

--- a/src/lib/editor/autosave/__tests__/record.test.ts
+++ b/src/lib/editor/autosave/__tests__/record.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test"
+import { AUTOSAVE_SCHEMA_VERSION } from "@/lib/editor/autosave/limits"
+import {
+  type AutosaveRecord,
+  buildAutosaveSignature,
+  chooseAutosaveRecord,
+  planRecordPruning,
+} from "@/lib/editor/autosave/record"
+import type { LabProjectFile } from "@/lib/editor/project-file"
+
+function projectFile(overrides?: Partial<LabProjectFile>): LabProjectFile {
+  return {
+    assets: [],
+    composition: { height: 1080, width: 1920 },
+    exportedAt: "2026-08-17T00:00:00.000Z",
+    format: "shader-lab",
+    layers: [{ id: "l1", type: "gradient" }],
+    selectedLayerId: "l1",
+    timeline: { duration: 10, loop: true, tracks: [] },
+    version: 5,
+    ...overrides,
+  } as unknown as LabProjectFile
+}
+
+function record(overrides?: Partial<AutosaveRecord>): AutosaveRecord {
+  return {
+    projectFile: projectFile(),
+    remixOrigin: null,
+    savedAt: 1000,
+    schemaVersion: AUTOSAVE_SCHEMA_VERSION,
+    sessionId: "other",
+    ...overrides,
+  }
+}
+
+describe("buildAutosaveSignature", () => {
+  test("ignores exportedAt, which changes on every build", () => {
+    const a = buildAutosaveSignature({
+      projectFile: projectFile({ exportedAt: "2026-01-01T00:00:00.000Z" }),
+      remixOrigin: null,
+    })
+    const b = buildAutosaveSignature({
+      projectFile: projectFile({ exportedAt: "2026-12-31T23:59:59.000Z" }),
+      remixOrigin: null,
+    })
+
+    expect(a).toBe(b)
+  })
+
+  test("changes when the layer stack changes", () => {
+    const a = buildAutosaveSignature({
+      projectFile: projectFile(),
+      remixOrigin: null,
+    })
+    const b = buildAutosaveSignature({
+      projectFile: projectFile({
+        layers: [{ id: "l1", type: "gradient" }, { id: "l2", type: "crt" }],
+      } as Partial<LabProjectFile>),
+      remixOrigin: null,
+    })
+
+    expect(a).not.toBe(b)
+  })
+
+  test("changes when the timeline duration or loop changes", () => {
+    const base = buildAutosaveSignature({
+      projectFile: projectFile(),
+      remixOrigin: null,
+    })
+
+    expect(
+      buildAutosaveSignature({
+        projectFile: projectFile({
+          timeline: { duration: 20, loop: true, tracks: [] },
+        } as Partial<LabProjectFile>),
+        remixOrigin: null,
+      })
+    ).not.toBe(base)
+
+    expect(
+      buildAutosaveSignature({
+        projectFile: projectFile({
+          timeline: { duration: 10, loop: false, tracks: [] },
+        } as Partial<LabProjectFile>),
+        remixOrigin: null,
+      })
+    ).not.toBe(base)
+  })
+
+  test("changes when the remix origin changes", () => {
+    expect(
+      buildAutosaveSignature({ projectFile: projectFile(), remixOrigin: null })
+    ).not.toBe(
+      buildAutosaveSignature({
+        projectFile: projectFile(),
+        remixOrigin: { slug: "a-1", title: "A" },
+      })
+    )
+  })
+})
+
+describe("chooseAutosaveRecord", () => {
+  test("skips this tab's own record", () => {
+    expect(
+      chooseAutosaveRecord({
+        currentSessionId: "mine",
+        now: 2000,
+        records: [record({ sessionId: "mine" })],
+      })
+    ).toBeNull()
+  })
+
+  test("picks the newest record from another session", () => {
+    const chosen = chooseAutosaveRecord({
+      currentSessionId: "mine",
+      now: 9000,
+      records: [
+        record({ savedAt: 1000, sessionId: "a" }),
+        record({ savedAt: 8000, sessionId: "b" }),
+        record({ savedAt: 4000, sessionId: "c" }),
+      ],
+    })
+
+    expect(chosen?.sessionId).toBe("b")
+  })
+
+  test("ignores records past the ttl", () => {
+    expect(
+      chooseAutosaveRecord({
+        currentSessionId: "mine",
+        maxAgeMs: 1000,
+        now: 10_000,
+        records: [record({ savedAt: 1000, sessionId: "old" })],
+      })
+    ).toBeNull()
+  })
+
+  test("ignores a record written by a different schema version", () => {
+    expect(
+      chooseAutosaveRecord({
+        currentSessionId: "mine",
+        now: 2000,
+        records: [record({ schemaVersion: 999 })],
+      })
+    ).toBeNull()
+  })
+
+  test("ignores a record with no layers", () => {
+    expect(
+      chooseAutosaveRecord({
+        currentSessionId: "mine",
+        now: 2000,
+        records: [
+          record({
+            projectFile: projectFile({ layers: [] } as Partial<LabProjectFile>),
+          }),
+        ],
+      })
+    ).toBeNull()
+  })
+
+  test("returns null for an empty store", () => {
+    expect(
+      chooseAutosaveRecord({
+        currentSessionId: "mine",
+        now: 1,
+        records: [],
+      })
+    ).toBeNull()
+  })
+})
+
+describe("planRecordPruning", () => {
+  test("never prunes this tab's own record", () => {
+    const doomed = planRecordPruning({
+      currentSessionId: "mine",
+      now: 10_000_000_000,
+      records: [record({ savedAt: 1, sessionId: "mine" })],
+    })
+
+    expect(doomed).not.toContain("mine")
+  })
+
+  test("drops expired and wrong-version records", () => {
+    const doomed = planRecordPruning({
+      currentSessionId: "mine",
+      now: 40 * 24 * 60 * 60 * 1000,
+      records: [
+        record({ savedAt: 1, sessionId: "expired" }),
+        record({ schemaVersion: 0, sessionId: "legacy" }),
+      ],
+    })
+
+    expect(doomed).toContain("expired")
+    expect(doomed).toContain("legacy")
+  })
+
+  test("keeps the newest few and drops the surplus", () => {
+    const now = 100_000
+    const doomed = planRecordPruning({
+      currentSessionId: "mine",
+      keep: 3,
+      now,
+      records: [
+        record({ savedAt: now - 10, sessionId: "newest" }),
+        record({ savedAt: now - 20, sessionId: "second" }),
+        record({ savedAt: now - 30, sessionId: "third" }),
+        record({ savedAt: now - 40, sessionId: "fourth" }),
+      ],
+    })
+
+    expect(doomed).not.toContain("newest")
+    expect(doomed).not.toContain("second")
+    expect(doomed).toContain("third")
+    expect(doomed).toContain("fourth")
+  })
+
+  test("returns no duplicates", () => {
+    const doomed = planRecordPruning({
+      currentSessionId: "mine",
+      keep: 1,
+      now: 40 * 24 * 60 * 60 * 1000,
+      records: [record({ savedAt: 1, schemaVersion: 0, sessionId: "both" })],
+    })
+
+    expect(doomed).toEqual([...new Set(doomed)])
+  })
+})

--- a/src/lib/editor/autosave/__tests__/scheduler.test.ts
+++ b/src/lib/editor/autosave/__tests__/scheduler.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test"
+import { createAutosaveScheduler } from "@/lib/editor/autosave/scheduler"
+
+function harness(options?: { debounceMs?: number; maxWaitMs?: number }) {
+  let clock = 0
+  let flushes = 0
+  let nextHandle = 1
+  let scheduled = 0
+  const timers = new Map<number, { at: number; run: () => void }>()
+  let suppressed = false
+
+  const scheduler = createAutosaveScheduler({
+    cancel: (handle) => timers.delete(handle),
+    debounceMs: options?.debounceMs ?? 1200,
+    isSuppressed: () => suppressed,
+    maxWaitMs: options?.maxWaitMs ?? 5000,
+    now: () => clock,
+    onFlush: () => {
+      flushes += 1
+    },
+    schedule: (run, ms) => {
+      const handle = nextHandle++
+      scheduled += 1
+      timers.set(handle, { at: clock + ms, run })
+
+      return handle
+    },
+  })
+
+  function advance(ms: number) {
+    const target = clock + ms
+
+    for (;;) {
+      const due = [...timers.entries()]
+        .filter(([, timer]) => timer.at <= target)
+        .sort((a, b) => a[1].at - b[1].at)[0]
+
+      if (!due) {
+        break
+      }
+
+      const [handle, timer] = due
+      timers.delete(handle)
+      clock = timer.at
+      timer.run()
+    }
+
+    clock = target
+  }
+
+  return {
+    advance,
+    get flushes() {
+      return flushes
+    },
+    get pending() {
+      return timers.size
+    },
+    get scheduled() {
+      return scheduled
+    },
+    scheduler,
+    suppress(next: boolean) {
+      suppressed = next
+    },
+  }
+}
+
+describe("createAutosaveScheduler", () => {
+  test("fires once after the debounce settles", () => {
+    const h = harness()
+
+    h.scheduler.request()
+    h.advance(1199)
+    expect(h.flushes).toBe(0)
+
+    h.advance(1)
+    expect(h.flushes).toBe(1)
+  })
+
+  test("coalesces a burst into a single flush", () => {
+    const h = harness()
+
+    for (let i = 0; i < 20; i++) {
+      h.scheduler.request()
+      h.advance(100)
+    }
+
+    h.advance(1200)
+    expect(h.flushes).toBe(1)
+  })
+
+  test("commits at the max wait during a continuous stream", () => {
+    const h = harness({ debounceMs: 1200, maxWaitMs: 5000 })
+
+    for (let elapsed = 0; elapsed < 5000; elapsed += 100) {
+      h.scheduler.request()
+      h.advance(100)
+    }
+
+    expect(h.flushes).toBe(1)
+  })
+
+  test("a 30 second drag commits roughly every max wait, not once", () => {
+    const h = harness({ debounceMs: 1200, maxWaitMs: 5000 })
+
+    for (let elapsed = 0; elapsed < 30_000; elapsed += 100) {
+      h.scheduler.request()
+      h.advance(100)
+    }
+
+    expect(h.flushes).toBeGreaterThanOrEqual(5)
+    expect(h.flushes).toBeLessThanOrEqual(7)
+  })
+
+  test("does not flush while suppressed, then flushes after release", () => {
+    const h = harness()
+
+    h.suppress(true)
+    h.scheduler.request()
+    h.advance(10_000)
+    expect(h.flushes).toBe(0)
+
+    h.suppress(false)
+    h.advance(1200)
+    expect(h.flushes).toBe(1)
+  })
+
+  test("flush() commits immediately when something is pending", () => {
+    const h = harness()
+
+    h.scheduler.request()
+    h.scheduler.flush()
+    expect(h.flushes).toBe(1)
+  })
+
+  test("flush() does nothing when nothing is pending", () => {
+    const h = harness()
+
+    h.scheduler.flush()
+    expect(h.flushes).toBe(0)
+
+    h.scheduler.request()
+    h.advance(1200)
+    h.scheduler.flush()
+    expect(h.flushes).toBe(1)
+  })
+
+  test("cancel() drops the pending write and leaves no timer", () => {
+    const h = harness()
+
+    h.scheduler.request()
+    h.scheduler.cancel()
+    h.advance(10_000)
+
+    expect(h.flushes).toBe(0)
+    expect(h.pending).toBe(0)
+  })
+
+  test("retries on a real interval while suppressed instead of spinning", () => {
+    const h = harness({ debounceMs: 1200, maxWaitMs: 5000 })
+
+    h.suppress(true)
+    h.scheduler.request()
+    h.advance(60_000)
+
+    expect(h.flushes).toBe(0)
+    expect(h.scheduled).toBeLessThan(60)
+  })
+
+  test("never double-fires for one request", () => {
+    const h = harness()
+
+    h.scheduler.request()
+    h.advance(1200)
+    h.advance(10_000)
+
+    expect(h.flushes).toBe(1)
+  })
+})

--- a/src/lib/editor/autosave/__tests__/triggers.test.ts
+++ b/src/lib/editor/autosave/__tests__/triggers.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test"
+import {
+  audioChanged,
+  editorChanged,
+  layersChanged,
+  releasedInteractiveEdit,
+  timelineChanged,
+} from "@/lib/editor/autosave/triggers"
+
+const tracks: unknown[] = []
+const bands = {}
+const links: unknown[] = []
+const sceneConfig = {}
+const outputSize = { height: 1080, width: 1920 }
+
+function timeline(extra?: Record<string, unknown>) {
+  return { duration: 10, loop: true, tracks, ...extra }
+}
+
+describe("timelineChanged", () => {
+  test("ignores a playhead tick, which fires every frame during playback", () => {
+    const a = timeline({ currentTime: 0 })
+    const b = timeline({ currentTime: 0.0167 })
+
+    expect(timelineChanged(a, b)).toBe(false)
+  })
+
+  test("ignores play and pause", () => {
+    expect(
+      timelineChanged(timeline({ isPlaying: true }), timeline({ isPlaying: false }))
+    ).toBe(false)
+  })
+
+  test("ignores keyframe selection", () => {
+    expect(
+      timelineChanged(
+        timeline({ selectedKeyframeId: null, selectedTrackId: null }),
+        timeline({ selectedKeyframeId: "k1", selectedTrackId: "t1" })
+      )
+    ).toBe(false)
+  })
+
+  test("a whole playthrough at 60fps never triggers a save", () => {
+    let triggers = 0
+    let previous = timeline({ currentTime: 0 })
+
+    for (let frame = 1; frame <= 600; frame++) {
+      const next = timeline({ currentTime: frame / 60 })
+
+      if (timelineChanged(previous, next)) {
+        triggers += 1
+      }
+
+      previous = next
+    }
+
+    expect(triggers).toBe(0)
+  })
+
+  test("still catches duration, loop and track edits", () => {
+    expect(timelineChanged(timeline(), timeline({ duration: 20 }))).toBe(true)
+    expect(timelineChanged(timeline(), timeline({ loop: false }))).toBe(true)
+    expect(timelineChanged(timeline(), { ...timeline(), tracks: [{}] })).toBe(
+      true
+    )
+  })
+})
+
+describe("layersChanged", () => {
+  const layers: unknown[] = []
+
+  test("ignores hover, which fires on every pointer move over the sidebar", () => {
+    expect(
+      layersChanged(
+        { hoveredLayerId: null, layers, selectedLayerId: "a" } as never,
+        { hoveredLayerId: "b", layers, selectedLayerId: "a" } as never
+      )
+    ).toBe(false)
+  })
+
+  test("catches a new layer array and a selection change", () => {
+    expect(layersChanged({ layers, selectedLayerId: "a" }, { layers: [{}], selectedLayerId: "a" })).toBe(true)
+    expect(layersChanged({ layers, selectedLayerId: "a" }, { layers, selectedLayerId: "b" })).toBe(true)
+  })
+})
+
+describe("editorChanged", () => {
+  test("ignores zoom, pan and canvas size, which churn while dragging", () => {
+    expect(
+      editorChanged(
+        { canvasSize: { height: 1, width: 1 }, outputSize, panOffset: { x: 0, y: 0 }, sceneConfig, zoom: 1 } as never,
+        { canvasSize: { height: 9, width: 9 }, outputSize, panOffset: { x: 5, y: 5 }, sceneConfig, zoom: 2 } as never
+      )
+    ).toBe(false)
+  })
+
+  test("catches scene config and output size", () => {
+    expect(editorChanged({ outputSize, sceneConfig }, { outputSize, sceneConfig: {} })).toBe(true)
+    expect(
+      editorChanged({ outputSize, sceneConfig }, { outputSize: { height: 720, width: 1280 }, sceneConfig })
+    ).toBe(true)
+  })
+})
+
+describe("audioChanged", () => {
+  test("ignores analysis output that updates continuously", () => {
+    expect(
+      audioChanged(
+        { bands, envelopes: {}, links, offsetSeconds: 0, source: null, spectrogram: null, status: "idle" } as never,
+        { bands, envelopes: { bass: 1 }, links, offsetSeconds: 0, source: null, spectrogram: [1], status: "ready" } as never
+      )
+    ).toBe(false)
+  })
+
+  test("catches the parts that are saved", () => {
+    expect(audioChanged({ bands, links, offsetSeconds: 0, source: null }, { bands: {}, links, offsetSeconds: 0, source: null })).toBe(true)
+    expect(audioChanged({ bands, links, offsetSeconds: 0, source: null }, { bands, links, offsetSeconds: 2, source: null })).toBe(true)
+  })
+})
+
+describe("releasedInteractiveEdit", () => {
+  test("fires only on the transition back to zero", () => {
+    expect(
+      releasedInteractiveEdit({ interactiveEditDepth: 0 }, { interactiveEditDepth: 1 })
+    ).toBe(true)
+    expect(
+      releasedInteractiveEdit({ interactiveEditDepth: 1 }, { interactiveEditDepth: 2 })
+    ).toBe(false)
+    expect(
+      releasedInteractiveEdit({ interactiveEditDepth: 1 }, { interactiveEditDepth: 0 })
+    ).toBe(false)
+  })
+})

--- a/src/lib/editor/autosave/bus.ts
+++ b/src/lib/editor/autosave/bus.ts
@@ -1,0 +1,11 @@
+type Requester = () => void
+
+let requester: Requester | null = null
+
+export function registerAutosaveRequester(next: Requester | null): void {
+  requester = next
+}
+
+export function requestAutosave(): void {
+  requester?.()
+}

--- a/src/lib/editor/autosave/idb.ts
+++ b/src/lib/editor/autosave/idb.ts
@@ -1,0 +1,110 @@
+import {
+  AUTOSAVE_DB_NAME,
+  AUTOSAVE_DB_VERSION,
+  AUTOSAVE_SAVED_INDEX,
+  AUTOSAVE_STORE,
+} from "@/lib/editor/autosave/limits"
+
+let opening: Promise<IDBDatabase | null> | null = null
+
+export function isIndexedDbAvailable(): boolean {
+  return typeof indexedDB !== "undefined"
+}
+
+function request<T>(source: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    source.onsuccess = () => resolve(source.result)
+    source.onerror = () => reject(source.error)
+  })
+}
+
+function upgrade(db: IDBDatabase): void {
+  if (db.objectStoreNames.contains(AUTOSAVE_STORE)) {
+    return
+  }
+
+  const store = db.createObjectStore(AUTOSAVE_STORE, { keyPath: "sessionId" })
+
+  store.createIndex(AUTOSAVE_SAVED_INDEX, "savedAt")
+}
+
+export function openAutosaveDb(): Promise<IDBDatabase | null> {
+  if (!isIndexedDbAvailable()) {
+    return Promise.resolve(null)
+  }
+
+  if (opening) {
+    return opening
+  }
+
+  opening = new Promise<IDBDatabase | null>((resolve) => {
+    const open = indexedDB.open(AUTOSAVE_DB_NAME, AUTOSAVE_DB_VERSION)
+
+    open.onupgradeneeded = () => upgrade(open.result)
+    open.onsuccess = () => {
+      open.result.onversionchange = () => {
+        open.result.close()
+        opening = null
+      }
+
+      resolve(open.result)
+    }
+    open.onerror = () => resolve(null)
+    open.onblocked = () => resolve(null)
+  })
+
+  return opening
+}
+
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  run: (store: IDBObjectStore) => Promise<T>
+): Promise<T | null> {
+  const db = await openAutosaveDb()
+
+  if (!db) {
+    return null
+  }
+
+  try {
+    const transaction = db.transaction(AUTOSAVE_STORE, mode)
+
+    return await run(transaction.objectStore(AUTOSAVE_STORE))
+  } catch {
+    return null
+  }
+}
+
+export function readAll<T>(): Promise<T[] | null> {
+  return withStore("readonly", (store) =>
+    request(store.getAll() as IDBRequest<T[]>)
+  )
+}
+
+export async function writeRecord(record: unknown): Promise<boolean> {
+  const result = await withStore("readwrite", async (store) => {
+    await request(store.put(record as never))
+
+    return true
+  })
+
+  return result ?? false
+}
+
+export function deleteRecord(sessionId: string): Promise<unknown> {
+  return withStore("readwrite", (store) => request(store.delete(sessionId)))
+}
+
+export function deleteRecords(sessionIds: readonly string[]): Promise<unknown> {
+  if (sessionIds.length === 0) {
+    return Promise.resolve(null)
+  }
+
+  return withStore("readwrite", async (store) => {
+    for (const sessionId of sessionIds) {
+      await request(store.delete(sessionId))
+    }
+
+    return true
+  })
+}

--- a/src/lib/editor/autosave/limits.ts
+++ b/src/lib/editor/autosave/limits.ts
@@ -1,0 +1,15 @@
+export const AUTOSAVE_DB_NAME = "shader-lab"
+export const AUTOSAVE_DB_VERSION = 1
+
+export const AUTOSAVE_STORE = "autosave"
+export const AUTOSAVE_SAVED_INDEX = "by-saved"
+
+export const AUTOSAVE_SCHEMA_VERSION = 1
+
+export const AUTOSAVE_DEBOUNCE_MS = 1200
+export const AUTOSAVE_MAX_WAIT_MS = 5000
+
+export const AUTOSAVE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+export const AUTOSAVE_KEEP_RECORDS = 3
+
+export const AUTOSAVE_PILL_MS = 10_000

--- a/src/lib/editor/autosave/record.ts
+++ b/src/lib/editor/autosave/record.ts
@@ -1,0 +1,80 @@
+import {
+  AUTOSAVE_KEEP_RECORDS,
+  AUTOSAVE_SCHEMA_VERSION,
+  AUTOSAVE_TTL_MS,
+} from "@/lib/editor/autosave/limits"
+import type { LabProjectFile } from "@/lib/editor/project-file"
+
+export interface AutosaveRecord {
+  projectFile: LabProjectFile
+  remixOrigin: { slug: string; title: string } | null
+  savedAt: number
+  schemaVersion: number
+  sessionId: string
+}
+
+export function buildAutosaveSignature(input: {
+  projectFile: LabProjectFile
+  remixOrigin: { slug: string; title: string } | null
+}): string {
+  const { exportedAt, ...rest } = input.projectFile
+
+  void exportedAt
+
+  return JSON.stringify({ document: rest, remix: input.remixOrigin })
+}
+
+export function chooseAutosaveRecord(input: {
+  currentSessionId: string
+  maxAgeMs?: number
+  now: number
+  records: readonly AutosaveRecord[]
+}): AutosaveRecord | null {
+  const maxAgeMs = input.maxAgeMs ?? AUTOSAVE_TTL_MS
+
+  const usable = input.records
+    .filter(
+      (record) =>
+        record.sessionId !== input.currentSessionId &&
+        record.schemaVersion === AUTOSAVE_SCHEMA_VERSION &&
+        input.now - record.savedAt <= maxAgeMs &&
+        record.projectFile?.layers?.length > 0
+    )
+    .sort((a, b) => b.savedAt - a.savedAt)
+
+  return usable[0] ?? null
+}
+
+export function planRecordPruning(input: {
+  currentSessionId: string
+  keep?: number
+  now: number
+  records: readonly AutosaveRecord[]
+}): string[] {
+  const keep = input.keep ?? AUTOSAVE_KEEP_RECORDS
+  const expired: string[] = []
+  const live: AutosaveRecord[] = []
+
+  for (const record of input.records) {
+    if (record.sessionId === input.currentSessionId) {
+      continue
+    }
+
+    if (
+      input.now - record.savedAt > AUTOSAVE_TTL_MS ||
+      record.schemaVersion !== AUTOSAVE_SCHEMA_VERSION
+    ) {
+      expired.push(record.sessionId)
+      continue
+    }
+
+    live.push(record)
+  }
+
+  const surplus = live
+    .sort((a, b) => b.savedAt - a.savedAt)
+    .slice(Math.max(0, keep - 1))
+    .map((record) => record.sessionId)
+
+  return [...new Set([...expired, ...surplus])]
+}

--- a/src/lib/editor/autosave/scheduler.ts
+++ b/src/lib/editor/autosave/scheduler.ts
@@ -1,0 +1,78 @@
+export interface AutosaveScheduler {
+  cancel: () => void
+  flush: () => void
+  request: () => void
+}
+
+export function createAutosaveScheduler(input: {
+  cancel: (handle: number) => void
+  debounceMs: number
+  isSuppressed: () => boolean
+  maxWaitMs: number
+  now: () => number
+  onFlush: () => void
+  schedule: (run: () => void, ms: number) => number
+}): AutosaveScheduler {
+  let handle: number | null = null
+  let firstRequestedAt: number | null = null
+
+  function clear(): void {
+    if (handle !== null) {
+      input.cancel(handle)
+      handle = null
+    }
+  }
+
+  function commit(): void {
+    clear()
+    firstRequestedAt = null
+    input.onFlush()
+  }
+
+  function arm(retryDelay?: number): void {
+    clear()
+
+    if (firstRequestedAt === null) {
+      return
+    }
+
+    const waited = input.now() - firstRequestedAt
+    const untilMaxWait = Math.max(0, input.maxWaitMs - waited)
+    const delay = retryDelay ?? Math.min(input.debounceMs, untilMaxWait)
+
+    handle = input.schedule(() => {
+      handle = null
+
+      if (input.isSuppressed()) {
+        arm(input.debounceMs)
+
+        return
+      }
+
+      commit()
+    }, delay)
+  }
+
+  return {
+    cancel(): void {
+      clear()
+      firstRequestedAt = null
+    },
+
+    flush(): void {
+      if (firstRequestedAt === null) {
+        return
+      }
+
+      commit()
+    },
+
+    request(): void {
+      if (firstRequestedAt === null) {
+        firstRequestedAt = input.now()
+      }
+
+      arm()
+    },
+  }
+}

--- a/src/lib/editor/autosave/store.ts
+++ b/src/lib/editor/autosave/store.ts
@@ -1,0 +1,90 @@
+import { deleteRecord, deleteRecords, readAll } from "@/lib/editor/autosave/idb"
+import { AUTOSAVE_SCHEMA_VERSION } from "@/lib/editor/autosave/limits"
+import {
+  type AutosaveRecord,
+  chooseAutosaveRecord,
+  planRecordPruning,
+} from "@/lib/editor/autosave/record"
+import { writeRecord } from "@/lib/editor/autosave/idb"
+import { parseLabProjectFileValue } from "@/lib/editor/project-file"
+
+const sessionId =
+  typeof crypto === "undefined" ? "server" : crypto.randomUUID()
+
+export function autosaveSessionId(): string {
+  return sessionId
+}
+
+export async function saveAutosaveRecord(input: {
+  projectFile: AutosaveRecord["projectFile"]
+  remixOrigin: AutosaveRecord["remixOrigin"]
+}): Promise<boolean> {
+  const now = Date.now()
+  const written = await writeRecord({
+    projectFile: input.projectFile,
+    remixOrigin: input.remixOrigin,
+    savedAt: now,
+    schemaVersion: AUTOSAVE_SCHEMA_VERSION,
+    sessionId,
+  } satisfies AutosaveRecord)
+
+  if (!written) {
+    return false
+  }
+
+  const records = await readAll<AutosaveRecord>()
+
+  if (records) {
+    await deleteRecords(
+      planRecordPruning({ currentSessionId: sessionId, now, records })
+    )
+  }
+
+  return true
+}
+
+export interface RestorableAutosave {
+  projectFile: AutosaveRecord["projectFile"]
+  remixOrigin: AutosaveRecord["remixOrigin"]
+  savedAt: number
+  sessionId: string
+}
+
+export async function findRestorableAutosave(): Promise<RestorableAutosave | null> {
+  const records = await readAll<AutosaveRecord>()
+
+  if (!records || records.length === 0) {
+    return null
+  }
+
+  const candidate = chooseAutosaveRecord({
+    currentSessionId: sessionId,
+    now: Date.now(),
+    records,
+  })
+
+  if (!candidate) {
+    return null
+  }
+
+  try {
+    return {
+      projectFile: parseLabProjectFileValue(candidate.projectFile),
+      remixOrigin: candidate.remixOrigin,
+      savedAt: candidate.savedAt,
+      sessionId: candidate.sessionId,
+    }
+  } catch {
+    await deleteRecord(candidate.sessionId)
+
+    return null
+  }
+}
+
+export function forgetAutosaveRecord(id: string): Promise<unknown> {
+  return deleteRecord(id)
+}
+
+export function forgetOwnAutosaveRecord(): Promise<unknown> {
+  return deleteRecord(sessionId)
+}

--- a/src/lib/editor/autosave/suppress.ts
+++ b/src/lib/editor/autosave/suppress.ts
@@ -1,0 +1,15 @@
+let depth = 0
+
+export function isAutosaveSuppressed(): boolean {
+  return depth > 0
+}
+
+export function withAutosaveSuppressed<T>(run: () => T): T {
+  depth += 1
+
+  try {
+    return run()
+  } finally {
+    depth -= 1
+  }
+}

--- a/src/lib/editor/autosave/triggers.ts
+++ b/src/lib/editor/autosave/triggers.ts
@@ -1,0 +1,53 @@
+export interface LayerTrigger {
+  layers: unknown
+  selectedLayerId: unknown
+}
+
+export interface TimelineTrigger {
+  duration: unknown
+  loop: unknown
+  tracks: unknown
+}
+
+export interface AudioTrigger {
+  bands: unknown
+  links: unknown
+  offsetSeconds: unknown
+  source: unknown
+}
+
+export interface EditorTrigger {
+  outputSize: unknown
+  sceneConfig: unknown
+}
+
+export function layersChanged(a: LayerTrigger, b: LayerTrigger): boolean {
+  return a.layers !== b.layers || a.selectedLayerId !== b.selectedLayerId
+}
+
+export function timelineChanged(
+  a: TimelineTrigger,
+  b: TimelineTrigger
+): boolean {
+  return a.tracks !== b.tracks || a.duration !== b.duration || a.loop !== b.loop
+}
+
+export function audioChanged(a: AudioTrigger, b: AudioTrigger): boolean {
+  return (
+    a.source !== b.source ||
+    a.bands !== b.bands ||
+    a.links !== b.links ||
+    a.offsetSeconds !== b.offsetSeconds
+  )
+}
+
+export function editorChanged(a: EditorTrigger, b: EditorTrigger): boolean {
+  return a.sceneConfig !== b.sceneConfig || a.outputSize !== b.outputSize
+}
+
+export function releasedInteractiveEdit(
+  next: { interactiveEditDepth: number },
+  previous: { interactiveEditDepth: number }
+): boolean {
+  return previous.interactiveEditDepth > 0 && next.interactiveEditDepth === 0
+}


### PR DESCRIPTION
Stacked on #119. **Phase 4, part one.** A refresh no longer loses your scene.

The editor kept everything in memory and persisted nothing, so a refresh, a crash, or a misplaced ⌘W lost the work. It now writes the project file to IndexedDB ~1.2s after you stop changing it, and restores it silently on the next load with a pill offering **Start fresh** instead.

### Deliberately the local half

Works signed out — most editor sessions are — and never waits on the network. **Media is not kept yet:** imported files only exist as `blob:` urls that die with the page, so a restored scene reports its media missing exactly as re-importing a `.lab` already does. Bytes come next.

### The playhead trap

`currentTime` ticks every frame. A naive subscription would ask to save 60×/sec, and every ask `structuredClone`s the entire layer stack.

So the subscriptions compare only fields that reach the saved document, and those comparisons live in `triggers.ts` as plain functions **so a test fails if anyone widens them** — a 600-frame playthrough must produce zero triggers. Zoom, pan, hover, keyframe selection and audio analysis output are excluded for the same reason.

### Per-tab records

Keyed by a per-tab session id, not a single `"current"` key. Two open editors would otherwise overwrite each other and a refresh would restore the wrong scene. Restore picks the newest record belonging to *another* session — which is exactly what a reloaded tab is.

### `?scene=` wins

An incoming shared link is never clobbered by a stale record.

## A real bug the scheduler surfaced

Once max-wait had elapsed **while saving was suppressed**, the retry delay computed to `0`, so the timer re-armed at zero and spun. Suppression is active during gizmo drags — precisely when the main thread must stay free. It now retries on the debounce interval.

The regression test **hangs against the old code** (control: exit 124, 4 of 10 tests completed), and passes 10/10 with the fix.

## Verification

`bun test` **633 pass / 0 fail** (+36 new); typecheck clean; lint 2 warnings, both pre-existing in `properties-sidebar.tsx`.

Production build driven over CDP:

| | |
|---|---|
| clean profile, no edits | no record written |
| change timeline duration to 7 | record appears, 5 layers, `duration: 7` |
| 20s of real playback (transport confirmed running) | **zero writes** |
| hard refresh | pill appears, same layer stack restored, still exactly 1 record — pruning works |
| `?scene=<slug>` with a stale record present | pill suppressed, shared scene wins |

### Where my own verification misled me, twice

Both worth recording because the conclusions would have been wrong:

1. **"Add layer" doesn't change the document** — it opens the layer picker. My first run reported no record written and I nearly went hunting in the storage layer. The duration input also needs an `Enter` keydown to commit; `input` + `change` alone doesn't.
2. **My "zero writes during playback" assertion was measuring the wrong guard.** With `currentTime` deliberately added back to the filter, it *still* passed — because `currentTime` isn't in `LabProjectFile`, so the signature check short-circuits the write regardless. Both protections are real, but the browser test can't tell them apart. I then tried counting `setTimeout` churn and got 720/12s on *both* variants, then 0 on both after refining the buckets — unreliable either way, since the app's render loop is rAF-based. That's why the filter is now guarded by unit tests on pure predicates instead of by an in-browser measurement I couldn't make trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
