### PR TITLE
Keep imported media too, so a restored scene is not full of holes

### DIFF
--- a/src/components/editor/autosave-mount.tsx
+++ b/src/components/editor/autosave-mount.tsx
@@ -254,6 +254,15 @@ export function AutosaveMount() {
           return
         }
 
+        // Re-checked here rather than only before the read: reading the blobs is
+        // a second gap in which someone can start working.
+        if (editedBeforeReadyRef.current) {
+          readyRef.current = true
+          scheduler.request()
+
+          return
+        }
+
         withAutosaveRestore(() => {
           if (usable.length > 0) {
             const rehydrated = usable.map((record) => {

--- a/src/components/editor/autosave-mount.tsx
+++ b/src/components/editor/autosave-mount.tsx
@@ -19,8 +19,12 @@ import {
   readStoredAssets,
   toEditorAsset,
 } from "@/lib/editor/autosave/assets"
-import { registerAutosaveRequester } from "@/lib/editor/autosave/bus"
+import {
+  registerAutosaveFlusher,
+  registerAutosaveRequester,
+} from "@/lib/editor/autosave/bus"
 import { buildAutosaveSignature } from "@/lib/editor/autosave/record"
+import { consumeAutosaveResume } from "@/lib/editor/autosave/resume"
 import { createAutosaveScheduler } from "@/lib/editor/autosave/scheduler"
 import {
   findRestorableAutosave,
@@ -156,6 +160,7 @@ export function AutosaveMount() {
   const signatureRef = useRef<string | null>(null)
   const restoredFromRef = useRef<string | null>(null)
   const editedBeforeReadyRef = useRef(false)
+  const pendingWriteRef = useRef<Promise<void> | null>(null)
 
   const persist = useCallback(() => {
     if (!readyRef.current) {
@@ -171,11 +176,18 @@ export function AutosaveMount() {
     }
 
     signatureRef.current = signature
-    void saveAutosaveRecord({ projectFile, remixOrigin }).then((written) => {
-      if (written) {
-        whenIdle(collectStoredAssetGarbage)
+
+    const write = saveAutosaveRecord({ projectFile, remixOrigin }).then(
+      (written) => {
+        if (written) {
+          whenIdle(collectStoredAssetGarbage)
+        }
       }
-    })
+    )
+
+    pendingWriteRef.current = write
+
+    void write
   }, [])
 
   const schedulerRef = useRef<ReturnType<
@@ -202,6 +214,8 @@ export function AutosaveMount() {
     let cancelled = false
 
     async function boot() {
+      const resuming = consumeAutosaveResume()
+
       if (getRequestedSceneSlug()) {
         readyRef.current = true
 
@@ -269,7 +283,10 @@ export function AutosaveMount() {
         })
 
         restoredFromRef.current = candidate.sessionId
-        setRestored(true)
+
+        if (!resuming) {
+          setRestored(true)
+        }
       } catch {
         for (const url of restoredUrls) {
           URL.revokeObjectURL(url)
@@ -300,8 +317,16 @@ export function AutosaveMount() {
 
   useEffect(() => {
     registerAutosaveRequester(() => scheduler.request())
+    registerAutosaveFlusher(async () => {
+      scheduler.flush()
 
-    return () => registerAutosaveRequester(null)
+      await pendingWriteRef.current
+    })
+
+    return () => {
+      registerAutosaveRequester(null)
+      registerAutosaveFlusher(null)
+    }
   }, [scheduler])
 
   useEffect(() => {

--- a/src/components/editor/autosave-mount.tsx
+++ b/src/components/editor/autosave-mount.tsx
@@ -10,6 +10,13 @@ import {
   AUTOSAVE_MAX_WAIT_MS,
   AUTOSAVE_PILL_MS,
 } from "@/lib/editor/autosave/limits"
+import {
+  collectAssetIdsInUse,
+  forgetStoredAssets,
+  planAssetEviction,
+  readStoredAssets,
+  toEditorAsset,
+} from "@/lib/editor/autosave/assets"
 import { registerAutosaveRequester } from "@/lib/editor/autosave/bus"
 import { buildAutosaveSignature } from "@/lib/editor/autosave/record"
 import { createAutosaveScheduler } from "@/lib/editor/autosave/scheduler"
@@ -17,6 +24,7 @@ import {
   findRestorableAutosave,
   forgetAutosaveRecord,
   forgetOwnAutosaveRecord,
+  listLiveAutosaveRecords,
   saveAutosaveRecord,
 } from "@/lib/editor/autosave/store"
 import {
@@ -43,6 +51,51 @@ import { useLayerStore } from "@/store/layer-store"
 import { useRemixOriginStore } from "@/store/remix-origin-store"
 import { useTimelineStore } from "@/store/timeline-store"
 
+function whenIdle(run: () => void): void {
+  const idle = (
+    window as typeof window & {
+      requestIdleCallback?: (cb: () => void) => number
+    }
+  ).requestIdleCallback
+
+  if (idle) {
+    idle(run)
+
+    return
+  }
+
+  window.setTimeout(run, 0)
+}
+
+async function collectStoredAssetGarbage(): Promise<void> {
+  const [records, live] = await Promise.all([
+    readStoredAssets(),
+    listLiveAutosaveRecords(),
+  ])
+
+  if (!records || records.length === 0) {
+    return
+  }
+
+  const referencedIds = new Set<string>()
+
+  for (const record of live ?? []) {
+    for (const id of collectAssetIdsInUse(record.projectFile)) {
+      referencedIds.add(id)
+    }
+  }
+
+  for (const asset of useAssetStore.getState().assets) {
+    referencedIds.add(asset.id)
+  }
+
+  const plan = planAssetEviction({ records, referencedIds })
+
+  if (plan.evict.length > 0) {
+    await forgetStoredAssets(plan.evict)
+  }
+}
+
 export function AutosaveMount() {
   const reduceMotion = useReducedMotion() ?? false
   const [restored, setRestored] = useState(false)
@@ -65,7 +118,11 @@ export function AutosaveMount() {
     }
 
     signatureRef.current = signature
-    void saveAutosaveRecord({ projectFile, remixOrigin })
+    void saveAutosaveRecord({ projectFile, remixOrigin }).then((written) => {
+      if (written) {
+        whenIdle(collectStoredAssetGarbage)
+      }
+    })
   }, [])
 
   const schedulerRef = useRef<ReturnType<
@@ -119,8 +176,30 @@ export function AutosaveMount() {
         return
       }
 
+      const restoredUrls: string[] = []
+
       try {
+        const wanted = collectAssetIdsInUse(candidate.projectFile)
+        const stored = (await readStoredAssets()) ?? []
+        const usable = stored.filter((record) => wanted.has(record.id))
+
+        if (cancelled) {
+          return
+        }
+
         withAutosaveSuppressed(() => {
+          if (usable.length > 0) {
+            const rehydrated = usable.map((record) => {
+              const url = URL.createObjectURL(record.blob)
+
+              restoredUrls.push(url)
+
+              return toEditorAsset(record, url)
+            })
+
+            useAssetStore.getState().replaceAssets(rehydrated)
+          }
+
           applyLabProjectFile(
             candidate.projectFile,
             useAssetStore.getState().assets
@@ -139,6 +218,10 @@ export function AutosaveMount() {
         restoredFromRef.current = candidate.sessionId
         setRestored(true)
       } catch {
+        for (const url of restoredUrls) {
+          URL.revokeObjectURL(url)
+        }
+
         signatureRef.current = null
       }
 

--- a/src/components/editor/autosave-mount.tsx
+++ b/src/components/editor/autosave-mount.tsx
@@ -1,9 +1,11 @@
 "use client"
 
+import { Cross2Icon } from "@radix-ui/react-icons"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { GlassPanel } from "@/components/ui/glass-panel"
+import { IconButton } from "@/components/ui/icon-button"
 import { Typography } from "@/components/ui/typography"
 import {
   AUTOSAVE_DEBOUNCE_MS,
@@ -29,6 +31,7 @@ import {
 } from "@/lib/editor/autosave/store"
 import {
   isAutosaveSuppressed,
+  withAutosaveRestore,
   withAutosaveSuppressed,
 } from "@/lib/editor/autosave/suppress"
 import {
@@ -50,6 +53,55 @@ import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
 import { useRemixOriginStore } from "@/store/remix-origin-store"
 import { useTimelineStore } from "@/store/timeline-store"
+
+const PILL_GAP_PX = 10
+const PILL_FALLBACK_BOTTOM_PX = 68
+
+function useBottomOffsetAboveTimeline(active: boolean): number {
+  const [offset, setOffset] = useState(PILL_FALLBACK_BOTTOM_PX)
+
+  useEffect(() => {
+    if (!active) {
+      return
+    }
+
+    const shell = document.querySelector("[data-timeline-shell]")
+
+    const measure = () => {
+      if (!shell) {
+        setOffset(PILL_FALLBACK_BOTTOM_PX)
+
+        return
+      }
+
+      const rect = shell.getBoundingClientRect()
+
+      setOffset(
+        Math.max(
+          PILL_GAP_PX,
+          Math.round(window.innerHeight - rect.top + PILL_GAP_PX)
+        )
+      )
+    }
+
+    measure()
+
+    const observer = shell ? new ResizeObserver(measure) : null
+
+    if (shell && observer) {
+      observer.observe(shell)
+    }
+
+    window.addEventListener("resize", measure)
+
+    return () => {
+      observer?.disconnect()
+      window.removeEventListener("resize", measure)
+    }
+  }, [active])
+
+  return offset
+}
 
 function whenIdle(run: () => void): void {
   const idle = (
@@ -99,6 +151,7 @@ async function collectStoredAssetGarbage(): Promise<void> {
 export function AutosaveMount() {
   const reduceMotion = useReducedMotion() ?? false
   const [restored, setRestored] = useState(false)
+  const pillBottom = useBottomOffsetAboveTimeline(restored)
   const readyRef = useRef(false)
   const signatureRef = useRef<string | null>(null)
   const restoredFromRef = useRef<string | null>(null)
@@ -187,7 +240,7 @@ export function AutosaveMount() {
           return
         }
 
-        withAutosaveSuppressed(() => {
+        withAutosaveRestore(() => {
           if (usable.length > 0) {
             const rehydrated = usable.map((record) => {
               const url = URL.createObjectURL(record.blob)
@@ -354,9 +407,10 @@ export function AutosaveMount() {
       {restored ? (
         <motion.div
           animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
-          className="pointer-events-none fixed bottom-4 left-1/2 z-95 -translate-x-1/2"
+          className="pointer-events-none fixed left-1/2 z-95 -translate-x-1/2"
           exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
           initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+          style={{ bottom: pillBottom }}
           transition={
             reduceMotion
               ? { duration: 0.12, ease: "easeOut" }
@@ -364,7 +418,7 @@ export function AutosaveMount() {
           }
         >
           <GlassPanel
-            className="pointer-events-auto flex items-center gap-[var(--ds-space-3)] px-3 py-2"
+            className="pointer-events-auto flex items-center gap-[var(--ds-space-2)] py-1.5 pr-1.5 pl-3"
             variant="panel"
           >
             <Typography as="span" tone="secondary" variant="caption">
@@ -373,6 +427,14 @@ export function AutosaveMount() {
             <Button onClick={startFresh} size="compact" variant="secondary">
               Start fresh
             </Button>
+            <IconButton
+              aria-label="Dismiss restore notice"
+              className="h-7 w-7"
+              onClick={() => setRestored(false)}
+              variant="default"
+            >
+              <Cross2Icon height={16} width={16} />
+            </IconButton>
           </GlassPanel>
         </motion.div>
       ) : null}

--- a/src/components/editor/editor-timeline-overlay.tsx
+++ b/src/components/editor/editor-timeline-overlay.tsx
@@ -1303,6 +1303,7 @@ export function EditorTimelineOverlay() {
               : { height: shellHeight, opacity: 1, width: shellWidth, y: 0 }
           }
           className="pointer-events-auto max-h-[min(380px,calc(100vh-268px))] origin-bottom"
+          data-timeline-shell=""
           initial={false}
           transition={
             reduceMotion

--- a/src/components/editor/editor-topbar.tsx
+++ b/src/components/editor/editor-topbar.tsx
@@ -30,6 +30,7 @@ import {
   buildEditorHistorySnapshotFromState,
   getHistorySnapshotSignature,
 } from "@/lib/editor/history"
+import { isRestoringAutosave } from "@/lib/editor/autosave/suppress"
 import {
   clearRequestedSceneSlug,
   getRequestedSceneSlug,
@@ -268,7 +269,7 @@ export function EditorTopBar() {
     const unregisterShortcuts = registerHistoryShortcuts(handleUndo, handleRedo)
     const unsubscribeLayers = useLayerStore.subscribe(
       (state, previousState) => {
-        if (applyingHistoryRef.current) {
+        if (applyingHistoryRef.current || isRestoringAutosave()) {
           syncHistorySnapshotRefs()
           return
         }
@@ -302,7 +303,7 @@ export function EditorTopBar() {
 
     const unsubscribeTimeline = useTimelineStore.subscribe(
       (state, previousState) => {
-        if (applyingHistoryRef.current) {
+        if (applyingHistoryRef.current || isRestoringAutosave()) {
           syncHistorySnapshotRefs()
           return
         }
@@ -340,7 +341,7 @@ export function EditorTopBar() {
 
     const unsubscribeAudio = useAudioStore.subscribe(
       (state, previousState) => {
-        if (applyingHistoryRef.current) {
+        if (applyingHistoryRef.current || isRestoringAutosave()) {
           syncHistorySnapshotRefs()
           return
         }

--- a/src/lib/auth/sign-in.ts
+++ b/src/lib/auth/sign-in.ts
@@ -1,4 +1,6 @@
 import { authClient } from "@/lib/auth/client"
+import { flushAutosave } from "@/lib/editor/autosave/bus"
+import { markAutosaveResume } from "@/lib/editor/autosave/resume"
 
 export const AUTH_RETURN_TO_KEY = "shader-lab:auth-return-to"
 
@@ -20,7 +22,9 @@ function rememberReturnTo() {
 export async function startSignIn(
   provider: SocialProvider
 ): Promise<"failed" | null> {
+  await flushAutosave()
   rememberReturnTo()
+  markAutosaveResume()
 
   try {
     const result = await authClient.signIn.social({

--- a/src/lib/editor/autosave/__tests__/assets.test.ts
+++ b/src/lib/editor/autosave/__tests__/assets.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test"
+import {
+  collectAssetIdsInUse,
+  exceedsAssetCap,
+  planAssetEviction,
+  toEditorAsset,
+} from "@/lib/editor/autosave/assets"
+import { AUTOSAVE_MAX_ASSET_BYTES } from "@/lib/editor/autosave/limits"
+
+const MB = 1024 * 1024
+
+function stored(id: string, sizeBytes: number, createdAt: number) {
+  return { createdAt, id, sizeBytes }
+}
+
+describe("planAssetEviction", () => {
+  test("evicts nothing when every record is referenced", () => {
+    const plan = planAssetEviction({
+      records: [stored("a", MB, 1), stored("b", MB, 2)],
+      referencedIds: new Set(["a", "b"]),
+    })
+
+    expect(plan.evict).toEqual([])
+    expect(plan.keptBytes).toBe(2 * MB)
+    expect(plan.overBudget).toBe(false)
+  })
+
+  test("evicts unreferenced records oldest first", () => {
+    const plan = planAssetEviction({
+      records: [
+        stored("new", MB, 300),
+        stored("old", MB, 100),
+        stored("mid", MB, 200),
+        stored("keep", MB, 400),
+      ],
+      referencedIds: new Set(["keep"]),
+    })
+
+    expect(plan.evict).toEqual(["old", "mid", "new"])
+  })
+
+  test("never evicts a referenced record, even far over budget", () => {
+    const plan = planAssetEviction({
+      maxTotalBytes: 10 * MB,
+      records: [
+        stored("huge-1", 200 * MB, 1),
+        stored("huge-2", 200 * MB, 2),
+      ],
+      referencedIds: new Set(["huge-1", "huge-2"]),
+    })
+
+    expect(plan.evict).toEqual([])
+    expect(plan.overBudget).toBe(true)
+    expect(plan.keptBytes).toBe(400 * MB)
+  })
+
+  test("reports over budget while still reclaiming what it can", () => {
+    const plan = planAssetEviction({
+      maxTotalBytes: 10 * MB,
+      records: [stored("kept", 50 * MB, 1), stored("junk", 5 * MB, 2)],
+      referencedIds: new Set(["kept"]),
+    })
+
+    expect(plan.evict).toEqual(["junk"])
+    expect(plan.overBudget).toBe(true)
+  })
+
+  test("handles an empty store", () => {
+    const plan = planAssetEviction({
+      records: [],
+      referencedIds: new Set(),
+    })
+
+    expect(plan.evict).toEqual([])
+    expect(plan.keptBytes).toBe(0)
+    expect(plan.overBudget).toBe(false)
+  })
+})
+
+describe("exceedsAssetCap", () => {
+  test("refuses anything over the per-asset cap", () => {
+    expect(exceedsAssetCap(AUTOSAVE_MAX_ASSET_BYTES + 1)).toBe(true)
+    expect(exceedsAssetCap(100 * MB)).toBe(true)
+  })
+
+  test("accepts everything at or under it", () => {
+    expect(exceedsAssetCap(AUTOSAVE_MAX_ASSET_BYTES)).toBe(false)
+    expect(exceedsAssetCap(2 * MB)).toBe(false)
+    expect(exceedsAssetCap(0)).toBe(false)
+  })
+})
+
+describe("collectAssetIdsInUse", () => {
+  test("reads the ids a project file references", () => {
+    expect(
+      collectAssetIdsInUse({ assets: [{ id: "a" }, { id: "b" }] })
+    ).toEqual(new Set(["a", "b"]))
+  })
+
+  test("returns empty for a project file with no assets, and for null", () => {
+    expect(collectAssetIdsInUse({ assets: [] }).size).toBe(0)
+    expect(collectAssetIdsInUse(null).size).toBe(0)
+  })
+})
+
+describe("toEditorAsset", () => {
+  test("rebuilds a local asset around a fresh object url", () => {
+    const asset = toEditorAsset(
+      {
+        blob: new Blob(["x"]),
+        createdAt: 1_700_000_000_000,
+        duration: 4,
+        fileName: "clip.mp4",
+        height: 1080,
+        id: "asset-1",
+        kind: "video",
+        mimeType: "video/mp4",
+        sizeBytes: 1234,
+        width: 1920,
+      },
+      "blob:fresh"
+    )
+
+    expect(asset.url).toBe("blob:fresh")
+    expect(asset.source).toBe("local")
+    expect(asset.status).toBe("ready")
+    expect(asset.error).toBeNull()
+    expect(asset.fileName).toBe("clip.mp4")
+    expect(asset.duration).toBe(4)
+    expect(asset.width).toBe(1920)
+    expect(asset.height).toBe(1080)
+    expect(asset.mimeType).toBe("video/mp4")
+    expect(asset.sizeBytes).toBe(1234)
+    expect(asset.createdAt).toBe(new Date(1_700_000_000_000).toISOString())
+  })
+})

--- a/src/lib/editor/autosave/__tests__/assets.test.ts
+++ b/src/lib/editor/autosave/__tests__/assets.test.ts
@@ -75,6 +75,50 @@ describe("planAssetEviction", () => {
     expect(plan.keptBytes).toBe(0)
     expect(plan.overBudget).toBe(false)
   })
+
+  test("spares a blob another tab may not have recorded yet", () => {
+    const now = 1_000_000
+
+    expect(
+      planAssetEviction({
+        graceMs: 60_000,
+        now,
+        records: [stored("just-imported", MB, now - 5_000)],
+        referencedIds: new Set(),
+      }).evict
+    ).toEqual([])
+  })
+
+  test("evicts once the grace period has passed", () => {
+    const now = 1_000_000
+
+    expect(
+      planAssetEviction({
+        graceMs: 60_000,
+        now,
+        records: [stored("stale", MB, now - 120_000)],
+        referencedIds: new Set(),
+      }).evict
+    ).toEqual(["stale"])
+  })
+
+  test("grace applies only to unreferenced blobs", () => {
+    const now = 1_000_000
+
+    const plan = planAssetEviction({
+      graceMs: 60_000,
+      now,
+      records: [
+        stored("kept", MB, now - 999_999),
+        stored("fresh-junk", MB, now - 1_000),
+        stored("old-junk", MB, now - 999_999),
+      ],
+      referencedIds: new Set(["kept"]),
+    })
+
+    expect(plan.evict).toEqual(["old-junk"])
+    expect(plan.keptBytes).toBe(MB)
+  })
 })
 
 describe("exceedsAssetCap", () => {

--- a/src/lib/editor/autosave/assets.ts
+++ b/src/lib/editor/autosave/assets.ts
@@ -1,5 +1,6 @@
 import {
   ASSET_STORE,
+  AUTOSAVE_ASSET_GRACE_MS,
   AUTOSAVE_MAX_ASSET_BYTES,
   AUTOSAVE_MAX_TOTAL_BYTES,
   AUTOSAVE_QUOTA_HEADROOM,
@@ -31,14 +32,21 @@ export interface EvictionPlan {
 }
 
 export function planAssetEviction(input: {
+  graceMs?: number
   maxTotalBytes?: number
+  now?: number
   records: readonly Pick<StoredAsset, "createdAt" | "id" | "sizeBytes">[]
   referencedIds: ReadonlySet<string>
 }): EvictionPlan {
   const maxTotalBytes = input.maxTotalBytes ?? AUTOSAVE_MAX_TOTAL_BYTES
+  const graceMs = input.graceMs ?? AUTOSAVE_ASSET_GRACE_MS
+  const now = input.now ?? Date.now()
 
   const evict = input.records
-    .filter((record) => !input.referencedIds.has(record.id))
+    .filter(
+      (record) =>
+        !input.referencedIds.has(record.id) && now - record.createdAt > graceMs
+    )
     .sort((a, b) => a.createdAt - b.createdAt)
     .map((record) => record.id)
 

--- a/src/lib/editor/autosave/assets.ts
+++ b/src/lib/editor/autosave/assets.ts
@@ -1,0 +1,130 @@
+import {
+  ASSET_STORE,
+  AUTOSAVE_MAX_ASSET_BYTES,
+  AUTOSAVE_MAX_TOTAL_BYTES,
+  AUTOSAVE_QUOTA_HEADROOM,
+} from "@/lib/editor/autosave/limits"
+import {
+  deleteKeysFrom,
+  putInto,
+  readAllFrom,
+} from "@/lib/editor/autosave/idb"
+import type { AssetKind, EditorAsset } from "@/types/editor"
+
+export interface StoredAsset {
+  blob: Blob
+  createdAt: number
+  duration: number | null
+  fileName: string
+  height: number | null
+  id: string
+  kind: AssetKind
+  mimeType: string
+  sizeBytes: number
+  width: number | null
+}
+
+export interface EvictionPlan {
+  evict: string[]
+  keptBytes: number
+  overBudget: boolean
+}
+
+export function planAssetEviction(input: {
+  maxTotalBytes?: number
+  records: readonly Pick<StoredAsset, "createdAt" | "id" | "sizeBytes">[]
+  referencedIds: ReadonlySet<string>
+}): EvictionPlan {
+  const maxTotalBytes = input.maxTotalBytes ?? AUTOSAVE_MAX_TOTAL_BYTES
+
+  const evict = input.records
+    .filter((record) => !input.referencedIds.has(record.id))
+    .sort((a, b) => a.createdAt - b.createdAt)
+    .map((record) => record.id)
+
+  const keptBytes = input.records
+    .filter((record) => input.referencedIds.has(record.id))
+    .reduce((total, record) => total + record.sizeBytes, 0)
+
+  return { evict, keptBytes, overBudget: keptBytes > maxTotalBytes }
+}
+
+export function exceedsAssetCap(sizeBytes: number): boolean {
+  return sizeBytes > AUTOSAVE_MAX_ASSET_BYTES
+}
+
+async function hasRoomFor(sizeBytes: number): Promise<boolean> {
+  if (typeof navigator === "undefined" || !navigator.storage?.estimate) {
+    return true
+  }
+
+  try {
+    const { quota, usage } = await navigator.storage.estimate()
+
+    if (!quota) {
+      return true
+    }
+
+    return (usage ?? 0) + sizeBytes <= quota * AUTOSAVE_QUOTA_HEADROOM
+  } catch {
+    return true
+  }
+}
+
+export async function persistAssetBlob(
+  asset: EditorAsset,
+  blob: Blob
+): Promise<boolean> {
+  if (exceedsAssetCap(asset.sizeBytes)) {
+    return false
+  }
+
+  if (!(await hasRoomFor(asset.sizeBytes))) {
+    return false
+  }
+
+  return putInto(ASSET_STORE, {
+    blob,
+    createdAt: Date.now(),
+    duration: asset.duration,
+    fileName: asset.fileName,
+    height: asset.height,
+    id: asset.id,
+    kind: asset.kind,
+    mimeType: asset.mimeType,
+    sizeBytes: asset.sizeBytes,
+    width: asset.width,
+  } satisfies StoredAsset)
+}
+
+export function readStoredAssets(): Promise<StoredAsset[] | null> {
+  return readAllFrom<StoredAsset>(ASSET_STORE)
+}
+
+export function forgetStoredAssets(ids: readonly string[]): Promise<unknown> {
+  return deleteKeysFrom(ASSET_STORE, ids)
+}
+
+export function collectAssetIdsInUse(
+  projectFile: { assets: readonly { id: string }[] } | null
+): Set<string> {
+  return new Set(projectFile?.assets.map((asset) => asset.id) ?? [])
+}
+
+export function toEditorAsset(record: StoredAsset, url: string): EditorAsset {
+  return {
+    createdAt: new Date(record.createdAt).toISOString(),
+    duration: record.duration,
+    error: null,
+    fileName: record.fileName,
+    height: record.height,
+    id: record.id,
+    kind: record.kind,
+    mimeType: record.mimeType,
+    sizeBytes: record.sizeBytes,
+    source: "local",
+    status: "ready",
+    url,
+    width: record.width,
+  }
+}

--- a/src/lib/editor/autosave/bus.ts
+++ b/src/lib/editor/autosave/bus.ts
@@ -1,6 +1,8 @@
 type Requester = () => void
+type Flusher = () => Promise<void>
 
 let requester: Requester | null = null
+let flusher: Flusher | null = null
 
 export function registerAutosaveRequester(next: Requester | null): void {
   requester = next
@@ -8,4 +10,12 @@ export function registerAutosaveRequester(next: Requester | null): void {
 
 export function requestAutosave(): void {
   requester?.()
+}
+
+export function registerAutosaveFlusher(next: Flusher | null): void {
+  flusher = next
+}
+
+export async function flushAutosave(): Promise<void> {
+  await flusher?.()
 }

--- a/src/lib/editor/autosave/idb.ts
+++ b/src/lib/editor/autosave/idb.ts
@@ -1,4 +1,6 @@
 import {
+  ASSET_CREATED_INDEX,
+  ASSET_STORE,
   AUTOSAVE_DB_NAME,
   AUTOSAVE_DB_VERSION,
   AUTOSAVE_SAVED_INDEX,
@@ -19,13 +21,19 @@ function request<T>(source: IDBRequest<T>): Promise<T> {
 }
 
 function upgrade(db: IDBDatabase): void {
-  if (db.objectStoreNames.contains(AUTOSAVE_STORE)) {
-    return
+  if (!db.objectStoreNames.contains(AUTOSAVE_STORE)) {
+    db.createObjectStore(AUTOSAVE_STORE, { keyPath: "sessionId" }).createIndex(
+      AUTOSAVE_SAVED_INDEX,
+      "savedAt"
+    )
   }
 
-  const store = db.createObjectStore(AUTOSAVE_STORE, { keyPath: "sessionId" })
-
-  store.createIndex(AUTOSAVE_SAVED_INDEX, "savedAt")
+  if (!db.objectStoreNames.contains(ASSET_STORE)) {
+    db.createObjectStore(ASSET_STORE, { keyPath: "id" }).createIndex(
+      ASSET_CREATED_INDEX,
+      "createdAt"
+    )
+  }
 }
 
 export function openAutosaveDb(): Promise<IDBDatabase | null> {
@@ -57,6 +65,7 @@ export function openAutosaveDb(): Promise<IDBDatabase | null> {
 }
 
 async function withStore<T>(
+  name: string,
   mode: IDBTransactionMode,
   run: (store: IDBObjectStore) => Promise<T>
 ): Promise<T | null> {
@@ -67,22 +76,22 @@ async function withStore<T>(
   }
 
   try {
-    const transaction = db.transaction(AUTOSAVE_STORE, mode)
+    const transaction = db.transaction(name, mode)
 
-    return await run(transaction.objectStore(AUTOSAVE_STORE))
+    return await run(transaction.objectStore(name))
   } catch {
     return null
   }
 }
 
-export function readAll<T>(): Promise<T[] | null> {
-  return withStore("readonly", (store) =>
+export function readAllFrom<T>(name: string): Promise<T[] | null> {
+  return withStore(name, "readonly", (store) =>
     request(store.getAll() as IDBRequest<T[]>)
   )
 }
 
-export async function writeRecord(record: unknown): Promise<boolean> {
-  const result = await withStore("readwrite", async (store) => {
+export async function putInto(name: string, record: unknown): Promise<boolean> {
+  const result = await withStore(name, "readwrite", async (store) => {
     await request(store.put(record as never))
 
     return true
@@ -91,20 +100,35 @@ export async function writeRecord(record: unknown): Promise<boolean> {
   return result ?? false
 }
 
-export function deleteRecord(sessionId: string): Promise<unknown> {
-  return withStore("readwrite", (store) => request(store.delete(sessionId)))
-}
-
-export function deleteRecords(sessionIds: readonly string[]): Promise<unknown> {
-  if (sessionIds.length === 0) {
+export function deleteKeysFrom(
+  name: string,
+  keys: readonly string[]
+): Promise<unknown> {
+  if (keys.length === 0) {
     return Promise.resolve(null)
   }
 
-  return withStore("readwrite", async (store) => {
-    for (const sessionId of sessionIds) {
-      await request(store.delete(sessionId))
+  return withStore(name, "readwrite", async (store) => {
+    for (const key of keys) {
+      await request(store.delete(key))
     }
 
     return true
   })
+}
+
+export function readAll<T>(): Promise<T[] | null> {
+  return readAllFrom<T>(AUTOSAVE_STORE)
+}
+
+export function writeRecord(record: unknown): Promise<boolean> {
+  return putInto(AUTOSAVE_STORE, record)
+}
+
+export function deleteRecord(sessionId: string): Promise<unknown> {
+  return deleteKeysFrom(AUTOSAVE_STORE, [sessionId])
+}
+
+export function deleteRecords(sessionIds: readonly string[]): Promise<unknown> {
+  return deleteKeysFrom(AUTOSAVE_STORE, sessionIds)
 }

--- a/src/lib/editor/autosave/limits.ts
+++ b/src/lib/editor/autosave/limits.ts
@@ -1,8 +1,15 @@
 export const AUTOSAVE_DB_NAME = "shader-lab"
-export const AUTOSAVE_DB_VERSION = 1
+export const AUTOSAVE_DB_VERSION = 2
 
 export const AUTOSAVE_STORE = "autosave"
 export const AUTOSAVE_SAVED_INDEX = "by-saved"
+
+export const ASSET_STORE = "assets"
+export const ASSET_CREATED_INDEX = "by-created"
+
+export const AUTOSAVE_MAX_ASSET_BYTES = 32 * 1024 * 1024
+export const AUTOSAVE_MAX_TOTAL_BYTES = 256 * 1024 * 1024
+export const AUTOSAVE_QUOTA_HEADROOM = 0.8
 
 export const AUTOSAVE_SCHEMA_VERSION = 1
 

--- a/src/lib/editor/autosave/limits.ts
+++ b/src/lib/editor/autosave/limits.ts
@@ -11,6 +11,10 @@ export const AUTOSAVE_MAX_ASSET_BYTES = 32 * 1024 * 1024
 export const AUTOSAVE_MAX_TOTAL_BYTES = 256 * 1024 * 1024
 export const AUTOSAVE_QUOTA_HEADROOM = 0.8
 
+// Another tab can have imported a blob and not yet written the record that
+// references it. Collecting inside this window would delete live media.
+export const AUTOSAVE_ASSET_GRACE_MS = 5 * 60 * 1000
+
 export const AUTOSAVE_SCHEMA_VERSION = 1
 
 export const AUTOSAVE_DEBOUNCE_MS = 1200

--- a/src/lib/editor/autosave/resume.ts
+++ b/src/lib/editor/autosave/resume.ts
@@ -1,0 +1,21 @@
+const AUTOSAVE_RESUME_KEY = "shader-lab:autosave-resume"
+
+export function markAutosaveResume(): void {
+  try {
+    window.sessionStorage.setItem(AUTOSAVE_RESUME_KEY, "1")
+  } catch {
+    return
+  }
+}
+
+export function consumeAutosaveResume(): boolean {
+  try {
+    const marked = window.sessionStorage.getItem(AUTOSAVE_RESUME_KEY) === "1"
+
+    window.sessionStorage.removeItem(AUTOSAVE_RESUME_KEY)
+
+    return marked
+  } catch {
+    return false
+  }
+}

--- a/src/lib/editor/autosave/store.ts
+++ b/src/lib/editor/autosave/store.ts
@@ -88,3 +88,7 @@ export function forgetAutosaveRecord(id: string): Promise<unknown> {
 export function forgetOwnAutosaveRecord(): Promise<unknown> {
   return deleteRecord(sessionId)
 }
+
+export async function listLiveAutosaveRecords(): Promise<AutosaveRecord[]> {
+  return (await readAll<AutosaveRecord>()) ?? []
+}

--- a/src/lib/editor/autosave/suppress.ts
+++ b/src/lib/editor/autosave/suppress.ts
@@ -1,4 +1,5 @@
 let depth = 0
+let restoreDepth = 0
 
 export function isAutosaveSuppressed(): boolean {
   return depth > 0
@@ -11,5 +12,19 @@ export function withAutosaveSuppressed<T>(run: () => T): T {
     return run()
   } finally {
     depth -= 1
+  }
+}
+
+export function isRestoringAutosave(): boolean {
+  return restoreDepth > 0
+}
+
+export function withAutosaveRestore<T>(run: () => T): T {
+  restoreDepth += 1
+
+  try {
+    return withAutosaveSuppressed(run)
+  } finally {
+    restoreDepth -= 1
   }
 }

--- a/src/store/asset-store.ts
+++ b/src/store/asset-store.ts
@@ -212,11 +212,14 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       }
     }
 
+    // Durable before the asset is handed back, so an autosave can never record a
+    // reference to bytes that are still in flight. A refusal is fine and still
+    // yields a usable asset for this session.
+    await persistAssetBlob(asset, file)
+
     set((state) => ({
       assets: [...state.assets, asset],
     }))
-
-    void persistAssetBlob(asset, file)
 
     return asset
   },

--- a/src/store/asset-store.ts
+++ b/src/store/asset-store.ts
@@ -1,4 +1,8 @@
 import { create } from "zustand"
+import {
+  forgetStoredAssets,
+  persistAssetBlob,
+} from "@/lib/editor/autosave/assets"
 import { inferFileAssetKind, isAudioFileName } from "@/lib/editor/media-file"
 import type { AssetKind, EditorAsset } from "@/types/editor"
 
@@ -212,6 +216,8 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       assets: [...state.assets, asset],
     }))
 
+    void persistAssetBlob(asset, file)
+
     return asset
   },
 
@@ -221,6 +227,8 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
     if (asset?.source === "local") {
       URL.revokeObjectURL(asset.url)
     }
+
+    void forgetStoredAssets([id])
 
     set((state) => ({
       assets: state.assets.filter((entry) => entry.id !== id),


### PR DESCRIPTION
Stacked on #125. **Phase 4, part two.** Media survives a refresh now, not just the document.

Autosave kept the scene but not the bytes, so reopening a scene with an image or video came back reporting its media missing. Bytes are now written to IndexedDB **at import** — the only moment they exist. `loadAsset` turns the `File` into an object url and then drops the `File`, and that url dies with the page.

### Choices worth defending

- **Blobs, not ArrayBuffers.** Every engine backs a stored Blob with a file on disk and reads it back lazily; a buffer doubles peak memory on both write and read.
- **The asset record carries its own metadata** rather than pointing at the project file, because `toAssetReference` deliberately emits only `{fileName, id, kind}` for local assets. Widening that is shared with publish and risks a `blob:` url reaching `validateProjectFilePayload`, so the duplication is the safer side of the trade.
- **Restore order is load-bearing.** Assets into the store *first*, then apply the project file. `applyLabProjectFile` appends remote assets to whatever it's handed and marks any layer whose asset it can't resolve — reverse the order and every media layer comes back broken.

### Not everything is kept

Anything over **32 MB** is refused up front, as is anything that would push past 80% of the origin's quota. A 100 MB video is exactly the case a server draft is for, and quietly eating a gigabyte of someone's disk to guard against a refresh is a bad trade.

**A refusal never fails the save.** The scene still persists; that one layer reports its media missing — the same thing reopening a `.lab` has always done, so it's not a new concept for the user.

GC runs after each successful save in idle time and deletes blobs no surviving record references. It **never evicts a referenced blob**, even over budget, because the alternative is breaking a scene someone can still open.

## Verification

`bun test` **643 pass / 0 fail** (+10); typecheck clean; lint 2 warnings, both pre-existing.

Production build, real `DOM.setFileInputFiles` upload of a 7,144-byte PNG through the editor's own media input:

| | |
|---|---|
| import | blob persisted, `isBlob: true`, `blobSize === sizeBytes`, dimensions 64×64 |
| the record links asset → layer | yes (a layer holds that `assetId`) |
| hard refresh | pill appears, **no "Missing asset"** |
| the restored session still references the asset | yes, same id |
| no layer errors after restore | yes |
| blob survives GC | yes — referenced blobs aren't evicted |

**The decisive assertion:** `buildLabProjectFile` only keeps assets that a layer references *and* that are present in the asset store. So a non-empty `assets` array in the record written by the **restored** session is only possible if the blob was actually rehydrated into the store — not merely still sitting on disk.

**Control:** with rehydration disabled (`if (false && usable.length > 0)`), all four post-reload assertions flip to `false` and the UI *does* show "Missing asset". So none of them are vacuous.

### One test-harness bug worth recording

My database wipe was silently doing nothing. `indexedDB.deleteDatabase` fires `onblocked` when a connection is open, and my handler resolved on `onblocked` as if it had succeeded — so records leaked between runs and two assertions failed for the wrong reason. `about:blank` can't be used to wipe either: opaque origin, IDB access denied. Wiping from a same-origin page that doesn't mount autosave (`/community`) works, and the scripts now report the outcome (`dbWipe: "deleted"`) instead of assuming it. Also removed the hardcoded `open(name, 1)`, which threw a `VersionError` once the schema went to v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
