### PR TITLE
Save a draft to your account, so work follows you off this machine

### DIFF
--- a/drizzle/0005_small_stardust.sql
+++ b/drizzle/0005_small_stardust.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "scenes_author_status_updated_idx" ON "scenes" USING btree ("author_id","status","updated_at" DESC NULLS LAST);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1032 @@
+{
+  "id": "04dd9c18-d20b-469c-91cc-78e07e63923a",
+  "prevId": "d15a0fd1-84f3-4079-aca5-17105773ff4e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.handle_claims": {
+      "name": "handle_claims",
+      "schema": "",
+      "columns": {
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "handle_claims_user_idx": {
+          "name": "handle_claims_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "handle_claims_user_id_profiles_user_id_fk": {
+          "name": "handle_claims_user_id_profiles_user_id_fk",
+          "tableFrom": "handle_claims",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "likes_scene_idx": {
+          "name": "likes_scene_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "likes_scene_id_scenes_id_fk": {
+          "name": "likes_scene_id_scenes_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_user_id_profiles_user_id_fk": {
+          "name": "likes_user_id_profiles_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_scene_id_pk": {
+          "name": "likes_user_id_scene_id_pk",
+          "columns": [
+            "user_id",
+            "scene_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle_renamed_at": {
+          "name": "handle_renamed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_handle_unique": {
+          "name": "profiles_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remixes": {
+      "name": "remixes",
+      "schema": "",
+      "columns": {
+        "actor_key": {
+          "name": "actor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "day_bucket": {
+          "name": "day_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remixes_scene_idx": {
+          "name": "remixes_scene_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remixes_scene_id_scenes_id_fk": {
+          "name": "remixes_scene_id_scenes_id_fk",
+          "tableFrom": "remixes",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "remixes_actor_day_unique": {
+          "name": "remixes_actor_day_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id",
+            "actor_key",
+            "day_bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "reports_scene_idx": {
+          "name": "reports_scene_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_open_idx": {
+          "name": "reports_open_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_profiles_user_id_fk": {
+          "name": "reports_reporter_id_profiles_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reports_resolved_by_profiles_user_id_fk": {
+          "name": "reports_resolved_by_profiles_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reports_scene_id_scenes_id_fk": {
+          "name": "reports_scene_id_scenes_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scene_assets": {
+      "name": "scene_assets",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "asset_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scene_assets_scene_idx": {
+          "name": "scene_assets_scene_idx",
+          "columns": [
+            {
+              "expression": "scene_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scene_assets_sha256_idx": {
+          "name": "scene_assets_sha256_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scene_assets_scene_id_scenes_id_fk": {
+          "name": "scene_assets_scene_id_scenes_id_fk",
+          "tableFrom": "scene_assets",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "scene_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scene_assets_scene_asset_unique": {
+          "name": "scene_assets_scene_asset_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scene_id",
+            "asset_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scenes": {
+      "name": "scenes",
+      "schema": "",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composition_height": {
+          "name": "composition_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composition_width": {
+          "name": "composition_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "featured_at": {
+          "name": "featured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forked_from_id": {
+          "name": "forked_from_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_custom_shader": {
+          "name": "has_custom_shader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lab_key": {
+          "name": "lab_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_version": {
+          "name": "lab_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layer_types": {
+          "name": "layer_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_video_uid": {
+          "name": "preview_video_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remix_count": {
+          "name": "remix_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scene_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "thumbnail_image_id": {
+          "name": "thumbnail_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scenes_latest_idx": {
+          "name": "scenes_latest_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_popular_idx": {
+          "name": "scenes_popular_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "like_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_author_idx": {
+          "name": "scenes_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_author_published_idx": {
+          "name": "scenes_author_published_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_author_status_updated_idx": {
+          "name": "scenes_author_status_updated_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_featured_idx": {
+          "name": "scenes_featured_idx",
+          "columns": [
+            {
+              "expression": "featured_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_forked_from_idx": {
+          "name": "scenes_forked_from_idx",
+          "columns": [
+            {
+              "expression": "forked_from_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scenes_layer_types_idx": {
+          "name": "scenes_layer_types_idx",
+          "columns": [
+            {
+              "expression": "layer_types",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scenes_author_id_profiles_user_id_fk": {
+          "name": "scenes_author_id_profiles_user_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scenes_forked_from_id_scenes_id_fk": {
+          "name": "scenes_forked_from_id_scenes_id_fk",
+          "tableFrom": "scenes",
+          "tableTo": "scenes",
+          "columnsFrom": [
+            "forked_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scenes_slug_unique": {
+          "name": "scenes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_quota": {
+      "name": "upload_quota",
+      "schema": "",
+      "columns": {
+        "bytes_used": {
+          "name": "bytes_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "day_bucket": {
+          "name": "day_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenes_today": {
+          "name": "scenes_today",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "upload_quota_user_id_profiles_user_id_fk": {
+          "name": "upload_quota_user_id_profiles_user_id_fk",
+          "tableFrom": "upload_quota",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_provider": {
+      "name": "asset_provider",
+      "schema": "public",
+      "values": [
+        "cf-images",
+        "cf-stream",
+        "r2"
+      ]
+    },
+    "public.scene_status": {
+      "name": "scene_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "processing",
+        "published",
+        "takendown"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1786991803543,
       "tag": "0004_handle_rename_guard",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787028425144,
+      "tag": "0005_small_stardust",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/community/drafts/[id]/publish/route.ts
+++ b/src/app/api/community/drafts/[id]/publish/route.ts
@@ -12,6 +12,7 @@ import {
   MAX_LAB_BYTES,
   normalizeDescription,
   normalizeTitle,
+  releaseQuota,
   reserveQuota,
   reserveSceneSlot,
   validateProjectFilePayload,
@@ -159,6 +160,10 @@ export async function POST(
     return badRequest(quota.reason ?? "Quota exceeded.", 429)
   }
 
+  // Promoting only spent a scene slot; a first publish also spent the bytes.
+  const refund = () =>
+    releaseQuota(userId, prior ? { scenes: 1 } : { bytes: totalBytes, scenes: 1 })
+
   const forkedFromId =
     (await resolveForkedFromId(payload.forkedFromSlug)) ??
     prior?.forkedFromId ??
@@ -198,6 +203,8 @@ export async function POST(
       .returning({ id: scenes.id })
 
     if (promoted.length === 0) {
+      await refund()
+
       return badRequest("This draft can no longer be published.", 409)
     }
   } else {
@@ -208,6 +215,8 @@ export async function POST(
       .returning({ id: scenes.id })
 
     if (claimed.length === 0) {
+      await refund()
+
       return badRequest("Unknown draft.", 404)
     }
   }
@@ -233,6 +242,8 @@ export async function POST(
     } else {
       await db.delete(scenes).where(eq(scenes.id, draftId))
     }
+
+    await refund()
 
     throw cause
   }

--- a/src/app/api/community/drafts/[id]/publish/route.ts
+++ b/src/app/api/community/drafts/[id]/publish/route.ts
@@ -17,32 +17,13 @@ import {
   validateProjectFilePayload,
 } from "@/lib/community/publish"
 import { putObject } from "@/lib/community/r2"
+import { resolveForkedFromId } from "@/lib/community/scenes"
 import { verifyTurnstile } from "@/lib/community/turnstile"
 import { getDatabase } from "@/lib/db"
 import { sceneAssets, scenes } from "@/lib/db/schema"
 
 function badRequest(error: string, status = 400) {
   return Response.json({ error }, { status })
-}
-
-async function resolveForkedFromId(slug: unknown): Promise<string | null> {
-  if (typeof slug !== "string" || slug.length === 0 || slug.length > 120) {
-    return null
-  }
-
-  const rows = await getDatabase()
-    .select({ id: scenes.id })
-    .from(scenes)
-    .where(
-      and(
-        eq(scenes.slug, slug),
-        eq(scenes.status, "published"),
-        isNull(scenes.deletedAt)
-      )
-    )
-    .limit(1)
-
-  return rows[0]?.id ?? null
 }
 
 export async function POST(
@@ -145,6 +126,7 @@ export async function POST(
     .select({
       authorId: scenes.authorId,
       deletedAt: scenes.deletedAt,
+      forkedFromId: scenes.forkedFromId,
       labKey: scenes.labKey,
       publishedAt: scenes.publishedAt,
       slug: scenes.slug,
@@ -177,7 +159,10 @@ export async function POST(
     return badRequest(quota.reason ?? "Quota exceeded.", 429)
   }
 
-  const forkedFromId = await resolveForkedFromId(payload.forkedFromSlug)
+  const forkedFromId =
+    (await resolveForkedFromId(payload.forkedFromSlug)) ??
+    prior?.forkedFromId ??
+    null
   const slug = buildSceneSlug(title)
 
   const shared = {

--- a/src/app/api/community/drafts/[id]/publish/route.ts
+++ b/src/app/api/community/drafts/[id]/publish/route.ts
@@ -13,6 +13,7 @@ import {
   normalizeDescription,
   normalizeTitle,
   reserveQuota,
+  reserveSceneSlot,
   validateProjectFilePayload,
 } from "@/lib/community/publish"
 import { putObject } from "@/lib/community/r2"
@@ -129,17 +130,6 @@ export async function POST(
     return badRequest("A thumbnail is required.")
   }
 
-  const totalBytes = validated.projectFile.assets.reduce(
-    (sum, asset) => sum + (asset.sizeBytes ?? 0),
-    raw.length
-  )
-
-  const quota = await reserveQuota(userId, totalBytes)
-
-  if (!quota.ok) {
-    return badRequest(quota.reason ?? "Quota exceeded.", 429)
-  }
-
   const profile = await ensureProfile(userId, {
     avatarUrl: session?.user.image ?? null,
     email: session?.user.email ?? null,
@@ -150,34 +140,91 @@ export async function POST(
   const db = getDatabase()
   const now = new Date()
   const composition = validated.projectFile.composition
-  const forkedFromId = await resolveForkedFromId(payload.forkedFromSlug)
 
-  const claimed = await db
-    .insert(scenes)
-    .values({
-      authorId: profile.userId,
-      compositionHeight: Math.round(composition.height),
-      compositionWidth: Math.round(composition.width),
-      description,
-      durationSeconds: validated.projectFile.timeline.duration,
-      forkedFromId,
-      hasCustomShader: validated.hasCustomShader,
-      id: draftId,
-      labKey,
-      labVersion: validated.projectFile.version,
-      layerTypes: validated.layerTypes,
-      publishedAt: now,
-      slug: buildSceneSlug(title),
-      status: "published",
-      thumbnailImageId: thumbnailUrl,
-      title,
-      updatedAt: now,
+  const priorRows = await db
+    .select({
+      authorId: scenes.authorId,
+      deletedAt: scenes.deletedAt,
+      labKey: scenes.labKey,
+      publishedAt: scenes.publishedAt,
+      slug: scenes.slug,
+      status: scenes.status,
     })
-    .onConflictDoNothing({ target: scenes.id })
-    .returning({ id: scenes.id })
+    .from(scenes)
+    .where(eq(scenes.id, draftId))
+    .limit(1)
 
-  if (claimed.length === 0) {
+  const prior = priorRows[0]
+
+  if (prior && (prior.authorId !== profile.userId || prior.deletedAt)) {
     return badRequest("Unknown draft.", 404)
+  }
+
+  if (prior && prior.status !== "draft") {
+    return badRequest("This scene has already been published.", 409)
+  }
+
+  const totalBytes = validated.projectFile.assets.reduce(
+    (sum, asset) => sum + (asset.sizeBytes ?? 0),
+    raw.length
+  )
+
+  const quota = prior
+    ? await reserveSceneSlot(userId)
+    : await reserveQuota(userId, totalBytes)
+
+  if (!quota.ok) {
+    return badRequest(quota.reason ?? "Quota exceeded.", 429)
+  }
+
+  const forkedFromId = await resolveForkedFromId(payload.forkedFromSlug)
+  const slug = buildSceneSlug(title)
+
+  const shared = {
+    compositionHeight: Math.round(composition.height),
+    compositionWidth: Math.round(composition.width),
+    description,
+    durationSeconds: validated.projectFile.timeline.duration,
+    forkedFromId,
+    hasCustomShader: validated.hasCustomShader,
+    labKey,
+    labVersion: validated.projectFile.version,
+    layerTypes: validated.layerTypes,
+    publishedAt: now,
+    slug,
+    status: "published" as const,
+    thumbnailImageId: thumbnailUrl,
+    title,
+    updatedAt: now,
+  }
+
+  if (prior) {
+    const promoted = await db
+      .update(scenes)
+      .set(shared)
+      .where(
+        and(
+          eq(scenes.id, draftId),
+          eq(scenes.authorId, profile.userId),
+          eq(scenes.status, "draft"),
+          isNull(scenes.deletedAt)
+        )
+      )
+      .returning({ id: scenes.id })
+
+    if (promoted.length === 0) {
+      return badRequest("This draft can no longer be published.", 409)
+    }
+  } else {
+    const claimed = await db
+      .insert(scenes)
+      .values({ ...shared, authorId: profile.userId, id: draftId })
+      .onConflictDoNothing({ target: scenes.id })
+      .returning({ id: scenes.id })
+
+    if (claimed.length === 0) {
+      return badRequest("Unknown draft.", 404)
+    }
   }
 
   try {
@@ -187,7 +234,21 @@ export async function POST(
       key: labKey,
     })
   } catch (cause) {
-    await db.delete(scenes).where(eq(scenes.id, draftId))
+    if (prior) {
+      await db
+        .update(scenes)
+        .set({
+          labKey: prior.labKey,
+          publishedAt: prior.publishedAt,
+          slug: prior.slug,
+          status: "draft",
+          updatedAt: new Date(),
+        })
+        .where(eq(scenes.id, draftId))
+    } else {
+      await db.delete(scenes).where(eq(scenes.id, draftId))
+    }
+
     throw cause
   }
 
@@ -209,21 +270,17 @@ export async function POST(
       width: asset.width ?? null,
     }))
 
+  await db.delete(sceneAssets).where(eq(sceneAssets.sceneId, draftId))
+
   if (assetRows.length > 0) {
     await db.insert(sceneAssets).values(assetRows)
   }
-
-  const created = await db
-    .select({ slug: scenes.slug })
-    .from(scenes)
-    .where(eq(scenes.id, draftId))
-    .limit(1)
 
   revalidateTag(COMMUNITY_FEED_TAG, "max")
   revalidateTag(authorTag(profile.userId), "max")
 
   return Response.json({
-    scene: { id: draftId, slug: created[0]?.slug ?? null },
+    scene: { id: draftId, slug },
     turnstileSkipped: turnstile.skipped,
   })
 }

--- a/src/app/api/community/drafts/[id]/route.ts
+++ b/src/app/api/community/drafts/[id]/route.ts
@@ -1,0 +1,227 @@
+import { eq, sql } from "drizzle-orm"
+import { nanoid } from "nanoid"
+import { getOptionalSession } from "@/lib/auth/server"
+import { isCommunityEnabled, isMediaConfigured } from "@/lib/community/config"
+import { ensureProfile } from "@/lib/community/profile"
+import {
+  DRAFT_ID_PATTERN,
+  MAX_LAB_BYTES,
+  normalizeDraftTitle,
+  reserveBytes,
+  validateDraftPayload,
+} from "@/lib/community/publish"
+import { putObject } from "@/lib/community/r2"
+import { getDatabase } from "@/lib/db"
+import { sceneAssets, scenes } from "@/lib/db/schema"
+
+function fail(error: string, status: number) {
+  return Response.json({ error }, { status })
+}
+
+export function draftLabKey(draftId: string): string {
+  return `scenes/${draftId}/draft.lab.json`
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!(isCommunityEnabled() && isMediaConfigured())) {
+    return fail("Drafts are not configured on this deployment.", 503)
+  }
+
+  const session = await getOptionalSession()
+  const userId = session?.user.id
+
+  if (!userId) {
+    return fail("Sign in to save a draft.", 401)
+  }
+
+  const { id: draftId } = await params
+
+  if (!DRAFT_ID_PATTERN.test(draftId)) {
+    return fail("Unknown draft.", 404)
+  }
+
+  let payload: {
+    projectFile?: unknown
+    thumbnailUrl?: unknown
+    title?: unknown
+  }
+
+  try {
+    payload = await request.json()
+  } catch {
+    return fail("Invalid request body.", 400)
+  }
+
+  const raw =
+    typeof payload.projectFile === "string" ? payload.projectFile : null
+
+  if (!raw) {
+    return fail("The scene payload is missing.", 400)
+  }
+
+  if (raw.length > MAX_LAB_BYTES) {
+    return fail("This scene is too large to save.", 400)
+  }
+
+  let validated: ReturnType<typeof validateDraftPayload>
+
+  try {
+    validated = validateDraftPayload(raw)
+  } catch (cause) {
+    return fail(
+      cause instanceof Error ? cause.message : "This scene is not valid.",
+      400
+    )
+  }
+
+  const profile = await ensureProfile(userId, {
+    avatarUrl: session?.user.image ?? null,
+    email: session?.user.email ?? null,
+    name: session?.user.name ?? null,
+  })
+
+  const db = getDatabase()
+
+  const existingRows = await db
+    .select({
+      authorId: scenes.authorId,
+      deletedAt: scenes.deletedAt,
+      status: scenes.status,
+    })
+    .from(scenes)
+    .where(eq(scenes.id, draftId))
+    .limit(1)
+
+  const existing = existingRows[0]
+
+  if (existing && (existing.authorId !== profile.userId || existing.deletedAt)) {
+    return fail("Unknown draft.", 404)
+  }
+
+  // Without this a PUT against a published scene's id would swap its content,
+  // skipping Turnstile and leaving no moderation trail.
+  if (existing && existing.status !== "draft") {
+    return fail("This scene has already been published.", 409)
+  }
+
+  const priorAssets = await db
+    .select({ sha256: sceneAssets.sha256 })
+    .from(sceneAssets)
+    .where(eq(sceneAssets.sceneId, draftId))
+
+  const charged = new Set(
+    priorAssets.flatMap((row) => (row.sha256 ? [row.sha256] : []))
+  )
+
+  // The lab file overwrites one key in place, so it is charged when the draft is
+  // created and not on every save; assets are charged the first time their
+  // content hash appears under this draft.
+  const bytes = validated.projectFile.assets.reduce(
+    (sum, asset) =>
+      asset.sha256 && charged.has(asset.sha256)
+        ? sum
+        : sum + (asset.sizeBytes ?? 0),
+    existing ? 0 : raw.length
+  )
+
+  if (bytes > 0) {
+    const quota = await reserveBytes(profile.userId, bytes)
+
+    if (!quota.ok) {
+      return fail(quota.reason ?? "Quota exceeded.", 429)
+    }
+  }
+
+  const composition = validated.projectFile.composition
+  const now = new Date()
+  const labKey = draftLabKey(draftId)
+  const thumbnailUrl =
+    typeof payload.thumbnailUrl === "string" ? payload.thumbnailUrl : null
+  const title = normalizeDraftTitle(payload.title)
+
+  // Written before the row, so a row can never point at a lab file that is not
+  // there. A stray object with no row is invisible and the next save overwrites
+  // it, which is the cheaper of the two failures.
+  await putObject({
+    body: raw,
+    contentType: "application/json",
+    key: labKey,
+  })
+
+  const saved = await db
+    .insert(scenes)
+    .values({
+      authorId: profile.userId,
+      compositionHeight: Math.round(composition.height),
+      compositionWidth: Math.round(composition.width),
+      durationSeconds: validated.projectFile.timeline.duration,
+      hasCustomShader: validated.hasCustomShader,
+      id: draftId,
+      labKey,
+      labVersion: validated.projectFile.version,
+      layerTypes: validated.layerTypes,
+      slug: draftId,
+      status: "draft",
+      thumbnailImageId: thumbnailUrl,
+      title,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      set: {
+        compositionHeight: Math.round(composition.height),
+        compositionWidth: Math.round(composition.width),
+        durationSeconds: validated.projectFile.timeline.duration,
+        hasCustomShader: validated.hasCustomShader,
+        labKey,
+        labVersion: validated.projectFile.version,
+        layerTypes: validated.layerTypes,
+        title,
+        updatedAt: now,
+        ...(thumbnailUrl ? { thumbnailImageId: thumbnailUrl } : {}),
+      },
+      setWhere: sql`${scenes.authorId} = ${profile.userId}::uuid and ${scenes.status} = 'draft' and ${scenes.deletedAt} is null`,
+      target: scenes.id,
+    })
+    .returning({ id: scenes.id })
+
+  // The read above is for the error message; this is the guard that holds, so a
+  // row that changed hands between the two still cannot be written.
+  if (saved.length === 0) {
+    return fail("This draft can no longer be saved.", 409)
+  }
+
+  const assetRows = validated.projectFile.assets.map((asset) => ({
+    assetId: asset.id,
+    duration: asset.duration ?? null,
+    height: asset.height ?? null,
+    id: `sa_${nanoid(16)}`,
+    kind: asset.kind,
+    mimeType: asset.mimeType ?? null,
+    provider: "r2" as const,
+    providerId: asset.sha256 ?? asset.id,
+    sceneId: draftId,
+    sha256: asset.sha256 ?? null,
+    sizeBytes: asset.sizeBytes ?? 0,
+    url: asset.url as string,
+    width: asset.width ?? null,
+  }))
+
+  // Replaced wholesale rather than upserted, so a layer the user deleted stops
+  // holding its media alive.
+  await db.delete(sceneAssets).where(eq(sceneAssets.sceneId, draftId))
+
+  if (assetRows.length > 0) {
+    await db.insert(sceneAssets).values(assetRows)
+  }
+
+  return Response.json({
+    draft: {
+      id: draftId,
+      savedAt: now.toISOString(),
+      title,
+    },
+  })
+}

--- a/src/app/api/community/drafts/[id]/route.ts
+++ b/src/app/api/community/drafts/[id]/route.ts
@@ -10,7 +10,11 @@ import {
   reserveBytes,
   validateDraftPayload,
 } from "@/lib/community/publish"
-import { putObject } from "@/lib/community/r2"
+import {
+  keyFromPublicUrl,
+  putObject,
+  scenePrefixOf,
+} from "@/lib/community/r2"
 import { getDatabase } from "@/lib/db"
 import { sceneAssets, scenes } from "@/lib/db/schema"
 
@@ -101,31 +105,31 @@ export async function PUT(
     return fail("Unknown draft.", 404)
   }
 
-  // Without this a PUT against a published scene's id would swap its content,
-  // skipping Turnstile and leaving no moderation trail.
   if (existing && existing.status !== "draft") {
     return fail("This scene has already been published.", 409)
   }
 
   const priorAssets = await db
-    .select({ sha256: sceneAssets.sha256 })
+    .select({ assetId: sceneAssets.assetId })
     .from(sceneAssets)
     .where(eq(sceneAssets.sceneId, draftId))
 
-  const charged = new Set(
-    priorAssets.flatMap((row) => (row.sha256 ? [row.sha256] : []))
-  )
+  const charged = new Set(priorAssets.map((row) => row.assetId))
+  const ownPrefix = `scenes/${draftId}`
 
-  // The lab file overwrites one key in place, so it is charged when the draft is
-  // created and not on every save; assets are charged the first time their
-  // content hash appears under this draft.
-  const bytes = validated.projectFile.assets.reduce(
-    (sum, asset) =>
-      asset.sha256 && charged.has(asset.sha256)
-        ? sum
-        : sum + (asset.sizeBytes ?? 0),
-    existing ? 0 : raw.length
-  )
+  const bytes = validated.projectFile.assets.reduce((sum, asset) => {
+    if (charged.has(asset.id)) {
+      return sum
+    }
+
+    const key = keyFromPublicUrl(asset.url ?? "")
+
+    if (!key || scenePrefixOf(key) !== ownPrefix) {
+      return sum
+    }
+
+    return sum + (asset.sizeBytes ?? 0)
+  }, existing ? 0 : raw.length)
 
   if (bytes > 0) {
     const quota = await reserveBytes(profile.userId, bytes)
@@ -142,9 +146,6 @@ export async function PUT(
     typeof payload.thumbnailUrl === "string" ? payload.thumbnailUrl : null
   const title = normalizeDraftTitle(payload.title)
 
-  // Written before the row, so a row can never point at a lab file that is not
-  // there. A stray object with no row is invisible and the next save overwrites
-  // it, which is the cheaper of the two failures.
   await putObject({
     body: raw,
     contentType: "application/json",
@@ -187,8 +188,6 @@ export async function PUT(
     })
     .returning({ id: scenes.id })
 
-  // The read above is for the error message; this is the guard that holds, so a
-  // row that changed hands between the two still cannot be written.
   if (saved.length === 0) {
     return fail("This draft can no longer be saved.", 409)
   }
@@ -209,8 +208,6 @@ export async function PUT(
     width: asset.width ?? null,
   }))
 
-  // Replaced wholesale rather than upserted, so a layer the user deleted stops
-  // holding its media alive.
   await db.delete(sceneAssets).where(eq(sceneAssets.sceneId, draftId))
 
   if (assetRows.length > 0) {

--- a/src/app/api/community/drafts/[id]/route.ts
+++ b/src/app/api/community/drafts/[id]/route.ts
@@ -16,6 +16,7 @@ import {
   scenePrefixOf,
 } from "@/lib/community/r2"
 import { MAX_DRAFTS_PER_AUTHOR } from "@/lib/community/upload-limits"
+import { resolveForkedFromId } from "@/lib/community/scenes"
 import { getDatabase } from "@/lib/db"
 import { sceneAssets, scenes } from "@/lib/db/schema"
 
@@ -49,6 +50,7 @@ export async function PUT(
   }
 
   let payload: {
+    forkedFromSlug?: unknown
     projectFile?: unknown
     thumbnailUrl?: unknown
     title?: unknown
@@ -166,6 +168,7 @@ export async function PUT(
   const thumbnailUrl =
     typeof payload.thumbnailUrl === "string" ? payload.thumbnailUrl : null
   const title = normalizeDraftTitle(payload.title)
+  const forkedFromId = await resolveForkedFromId(payload.forkedFromSlug)
 
   await putObject({
     body: raw,
@@ -180,6 +183,7 @@ export async function PUT(
       compositionHeight: Math.round(composition.height),
       compositionWidth: Math.round(composition.width),
       durationSeconds: validated.projectFile.timeline.duration,
+      forkedFromId,
       hasCustomShader: validated.hasCustomShader,
       id: draftId,
       labKey,
@@ -198,6 +202,7 @@ export async function PUT(
         durationSeconds: validated.projectFile.timeline.duration,
         hasCustomShader: validated.hasCustomShader,
         labKey,
+        ...(forkedFromId ? { forkedFromId } : {}),
         labVersion: validated.projectFile.version,
         layerTypes: validated.layerTypes,
         title,

--- a/src/app/api/community/drafts/[id]/route.ts
+++ b/src/app/api/community/drafts/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   DRAFT_ID_PATTERN,
   MAX_LAB_BYTES,
   normalizeDraftTitle,
+  releaseQuota,
   reserveBytes,
   validateDraftPayload,
 } from "@/lib/community/publish"
@@ -162,6 +163,9 @@ export async function PUT(
     }
   }
 
+  const refund = () =>
+    bytes > 0 ? releaseQuota(profile.userId, { bytes }) : Promise.resolve()
+
   const composition = validated.projectFile.composition
   const now = new Date()
   const labKey = draftLabKey(draftId)
@@ -170,11 +174,17 @@ export async function PUT(
   const title = normalizeDraftTitle(payload.title)
   const forkedFromId = await resolveForkedFromId(payload.forkedFromSlug)
 
-  await putObject({
-    body: raw,
-    contentType: "application/json",
-    key: labKey,
-  })
+  try {
+    await putObject({
+      body: raw,
+      contentType: "application/json",
+      key: labKey,
+    })
+  } catch (cause) {
+    await refund()
+
+    throw cause
+  }
 
   const saved = await db
     .insert(scenes)
@@ -215,6 +225,8 @@ export async function PUT(
     .returning({ id: scenes.id })
 
   if (saved.length === 0) {
+    await refund()
+
     return fail("This draft can no longer be saved.", 409)
   }
 

--- a/src/app/api/community/drafts/[id]/route.ts
+++ b/src/app/api/community/drafts/[id]/route.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm"
+import { and, eq, isNull, sql } from "drizzle-orm"
 import { nanoid } from "nanoid"
 import { getOptionalSession } from "@/lib/auth/server"
 import { isCommunityEnabled, isMediaConfigured } from "@/lib/community/config"
@@ -15,6 +15,7 @@ import {
   putObject,
   scenePrefixOf,
 } from "@/lib/community/r2"
+import { MAX_DRAFTS_PER_AUTHOR } from "@/lib/community/upload-limits"
 import { getDatabase } from "@/lib/db"
 import { sceneAssets, scenes } from "@/lib/db/schema"
 
@@ -107,6 +108,26 @@ export async function PUT(
 
   if (existing && existing.status !== "draft") {
     return fail("This scene has already been published.", 409)
+  }
+
+  if (!existing) {
+    const held = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(scenes)
+      .where(
+        and(
+          eq(scenes.authorId, profile.userId),
+          eq(scenes.status, "draft"),
+          isNull(scenes.deletedAt)
+        )
+      )
+
+    if ((held[0]?.count ?? 0) >= MAX_DRAFTS_PER_AUTHOR) {
+      return fail(
+        `You already have ${MAX_DRAFTS_PER_AUTHOR} drafts. Delete or publish one to save another.`,
+        409
+      )
+    }
   }
 
   const priorAssets = await db

--- a/src/app/api/community/drafts/route.ts
+++ b/src/app/api/community/drafts/route.ts
@@ -33,9 +33,6 @@ type DraftClaim =
   | { draftId: string }
   | { error: string; status: number }
 
-// A caller-supplied id decides where the presigned PUTs land, so it has to be
-// proved to be theirs first: without this an attacker signs an upload into
-// someone else's scene prefix and overwrites a published scene's media.
 async function claimDraftId(input: {
   authorId: string
   requested: unknown
@@ -63,8 +60,6 @@ async function claimDraftId(input: {
     return { draftId: input.requested }
   }
 
-  // 404 rather than 403 for someone else's id, so this cannot be used to ask
-  // whether an id exists.
   if (existing.authorId !== input.authorId) {
     return { error: "Unknown draft.", status: 404 }
   }

--- a/src/app/api/community/drafts/route.ts
+++ b/src/app/api/community/drafts/route.ts
@@ -1,19 +1,99 @@
+import { and, eq, inArray } from "drizzle-orm"
 import { nanoid } from "nanoid"
 import { getOptionalSession } from "@/lib/auth/server"
 import { isCommunityEnabled, isMediaConfigured } from "@/lib/community/config"
 import { ensureProfile } from "@/lib/community/profile"
 import {
+  DRAFT_ID_PATTERN,
   MAX_ASSETS_PER_SCENE,
   UPLOADABLE_MIME_TYPES,
 } from "@/lib/community/publish"
 import { createUploadUrl } from "@/lib/community/r2"
 import { describeUploadLimit } from "@/lib/community/upload-limits"
+import { getDatabase } from "@/lib/db"
+import { sceneAssets, scenes } from "@/lib/db/schema"
 
 interface RequestedUpload {
   contentLength?: unknown
   contentType?: unknown
   kind?: unknown
   sha256?: unknown
+}
+
+interface UploadTarget {
+  alreadyStored?: boolean
+  contentType: string
+  key: string
+  publicUrl: string
+  sha256: string
+  uploadUrl?: string
+}
+
+type DraftClaim =
+  | { draftId: string }
+  | { error: string; status: number }
+
+// A caller-supplied id decides where the presigned PUTs land, so it has to be
+// proved to be theirs first: without this an attacker signs an upload into
+// someone else's scene prefix and overwrites a published scene's media.
+async function claimDraftId(input: {
+  authorId: string
+  requested: unknown
+}): Promise<DraftClaim> {
+  if (input.requested === undefined || input.requested === null) {
+    return { draftId: `scn_${nanoid(16)}` }
+  }
+
+  if (
+    typeof input.requested !== "string" ||
+    !DRAFT_ID_PATTERN.test(input.requested)
+  ) {
+    return { error: "Unknown draft.", status: 404 }
+  }
+
+  const rows = await getDatabase()
+    .select({ authorId: scenes.authorId, status: scenes.status })
+    .from(scenes)
+    .where(eq(scenes.id, input.requested))
+    .limit(1)
+
+  const existing = rows[0]
+
+  if (!existing) {
+    return { draftId: input.requested }
+  }
+
+  // 404 rather than 403 for someone else's id, so this cannot be used to ask
+  // whether an id exists.
+  if (existing.authorId !== input.authorId) {
+    return { error: "Unknown draft.", status: 404 }
+  }
+
+  if (existing.status !== "draft") {
+    return { error: "This scene has already been published.", status: 409 }
+  }
+
+  return { draftId: input.requested }
+}
+
+async function readStoredShas(
+  draftId: string,
+  shas: readonly string[]
+): Promise<Map<string, string>> {
+  if (shas.length === 0) {
+    return new Map()
+  }
+
+  const rows = await getDatabase()
+    .select({ sha256: sceneAssets.sha256, url: sceneAssets.url })
+    .from(sceneAssets)
+    .where(
+      and(eq(sceneAssets.sceneId, draftId), inArray(sceneAssets.sha256, shas))
+    )
+
+  return new Map(
+    rows.flatMap((row) => (row.sha256 ? [[row.sha256, row.url]] : []))
+  )
 }
 
 function extensionFor(contentType: string): string {
@@ -52,10 +132,10 @@ export async function POST(request: Request) {
     return Response.json({ error: "Sign in to publish." }, { status: 401 })
   }
 
-  let payload: { uploads?: unknown }
+  let payload: { draftId?: unknown; uploads?: unknown }
 
   try {
-    payload = (await request.json()) as { uploads?: unknown }
+    payload = (await request.json()) as { draftId?: unknown; uploads?: unknown }
   } catch {
     return Response.json({ error: "Invalid request body." }, { status: 400 })
   }
@@ -77,14 +157,23 @@ export async function POST(request: Request) {
     name: session?.user.name ?? null,
   })
 
-  const draftId = `scn_${nanoid(16)}`
-  const targets: {
-    contentType: string
-    key: string
-    publicUrl: string
-    sha256: string
-    uploadUrl: string
-  }[] = []
+  const claim = await claimDraftId({
+    authorId: profile.userId,
+    requested: payload.draftId,
+  })
+
+  if ("error" in claim) {
+    return Response.json({ error: claim.error }, { status: claim.status })
+  }
+
+  const { draftId } = claim
+  const stored = await readStoredShas(
+    draftId,
+    requested.flatMap((upload) =>
+      typeof upload.sha256 === "string" ? [upload.sha256] : []
+    )
+  )
+  const targets: UploadTarget[] = []
 
   for (const upload of requested) {
     const contentType =
@@ -117,6 +206,20 @@ export async function POST(request: Request) {
     }
 
     const key = `scenes/${draftId}/${sha256}.${extensionFor(contentType)}`
+    const alreadyStored = stored.get(sha256)
+
+    if (alreadyStored) {
+      targets.push({
+        alreadyStored: true,
+        contentType,
+        key,
+        publicUrl: alreadyStored,
+        sha256,
+      })
+
+      continue
+    }
+
     const signed = await createUploadUrl({ contentLength, contentType, key })
 
     targets.push({

--- a/src/app/api/community/me/drafts/route.ts
+++ b/src/app/api/community/me/drafts/route.ts
@@ -1,0 +1,29 @@
+import { connection } from "next/server"
+import { getOptionalSession } from "@/lib/auth/server"
+import { isCommunityEnabled } from "@/lib/community/config"
+import { listDraftsByAuthor } from "@/lib/community/scenes"
+
+export async function GET() {
+  await connection()
+
+  if (!isCommunityEnabled()) {
+    return Response.json({ error: "Not available." }, { status: 503 })
+  }
+
+  const session = await getOptionalSession()
+
+  if (!session) {
+    return Response.json({ error: "Sign in first." }, { status: 401 })
+  }
+
+  try {
+    return Response.json({
+      drafts: await listDraftsByAuthor(session.user.id),
+    })
+  } catch {
+    return Response.json(
+      { error: "Could not load your drafts." },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/community/__tests__/draft-card.test.ts
+++ b/src/components/community/__tests__/draft-card.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test"
+import {
+  describeDraftContents,
+  describeSavedAt,
+} from "@/components/community/draft-card"
+import type { DraftSummary } from "@/lib/community/scenes"
+
+const NOW = Date.parse("2026-08-18T12:00:00.000Z")
+
+function at(offsetMs: number): string {
+  return new Date(NOW - offsetMs).toISOString()
+}
+
+function draft(overrides?: Partial<DraftSummary>): DraftSummary {
+  return {
+    compositionHeight: 1080,
+    compositionWidth: 1920,
+    durationSeconds: 6,
+    id: "scn_aaaaaaaaaaaaaaaa",
+    labUrl: "https://cdn.test/scenes/x/draft.lab.json",
+    layerTypes: [],
+    thumbnailUrl: null,
+    title: "Untitled draft",
+    updatedAt: at(0),
+    ...overrides,
+  } as DraftSummary
+}
+
+describe("describeSavedAt", () => {
+  test("anything under a minute reads as just now", () => {
+    expect(describeSavedAt(at(0), NOW)).toBe("Saved just now")
+    expect(describeSavedAt(at(59_000), NOW)).toBe("Saved just now")
+  })
+
+  test("singular and plural minutes", () => {
+    expect(describeSavedAt(at(60_000), NOW)).toBe("Saved 1 minute ago")
+    expect(describeSavedAt(at(4 * 60_000), NOW)).toBe("Saved 4 minutes ago")
+  })
+
+  test("rolls up to hours and days, largest unit first", () => {
+    expect(describeSavedAt(at(3_600_000), NOW)).toBe("Saved 1 hour ago")
+    expect(describeSavedAt(at(5 * 3_600_000), NOW)).toBe("Saved 5 hours ago")
+    expect(describeSavedAt(at(86_400_000), NOW)).toBe("Saved 1 day ago")
+    expect(describeSavedAt(at(9 * 86_400_000), NOW)).toBe("Saved 9 days ago")
+  })
+
+  test("a clock skewed into the future does not read as negative", () => {
+    expect(describeSavedAt(at(-90_000), NOW)).toBe("Saved just now")
+  })
+
+  test("an unparseable timestamp does not render NaN", () => {
+    expect(describeSavedAt("not a date", NOW)).toBe("Saved just now")
+  })
+})
+
+describe("describeDraftContents", () => {
+  test("names the layers a draft holds", () => {
+    expect(
+      describeDraftContents(draft({ layerTypes: ["gradient", "crt"] }))
+    ).toBe("gradient, crt")
+  })
+
+  test("caps the list so a long stack does not overflow the tile", () => {
+    expect(
+      describeDraftContents(
+        draft({ layerTypes: ["a", "b", "c", "d", "e"] as never })
+      )
+    ).toBe("a, b, c")
+  })
+
+  test("an empty draft says so rather than rendering nothing", () => {
+    expect(describeDraftContents(draft())).toBe("Empty scene")
+  })
+})

--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -130,14 +130,18 @@ export function CommunityModal({
     return () => window.clearTimeout(timeout)
   }, [search])
 
+  const userId = session?.user?.id ?? null
+
   useEffect(() => {
-    if (!session?.user) {
-      setTab("explore")
-      setMine(null)
-      setDrafts(null)
-      setUpvoted(new Set())
+    if (userId) {
+      return
     }
-  }, [session?.user])
+
+    setTab("explore")
+    setMine(null)
+    setDrafts(null)
+    setUpvoted(new Set())
+  }, [userId])
 
   useEffect(() => {
     if (open) {
@@ -158,7 +162,7 @@ export function CommunityModal({
   }, [])
 
   useEffect(() => {
-    if (!(open && session?.user)) {
+    if (!(open && userId)) {
       return
     }
 
@@ -176,15 +180,15 @@ export function CommunityModal({
     return () => {
       cancelled = true
     }
-  }, [open, session?.user])
+  }, [open, userId])
 
   useEffect(() => {
-    if (!(open && session?.user)) {
+    if (!(open && userId)) {
       return
     }
 
     let cancelled = false
-    setMine(null)
+
     setMineFailed(false)
 
     fetch("/api/community/me/scenes")
@@ -204,10 +208,9 @@ export function CommunityModal({
     return () => {
       cancelled = true
     }
-  }, [open, session?.user])
+  }, [open, userId])
 
   const loadDrafts = useCallback(() => {
-    setDrafts(null)
     setDraftsFailed(false)
 
     return fetch("/api/community/me/drafts")
@@ -220,12 +223,12 @@ export function CommunityModal({
   }, [])
 
   useEffect(() => {
-    if (!(open && session?.user && tab === "drafts")) {
+    if (!(open && userId && tab === "drafts")) {
       return
     }
 
     void loadDrafts()
-  }, [loadDrafts, open, session?.user, tab])
+  }, [loadDrafts, open, tab, userId])
 
   useEffect(() => {
     if (!open) {

--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -32,6 +32,7 @@ import type {
   SceneSort,
 } from "@/lib/community/scenes"
 import { scenePagePath } from "@/lib/community/scene-links"
+import { MAX_DRAFTS_PER_AUTHOR } from "@/lib/community/upload-limits"
 import { useScenePages } from "@/lib/community/use-scene-pages"
 import { requestAutosave } from "@/lib/editor/autosave/bus"
 import { withAutosaveSuppressed } from "@/lib/editor/autosave/suppress"
@@ -344,6 +345,35 @@ export function CommunityModal({
     },
     [onOpenChange]
   )
+
+  const publishDraft = useCallback(
+    async (draft: DraftSummary) => {
+      await openDraft(draft)
+
+      if (useDraftStore.getState().activeDraft?.id === draft.id) {
+        onRequestPublish()
+      }
+    },
+    [onRequestPublish, openDraft]
+  )
+
+  const saveAsNewDraft = useCallback(async () => {
+    setBusyDraftId("new")
+    setError(null)
+
+    try {
+      const { saveDraft } = await import("@/lib/community/publish-client")
+
+      await saveDraft({ asNewDraft: true })
+      await loadDrafts()
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : "Could not save a new draft."
+      )
+    } finally {
+      setBusyDraftId(null)
+    }
+  }, [loadDrafts])
 
   const deleteDraft = useCallback(
     async (draft: DraftSummary) => {
@@ -793,8 +823,37 @@ export function CommunityModal({
                           >
                             {draftsFailed
                               ? "Could not load your drafts."
-                              : "No drafts yet. Press \u2318S in the editor to save one."}
+                              : "No drafts yet. Save the scene you are working on to keep it here."}
                           </Typography>
+                          {draftsFailed ? null : (
+                            <Button
+                              disabled={busyDraftId !== null}
+                              onClick={() => void saveAsNewDraft()}
+                              size="compact"
+                              variant="primary"
+                            >
+                              Save current scene
+                            </Button>
+                          )}
+                        </div>
+                      ) : null}
+
+                      {drafts && drafts.length > 0 ? (
+                        <div className="mb-[var(--ds-space-4)] flex items-center justify-between gap-[var(--ds-space-3)]">
+                          <Typography as="span" tone="tertiary" variant="caption">
+                            {drafts.length} of {MAX_DRAFTS_PER_AUTHOR} slots used
+                          </Typography>
+                          <Button
+                            disabled={
+                              busyDraftId !== null ||
+                              drafts.length >= MAX_DRAFTS_PER_AUTHOR
+                            }
+                            onClick={() => void saveAsNewDraft()}
+                            size="compact"
+                            variant="secondary"
+                          >
+                            Save current scene as new draft
+                          </Button>
                         </div>
                       ) : null}
 
@@ -804,6 +863,7 @@ export function CommunityModal({
                           drafts={drafts}
                           onDelete={deleteDraft}
                           onOpen={openDraft}
+                          onPublish={publishDraft}
                         />
                       ) : null}
                     </div>

--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -304,8 +304,6 @@ export function CommunityModal({
             slug: scene.slug,
             title: scene.title,
           })
-          // A remix is somebody else's scene, so it must not save over whatever
-          // draft was open a moment ago.
           useDraftStore.getState().clearActiveDraft()
         })
 
@@ -339,16 +337,15 @@ export function CommunityModal({
     autoOpened.current = true
 
     void (async () => {
-      try {
-        const res = await fetch(`/api/community/scenes/${autoOpenSlug}`)
-        const data = (await res.json()) as { scene?: CommunitySceneDetail }
+      const scene = await fetch(`/api/community/scenes/${autoOpenSlug}`)
+        .then((res) => res.json() as Promise<{ scene?: CommunitySceneDetail }>)
+        .then((data) => data.scene ?? null)
+        .catch(() => null)
 
-        if (data.scene) {
-          await remix(data.scene, { auto: true })
-          return
-        }
-      } catch {
-        // fall through to the browser below
+      if (scene) {
+        await remix(scene, { auto: true })
+
+        return
       }
 
       setError("That scene is no longer available.")

--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -40,6 +40,7 @@ import {
   parseLabProjectFile,
 } from "@/lib/editor/project-file"
 import { useAssetStore } from "@/store/asset-store"
+import { useDraftStore } from "@/store/draft-store"
 import { useEditorStore } from "@/store/editor-store"
 import { useRemixOriginStore } from "@/store/remix-origin-store"
 
@@ -303,6 +304,9 @@ export function CommunityModal({
             slug: scene.slug,
             title: scene.title,
           })
+          // A remix is somebody else's scene, so it must not save over whatever
+          // draft was open a moment ago.
+          useDraftStore.getState().clearActiveDraft()
         })
 
         requestAutosave()

--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -3,6 +3,7 @@
 import {
   ArrowLeftIcon,
   Cross2Icon,
+  InfoCircledIcon,
   MagnifyingGlassIcon,
 } from "@radix-ui/react-icons"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
@@ -20,6 +21,7 @@ import { ShaderConsentDialog } from "@/components/community/shader-consent-dialo
 import { Button } from "@/components/ui/button"
 import { GlassPanel } from "@/components/ui/glass-panel"
 import { IconButton } from "@/components/ui/icon-button"
+import { HoverTooltip } from "@/components/ui/tooltip"
 import { Typography } from "@/components/ui/typography"
 import { authClient } from "@/lib/auth/client"
 import { cn } from "@/lib/cn"
@@ -48,6 +50,9 @@ import { useEditorStore } from "@/store/editor-store"
 import { useRemixOriginStore } from "@/store/remix-origin-store"
 
 const SKELETON_KEYS = ["s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"] as const
+
+const DRAFT_SAVE_HINT =
+  "\u2318S updates the draft you have open. \u2318\u21e7S saves the current scene as a new one. Opening a draft makes it the one \u2318S writes to."
 
 const SORT_TABS: readonly { label: string; value: SceneSort }[] = [
   { label: "Popular", value: "popular" },
@@ -325,7 +330,16 @@ export function CommunityModal({
 
         withAutosaveSuppressed(() => {
           applyLabProjectFile(projectFile, useAssetStore.getState().assets)
-          useRemixOriginStore.getState().clearRemixOrigin()
+
+          if (draft.forkedFrom) {
+            useRemixOriginStore.getState().setRemixOrigin({
+              slug: draft.forkedFrom.slug,
+              title: draft.forkedFrom.title,
+            })
+          } else {
+            useRemixOriginStore.getState().clearRemixOrigin()
+          }
+
           useDraftStore.getState().setActiveDraft({
             id: draft.id,
             savedAt: draft.updatedAt,
@@ -826,23 +840,50 @@ export function CommunityModal({
                               : "No drafts yet. Save the scene you are working on to keep it here."}
                           </Typography>
                           {draftsFailed ? null : (
-                            <Button
-                              disabled={busyDraftId !== null}
-                              onClick={() => void saveAsNewDraft()}
-                              size="compact"
-                              variant="primary"
-                            >
-                              Save current scene
-                            </Button>
+                            <>
+                              <Button
+                                disabled={busyDraftId !== null}
+                                onClick={() => void saveAsNewDraft()}
+                                size="compact"
+                                variant="primary"
+                              >
+                                Save current scene
+                              </Button>
+                              <Typography
+                                align="center"
+                                as="p"
+                                className="max-w-[320px]"
+                                tone="muted"
+                                variant="monoXs"
+                              >
+                                {DRAFT_SAVE_HINT}
+                              </Typography>
+                            </>
                           )}
                         </div>
                       ) : null}
 
                       {drafts && drafts.length > 0 ? (
                         <div className="mb-[var(--ds-space-4)] flex items-center justify-between gap-[var(--ds-space-3)]">
-                          <Typography as="span" tone="tertiary" variant="caption">
-                            {drafts.length} of {MAX_DRAFTS_PER_AUTHOR} slots used
-                          </Typography>
+                          <span className="inline-flex items-center gap-1.5">
+                            <Typography
+                              as="span"
+                              tone="tertiary"
+                              variant="caption"
+                            >
+                              {drafts.length} of {MAX_DRAFTS_PER_AUTHOR} slots
+                              used
+                            </Typography>
+                            <HoverTooltip content={DRAFT_SAVE_HINT} side="bottom">
+                              <button
+                                aria-label="How saving drafts works"
+                                className="inline-flex cursor-help items-center bg-transparent p-0 text-[var(--ds-color-text-muted)] transition-colors duration-160 hover:text-[var(--ds-color-text-secondary)]"
+                                type="button"
+                              >
+                                <InfoCircledIcon height={13} width={13} />
+                              </button>
+                            </HoverTooltip>
+                          </span>
                           <Button
                             disabled={
                               busyDraftId !== null ||

--- a/src/components/community/community-modal.tsx
+++ b/src/components/community/community-modal.tsx
@@ -9,6 +9,7 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { AuthMenu } from "@/components/community/auth-menu"
+import { DraftsGrid } from "@/components/community/drafts-grid"
 import { MyScenesGrid } from "@/components/community/my-scenes-grid"
 import { ProfilePanel } from "@/components/community/profile-panel"
 import { SceneCard } from "@/components/community/scene-card"
@@ -25,6 +26,7 @@ import { cn } from "@/lib/cn"
 import { getAnonId } from "@/lib/community/anon-id"
 import type {
   AuthoredScene,
+  DraftSummary,
   CommunitySceneDetail,
   CommunitySceneSummary,
   SceneSort,
@@ -51,9 +53,13 @@ const SORT_TABS: readonly { label: string; value: SceneSort }[] = [
   { label: "Latest", value: "latest" },
 ]
 
-const VIEW_TABS: readonly { label: string; value: "explore" | "mine" }[] = [
+const VIEW_TABS: readonly {
+  label: string
+  value: "drafts" | "explore" | "mine"
+}[] = [
   { label: "Explore", value: "explore" },
   { label: "My scenes", value: "mine" },
+  { label: "Drafts", value: "drafts" },
 ]
 
 const TAB_CLASS_NAME =
@@ -75,9 +81,12 @@ export function CommunityModal({
   const reduceMotion = useReducedMotion() ?? false
   const { data: session } = authClient.useSession()
   const [mounted, setMounted] = useState(false)
-  const [tab, setTab] = useState<"explore" | "mine">("explore")
+  const [tab, setTab] = useState<"drafts" | "explore" | "mine">("explore")
   const [mine, setMine] = useState<AuthoredScene[] | null>(null)
   const [mineFailed, setMineFailed] = useState(false)
+  const [drafts, setDrafts] = useState<DraftSummary[] | null>(null)
+  const [draftsFailed, setDraftsFailed] = useState(false)
+  const [busyDraftId, setBusyDraftId] = useState<string | null>(null)
   const [upvoted, setUpvoted] = useState<Set<string>>(new Set())
   const [sort, setSort] = useState<SceneSort>("popular")
   const [search, setSearch] = useState("")
@@ -119,6 +128,7 @@ export function CommunityModal({
     if (!session?.user) {
       setTab("explore")
       setMine(null)
+      setDrafts(null)
       setUpvoted(new Set())
     }
   }, [session?.user])
@@ -189,6 +199,27 @@ export function CommunityModal({
       cancelled = true
     }
   }, [open, session?.user])
+
+  const loadDrafts = useCallback(() => {
+    setDrafts(null)
+    setDraftsFailed(false)
+
+    return fetch("/api/community/me/drafts")
+      .then((res) => res.json() as Promise<{ drafts?: DraftSummary[] }>)
+      .then((data) => setDrafts(data.drafts ?? []))
+      .catch(() => {
+        setDrafts([])
+        setDraftsFailed(true)
+      })
+  }, [])
+
+  useEffect(() => {
+    if (!(open && session?.user && tab === "drafts")) {
+      return
+    }
+
+    void loadDrafts()
+  }, [loadDrafts, open, session?.user, tab])
 
   useEffect(() => {
     if (!open) {
@@ -276,6 +307,75 @@ export function CommunityModal({
     setConsentTitle(null)
     resolve?.(granted)
   }, [])
+
+  const openDraft = useCallback(
+    async (draft: DraftSummary) => {
+      setBusyDraftId(draft.id)
+      setError(null)
+
+      try {
+        const res = await fetch(draft.labUrl)
+
+        if (!res.ok) {
+          throw new Error("Could not load that draft.")
+        }
+
+        const projectFile = parseLabProjectFile(await res.text())
+
+        withAutosaveSuppressed(() => {
+          applyLabProjectFile(projectFile, useAssetStore.getState().assets)
+          useRemixOriginStore.getState().clearRemixOrigin()
+          useDraftStore.getState().setActiveDraft({
+            id: draft.id,
+            savedAt: draft.updatedAt,
+            title: draft.title,
+          })
+        })
+
+        requestAutosave()
+        onOpenChange(false)
+      } catch (cause) {
+        setError(
+          cause instanceof Error ? cause.message : "Could not load that draft."
+        )
+      } finally {
+        setBusyDraftId(null)
+      }
+    },
+    [onOpenChange]
+  )
+
+  const deleteDraft = useCallback(
+    async (draft: DraftSummary) => {
+      setBusyDraftId(draft.id)
+      setError(null)
+
+      try {
+        const res = await fetch(`/api/community/scenes/${draft.id}`, {
+          method: "DELETE",
+        })
+
+        if (!res.ok) {
+          throw new Error("Could not delete that draft.")
+        }
+
+        if (useDraftStore.getState().activeDraft?.id === draft.id) {
+          useDraftStore.getState().clearActiveDraft()
+        }
+
+        setDrafts((current) =>
+          (current ?? []).filter((entry) => entry.id !== draft.id)
+        )
+      } catch (cause) {
+        setError(
+          cause instanceof Error ? cause.message : "Could not delete that draft."
+        )
+      } finally {
+        setBusyDraftId(null)
+      }
+    },
+    []
+  )
 
   const remix = useCallback(
     async (scene: CommunitySceneDetail, options?: { auto?: boolean }) => {
@@ -663,6 +763,48 @@ export function CommunityModal({
 
                       {mine && mine.length > 0 ? (
                         <MyScenesGrid onSelect={openScene} scenes={mine} />
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {!(selected || selectedHandle) && tab === "drafts" ? (
+                    <div className="h-full overflow-y-auto p-4">
+                      {drafts === null && !error ? (
+                        <div className="grid grid-cols-2 gap-[var(--ds-space-4)] min-[720px]:grid-cols-4">
+                          {SKELETON_KEYS.slice(0, 4).map((key) => (
+                            <div
+                              className="flex animate-pulse flex-col gap-[var(--ds-space-2)]"
+                              key={key}
+                            >
+                              <div className="aspect-[16/10] w-full rounded-[8px] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)]" />
+                              <div className="h-[10px] w-3/5 rounded-[3px] bg-[var(--ds-color-surface-subtle)]" />
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+
+                      {drafts?.length === 0 ? (
+                        <div className="flex h-full flex-col items-center justify-center gap-[var(--ds-space-3)]">
+                          <Typography
+                            align="center"
+                            as="p"
+                            tone="tertiary"
+                            variant="caption"
+                          >
+                            {draftsFailed
+                              ? "Could not load your drafts."
+                              : "No drafts yet. Press \u2318S in the editor to save one."}
+                          </Typography>
+                        </div>
+                      ) : null}
+
+                      {drafts && drafts.length > 0 ? (
+                        <DraftsGrid
+                          busyId={busyDraftId}
+                          drafts={drafts}
+                          onDelete={deleteDraft}
+                          onOpen={openDraft}
+                        />
                       ) : null}
                     </div>
                   ) : null}

--- a/src/components/community/draft-card.tsx
+++ b/src/components/community/draft-card.tsx
@@ -2,6 +2,7 @@
 
 import { TrashIcon } from "@radix-ui/react-icons"
 import Image from "next/image"
+import { Button } from "@/components/ui/button"
 import { IconButton } from "@/components/ui/icon-button"
 import { Typography } from "@/components/ui/typography"
 import type { DraftSummary } from "@/lib/community/scenes"
@@ -43,11 +44,13 @@ export function DraftCard({
   draft,
   onDelete,
   onOpen,
+  onPublish,
 }: {
   busy: boolean
   draft: DraftSummary
   onDelete: (draft: DraftSummary) => void
   onOpen: (draft: DraftSummary) => void
+  onPublish: (draft: DraftSummary) => void
 }) {
   return (
     <div className="group relative flex flex-col gap-[var(--ds-space-2)]">
@@ -99,6 +102,25 @@ export function DraftCard({
           </Typography>
         </div>
       </button>
+
+      <div className="flex items-center gap-[var(--ds-space-2)] px-[2px]">
+        <Button
+          disabled={busy}
+          onClick={() => onPublish(draft)}
+          size="compact"
+          variant="primary"
+        >
+          Publish
+        </Button>
+        <Button
+          disabled={busy}
+          onClick={() => onOpen(draft)}
+          size="compact"
+          variant="secondary"
+        >
+          Open
+        </Button>
+      </div>
 
       <IconButton
         aria-label={`Delete ${draft.title}`}

--- a/src/components/community/draft-card.tsx
+++ b/src/components/community/draft-card.tsx
@@ -5,6 +5,7 @@ import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { IconButton } from "@/components/ui/icon-button"
 import { Typography } from "@/components/ui/typography"
+import { DEFAULT_DRAFT_TITLE } from "@/lib/community/upload-limits"
 import type { DraftSummary } from "@/lib/community/scenes"
 
 const RELATIVE_STEPS: readonly { label: string; ms: number }[] = [
@@ -60,7 +61,7 @@ export function DraftCard({
         onClick={() => onOpen(draft)}
         type="button"
       >
-        <div className="relative aspect-[16/10] w-full overflow-hidden rounded-[8px] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)] transition-[border-color] duration-160 ease-[var(--ease-out-cubic)] group-hover:border-[var(--ds-border-hover)]">
+        <div className="relative aspect-[16/10] w-full overflow-hidden rounded-[8px] bg-[var(--ds-color-surface-subtle)] outline-1 outline-[var(--ds-border-subtle)] outline-offset-2 outline-dashed transition-[outline-color] duration-160 ease-[var(--ease-out-cubic)] group-hover:outline-[var(--ds-border-hover)]">
           {draft.thumbnailUrl ? (
             <Image
               alt={draft.title}
@@ -81,22 +82,18 @@ export function DraftCard({
               </Typography>
             </span>
           )}
-
-          <div className="pointer-events-none absolute top-1.5 left-1.5 rounded-[var(--ds-radius-control)] border border-white/10 bg-[rgb(8_9_12_/_0.68)] px-1.5 py-[3px] backdrop-blur-[8px]">
-            <Typography as="span" tone="secondary" variant="monoXs">
-              draft
-            </Typography>
-          </div>
         </div>
 
         <div className="flex min-w-0 flex-col gap-[5px] px-[2px]">
-          <Typography
-            as="span"
-            className="overflow-hidden text-ellipsis whitespace-nowrap transition-colors duration-160 group-hover:text-white"
-            variant="label"
-          >
-            {draft.title}
-          </Typography>
+          {draft.title === DEFAULT_DRAFT_TITLE ? null : (
+            <Typography
+              as="span"
+              className="overflow-hidden text-ellipsis whitespace-nowrap transition-colors duration-160 group-hover:text-white"
+              variant="label"
+            >
+              {draft.title}
+            </Typography>
+          )}
           <Typography as="span" tone="tertiary" variant="caption">
             {describeSavedAt(draft.updatedAt)}
           </Typography>

--- a/src/components/community/draft-card.tsx
+++ b/src/components/community/draft-card.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { TrashIcon } from "@radix-ui/react-icons"
+import Image from "next/image"
+import { IconButton } from "@/components/ui/icon-button"
+import { Typography } from "@/components/ui/typography"
+import type { DraftSummary } from "@/lib/community/scenes"
+
+const RELATIVE_STEPS: readonly { label: string; ms: number }[] = [
+  { label: "day", ms: 86_400_000 },
+  { label: "hour", ms: 3_600_000 },
+  { label: "minute", ms: 60_000 },
+]
+
+export function describeSavedAt(updatedAt: string, now = Date.now()): string {
+  const elapsed = now - new Date(updatedAt).getTime()
+
+  if (!Number.isFinite(elapsed) || elapsed < 60_000) {
+    return "Saved just now"
+  }
+
+  for (const step of RELATIVE_STEPS) {
+    const count = Math.floor(elapsed / step.ms)
+
+    if (count >= 1) {
+      return `Saved ${count} ${step.label}${count === 1 ? "" : "s"} ago`
+    }
+  }
+
+  return "Saved just now"
+}
+
+export function describeDraftContents(draft: DraftSummary): string {
+  if (draft.layerTypes.length === 0) {
+    return "Empty scene"
+  }
+
+  return draft.layerTypes.slice(0, 3).join(", ")
+}
+
+export function DraftCard({
+  busy,
+  draft,
+  onDelete,
+  onOpen,
+}: {
+  busy: boolean
+  draft: DraftSummary
+  onDelete: (draft: DraftSummary) => void
+  onOpen: (draft: DraftSummary) => void
+}) {
+  return (
+    <div className="group relative flex flex-col gap-[var(--ds-space-2)]">
+      <button
+        className="flex w-full cursor-pointer flex-col gap-[var(--ds-space-2)] rounded-[10px] text-left focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--ds-border-active)] focus-visible:outline-offset-2 disabled:cursor-wait"
+        disabled={busy}
+        onClick={() => onOpen(draft)}
+        type="button"
+      >
+        <div className="relative aspect-[16/10] w-full overflow-hidden rounded-[8px] border border-[var(--ds-border-subtle)] bg-[var(--ds-color-surface-subtle)] transition-[border-color] duration-160 ease-[var(--ease-out-cubic)] group-hover:border-[var(--ds-border-hover)]">
+          {draft.thumbnailUrl ? (
+            <Image
+              alt={draft.title}
+              className="object-cover"
+              fill
+              sizes="(max-width: 900px) 45vw, 260px"
+              src={draft.thumbnailUrl}
+            />
+          ) : (
+            <span className="absolute inset-0 flex items-center justify-center px-3">
+              <Typography
+                align="center"
+                as="span"
+                tone="tertiary"
+                variant="monoXs"
+              >
+                {describeDraftContents(draft)}
+              </Typography>
+            </span>
+          )}
+
+          <div className="pointer-events-none absolute top-1.5 left-1.5 rounded-[var(--ds-radius-control)] border border-white/10 bg-[rgb(8_9_12_/_0.68)] px-1.5 py-[3px] backdrop-blur-[8px]">
+            <Typography as="span" tone="secondary" variant="monoXs">
+              draft
+            </Typography>
+          </div>
+        </div>
+
+        <div className="flex min-w-0 flex-col gap-[5px] px-[2px]">
+          <Typography
+            as="span"
+            className="overflow-hidden text-ellipsis whitespace-nowrap transition-colors duration-160 group-hover:text-white"
+            variant="label"
+          >
+            {draft.title}
+          </Typography>
+          <Typography as="span" tone="tertiary" variant="caption">
+            {describeSavedAt(draft.updatedAt)}
+          </Typography>
+        </div>
+      </button>
+
+      <IconButton
+        aria-label={`Delete ${draft.title}`}
+        className="absolute top-1.5 right-1.5 h-7 w-7 opacity-0 transition-opacity duration-160 focus-visible:opacity-100 group-hover:opacity-100"
+        disabled={busy}
+        onClick={() => onDelete(draft)}
+        variant="default"
+      >
+        <TrashIcon height={14} width={14} />
+      </IconButton>
+    </div>
+  )
+}

--- a/src/components/community/drafts-grid.tsx
+++ b/src/components/community/drafts-grid.tsx
@@ -8,11 +8,13 @@ export function DraftsGrid({
   drafts,
   onDelete,
   onOpen,
+  onPublish,
 }: {
   busyId: string | null
   drafts: DraftSummary[]
   onDelete: (draft: DraftSummary) => void
   onOpen: (draft: DraftSummary) => void
+  onPublish: (draft: DraftSummary) => void
 }) {
   return (
     <div className="grid grid-cols-2 gap-[var(--ds-space-4)] min-[720px]:grid-cols-4">
@@ -23,6 +25,7 @@ export function DraftsGrid({
           key={draft.id}
           onDelete={onDelete}
           onOpen={onOpen}
+          onPublish={onPublish}
         />
       ))}
     </div>

--- a/src/components/community/drafts-grid.tsx
+++ b/src/components/community/drafts-grid.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { DraftCard } from "@/components/community/draft-card"
+import type { DraftSummary } from "@/lib/community/scenes"
+
+export function DraftsGrid({
+  busyId,
+  drafts,
+  onDelete,
+  onOpen,
+}: {
+  busyId: string | null
+  drafts: DraftSummary[]
+  onDelete: (draft: DraftSummary) => void
+  onOpen: (draft: DraftSummary) => void
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-[var(--ds-space-4)] min-[720px]:grid-cols-4">
+      {drafts.map((draft) => (
+        <DraftCard
+          busy={busyId === draft.id}
+          draft={draft}
+          key={draft.id}
+          onDelete={onDelete}
+          onOpen={onOpen}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/editor/autosave-mount.tsx
+++ b/src/components/editor/autosave-mount.tsx
@@ -3,6 +3,7 @@
 import { Cross2Icon } from "@radix-ui/react-icons"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 import { useCallback, useEffect, useRef, useState } from "react"
+import { useBottomOffsetAboveTimeline } from "@/components/editor/use-bottom-offset-above-timeline"
 import { Button } from "@/components/ui/button"
 import { GlassPanel } from "@/components/ui/glass-panel"
 import { IconButton } from "@/components/ui/icon-button"
@@ -53,59 +54,11 @@ import {
 import { getRequestedSceneSlug } from "@/lib/editor/requested-scene-slug"
 import { useAssetStore } from "@/store/asset-store"
 import { useAudioStore } from "@/store/audio-store"
+import { useDraftStore } from "@/store/draft-store"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
 import { useRemixOriginStore } from "@/store/remix-origin-store"
 import { useTimelineStore } from "@/store/timeline-store"
-
-const PILL_GAP_PX = 10
-const PILL_FALLBACK_BOTTOM_PX = 68
-
-function useBottomOffsetAboveTimeline(active: boolean): number {
-  const [offset, setOffset] = useState(PILL_FALLBACK_BOTTOM_PX)
-
-  useEffect(() => {
-    if (!active) {
-      return
-    }
-
-    const shell = document.querySelector("[data-timeline-shell]")
-
-    const measure = () => {
-      if (!shell) {
-        setOffset(PILL_FALLBACK_BOTTOM_PX)
-
-        return
-      }
-
-      const rect = shell.getBoundingClientRect()
-
-      setOffset(
-        Math.max(
-          PILL_GAP_PX,
-          Math.round(window.innerHeight - rect.top + PILL_GAP_PX)
-        )
-      )
-    }
-
-    measure()
-
-    const observer = shell ? new ResizeObserver(measure) : null
-
-    if (shell && observer) {
-      observer.observe(shell)
-    }
-
-    window.addEventListener("resize", measure)
-
-    return () => {
-      observer?.disconnect()
-      window.removeEventListener("resize", measure)
-    }
-  }, [active])
-
-  return offset
-}
 
 function whenIdle(run: () => void): void {
   const idle = (
@@ -169,7 +122,12 @@ export function AutosaveMount() {
 
     const projectFile = buildLabProjectFile()
     const remixOrigin = useRemixOriginStore.getState().origin
-    const signature = buildAutosaveSignature({ projectFile, remixOrigin })
+    const activeDraft = useDraftStore.getState().activeDraft
+    const signature = buildAutosaveSignature({
+      activeDraft,
+      projectFile,
+      remixOrigin,
+    })
 
     if (signature === signatureRef.current) {
       return
@@ -177,13 +135,15 @@ export function AutosaveMount() {
 
     signatureRef.current = signature
 
-    const write = saveAutosaveRecord({ projectFile, remixOrigin }).then(
-      (written) => {
-        if (written) {
-          whenIdle(collectStoredAssetGarbage)
-        }
+    const write = saveAutosaveRecord({
+      activeDraft,
+      projectFile,
+      remixOrigin,
+    }).then((written) => {
+      if (written) {
+        whenIdle(collectStoredAssetGarbage)
       }
-    )
+    })
 
     pendingWriteRef.current = write
 
@@ -284,9 +244,16 @@ export function AutosaveMount() {
           if (candidate.remixOrigin) {
             useRemixOriginStore.getState().setRemixOrigin(candidate.remixOrigin)
           }
+
+          // Without this every save after a refresh would mint a new draft row
+          // and re-upload every asset.
+          if (candidate.activeDraft) {
+            useDraftStore.getState().setActiveDraft(candidate.activeDraft)
+          }
         })
 
         signatureRef.current = buildAutosaveSignature({
+          activeDraft: candidate.activeDraft,
           projectFile: candidate.projectFile,
           remixOrigin: candidate.remixOrigin,
         })
@@ -382,6 +349,11 @@ export function AutosaveMount() {
           request()
         }
       }),
+      useDraftStore.subscribe((state, previous) => {
+        if (state.activeDraft !== previous.activeDraft) {
+          request()
+        }
+      }),
     ]
 
     return () => {
@@ -420,6 +392,7 @@ export function AutosaveMount() {
         useAssetStore.getState().assets
       )
       useRemixOriginStore.getState().clearRemixOrigin()
+      useDraftStore.getState().clearActiveDraft()
     })
 
     signatureRef.current = null

--- a/src/components/editor/autosave-mount.tsx
+++ b/src/components/editor/autosave-mount.tsx
@@ -194,8 +194,6 @@ export function AutosaveMount() {
         return
       }
 
-      // The editor is usable before this lookup finishes. Anything typed in that
-      // window is real work and outranks the record on disk.
       if (editedBeforeReadyRef.current) {
         readyRef.current = true
         scheduler.request()
@@ -214,8 +212,6 @@ export function AutosaveMount() {
           return
         }
 
-        // Re-checked here rather than only before the read: reading the blobs is
-        // a second gap in which someone can start working.
         if (editedBeforeReadyRef.current) {
           readyRef.current = true
           scheduler.request()
@@ -245,8 +241,6 @@ export function AutosaveMount() {
             useRemixOriginStore.getState().setRemixOrigin(candidate.remixOrigin)
           }
 
-          // Without this every save after a refresh would mint a new draft row
-          // and re-upload every asset.
           if (candidate.activeDraft) {
             useDraftStore.getState().setActiveDraft(candidate.activeDraft)
           }
@@ -403,7 +397,6 @@ export function AutosaveMount() {
 
     void forgetOwnAutosaveRecord()
 
-    // The discarded scene lives under the session that wrote it, not this one.
     if (restoredFrom) {
       void forgetAutosaveRecord(restoredFrom)
     }

--- a/src/components/editor/draft-save-mount.tsx
+++ b/src/components/editor/draft-save-mount.tsx
@@ -8,6 +8,7 @@ import { GlassPanel } from "@/components/ui/glass-panel"
 import { IconButton } from "@/components/ui/icon-button"
 import { Typography } from "@/components/ui/typography"
 import { authClient } from "@/lib/auth/client"
+import { DEFAULT_DRAFT_TITLE } from "@/lib/community/upload-limits"
 import {
   type DraftSaveRequest,
   registerDraftSaver,
@@ -63,7 +64,13 @@ export function DraftSaveMount() {
                 message: `${saved}. ${result.skipped.join(", ")} ${result.skipped.length === 1 ? "was" : "were"} too large to upload.`,
                 tone: "error",
               }
-            : { message: `${saved} · ${result.title}`, tone: "success" }
+            : {
+                message:
+                  result.title === DEFAULT_DRAFT_TITLE
+                    ? saved
+                    : `${saved} · ${result.title}`,
+                tone: "success",
+              }
         )
       } catch (cause) {
         setNotice({

--- a/src/components/editor/draft-save-mount.tsx
+++ b/src/components/editor/draft-save-mount.tsx
@@ -8,7 +8,10 @@ import { GlassPanel } from "@/components/ui/glass-panel"
 import { IconButton } from "@/components/ui/icon-button"
 import { Typography } from "@/components/ui/typography"
 import { authClient } from "@/lib/auth/client"
-import { registerDraftSaver } from "@/lib/editor/draft-save-bus"
+import {
+  type DraftSaveRequest,
+  registerDraftSaver,
+} from "@/lib/editor/draft-save-bus"
 
 const SAVED_PILL_MS = 2500
 const MESSAGE_PILL_MS = 6000
@@ -26,48 +29,59 @@ export function DraftSaveMount() {
   const savingRef = useRef(false)
   const signedIn = Boolean(session?.user)
 
-  const save = useCallback(async () => {
-    if (!signedIn) {
+  const save = useCallback(
+    async (request: DraftSaveRequest) => {
+      if (!signedIn) {
+        setNotice({
+          message: "Sign in to save this draft to your account.",
+          tone: "notice",
+        })
+
+        return
+      }
+
+      if (savingRef.current) {
+        return
+      }
+
+      savingRef.current = true
       setNotice({
-        message: "Sign in to save this draft to your account.",
-        tone: "notice",
+        message: request.asNewDraft ? "Saving a new draft…" : "Saving draft…",
+        tone: "progress",
       })
 
-      return
-    }
+      try {
+        const { saveDraft } = await import("@/lib/community/publish-client")
+        const result = await saveDraft({
+          asNewDraft: Boolean(request.asNewDraft),
+        })
+        const saved = result.created ? "New draft saved" : "Draft saved"
 
-    if (savingRef.current) {
-      return
-    }
-
-    savingRef.current = true
-    setNotice({ message: "Saving draft…", tone: "progress" })
-
-    try {
-      const { saveDraft } = await import("@/lib/community/publish-client")
-      const result = await saveDraft()
-
-      setNotice(
-        result.skipped.length > 0
-          ? {
-              message: `Draft saved. ${result.skipped.join(", ")} ${result.skipped.length === 1 ? "was" : "were"} too large to upload.`,
-              tone: "error",
-            }
-          : { message: "Draft saved", tone: "success" }
-      )
-    } catch (cause) {
-      setNotice({
-        message:
-          cause instanceof Error ? cause.message : "Could not save this draft.",
-        tone: "error",
-      })
-    } finally {
-      savingRef.current = false
-    }
-  }, [signedIn])
+        setNotice(
+          result.skipped.length > 0
+            ? {
+                message: `${saved}. ${result.skipped.join(", ")} ${result.skipped.length === 1 ? "was" : "were"} too large to upload.`,
+                tone: "error",
+              }
+            : { message: `${saved} · ${result.title}`, tone: "success" }
+        )
+      } catch (cause) {
+        setNotice({
+          message:
+            cause instanceof Error
+              ? cause.message
+              : "Could not save this draft.",
+          tone: "error",
+        })
+      } finally {
+        savingRef.current = false
+      }
+    },
+    [signedIn]
+  )
 
   useEffect(() => {
-    registerDraftSaver(() => void save())
+    registerDraftSaver((request) => void save(request))
 
     return () => registerDraftSaver(null)
   }, [save])

--- a/src/components/editor/draft-save-mount.tsx
+++ b/src/components/editor/draft-save-mount.tsx
@@ -36,7 +36,6 @@ export function DraftSaveMount() {
       return
     }
 
-    // Mashing the shortcut must not start a second upload of the same media.
     if (savingRef.current) {
       return
     }

--- a/src/components/editor/draft-save-mount.tsx
+++ b/src/components/editor/draft-save-mount.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { Cross2Icon } from "@radix-ui/react-icons"
+import { AnimatePresence, motion, useReducedMotion } from "motion/react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useBottomOffsetAboveTimeline } from "@/components/editor/use-bottom-offset-above-timeline"
+import { GlassPanel } from "@/components/ui/glass-panel"
+import { IconButton } from "@/components/ui/icon-button"
+import { Typography } from "@/components/ui/typography"
+import { authClient } from "@/lib/auth/client"
+import { registerDraftSaver } from "@/lib/editor/draft-save-bus"
+
+const SAVED_PILL_MS = 2500
+const MESSAGE_PILL_MS = 6000
+
+interface Notice {
+  message: string
+  tone: "error" | "notice" | "progress" | "success"
+}
+
+export function DraftSaveMount() {
+  const reduceMotion = useReducedMotion() ?? false
+  const { data: session } = authClient.useSession()
+  const [notice, setNotice] = useState<Notice | null>(null)
+  const pillBottom = useBottomOffsetAboveTimeline(notice !== null)
+  const savingRef = useRef(false)
+  const signedIn = Boolean(session?.user)
+
+  const save = useCallback(async () => {
+    if (!signedIn) {
+      setNotice({
+        message: "Sign in to save this draft to your account.",
+        tone: "notice",
+      })
+
+      return
+    }
+
+    // Mashing the shortcut must not start a second upload of the same media.
+    if (savingRef.current) {
+      return
+    }
+
+    savingRef.current = true
+    setNotice({ message: "Saving draft…", tone: "progress" })
+
+    try {
+      const { saveDraft } = await import("@/lib/community/publish-client")
+      const result = await saveDraft()
+
+      setNotice(
+        result.skipped.length > 0
+          ? {
+              message: `Draft saved. ${result.skipped.join(", ")} ${result.skipped.length === 1 ? "was" : "were"} too large to upload.`,
+              tone: "error",
+            }
+          : { message: "Draft saved", tone: "success" }
+      )
+    } catch (cause) {
+      setNotice({
+        message:
+          cause instanceof Error ? cause.message : "Could not save this draft.",
+        tone: "error",
+      })
+    } finally {
+      savingRef.current = false
+    }
+  }, [signedIn])
+
+  useEffect(() => {
+    registerDraftSaver(() => void save())
+
+    return () => registerDraftSaver(null)
+  }, [save])
+
+  useEffect(() => {
+    if (!notice || notice.tone === "progress") {
+      return
+    }
+
+    const timer = window.setTimeout(
+      () => setNotice(null),
+      notice.tone === "success" ? SAVED_PILL_MS : MESSAGE_PILL_MS
+    )
+
+    return () => window.clearTimeout(timer)
+  }, [notice])
+
+  return (
+    <AnimatePresence initial={false}>
+      {notice ? (
+        <motion.div
+          animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+          className="pointer-events-none fixed left-1/2 z-95 -translate-x-1/2"
+          exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+          initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+          style={{ bottom: pillBottom }}
+          transition={
+            reduceMotion
+              ? { duration: 0.12, ease: "easeOut" }
+              : { duration: 0.22, ease: [0.22, 1, 0.36, 1] }
+          }
+        >
+          <GlassPanel
+            className="pointer-events-auto flex items-center gap-[var(--ds-space-2)] py-1.5 pr-1.5 pl-3"
+            variant="panel"
+          >
+            <Typography
+              as="span"
+              tone={notice.tone === "error" ? "primary" : "secondary"}
+              variant="caption"
+            >
+              {notice.message}
+            </Typography>
+            <IconButton
+              aria-label="Dismiss draft notice"
+              className="h-7 w-7"
+              onClick={() => setNotice(null)}
+              variant="default"
+            >
+              <Cross2Icon height={16} width={16} />
+            </IconButton>
+          </GlassPanel>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  )
+}

--- a/src/components/editor/editor-export-dialog.tsx
+++ b/src/components/editor/editor-export-dialog.tsx
@@ -855,8 +855,6 @@ export function EditorExportDialog({
       }
 
       const result = withAutosaveSuppressed(() => {
-        // An imported file is a different scene, so it must not save over the
-        // draft that was open before.
         useDraftStore.getState().clearActiveDraft()
 
         return applyLabProjectFile(projectFile, useAssetStore.getState().assets)

--- a/src/components/editor/editor-export-dialog.tsx
+++ b/src/components/editor/editor-export-dialog.tsx
@@ -66,6 +66,7 @@ import {
   type AudioAnalysisStatus,
   selectAudioModulationInput,
 } from "@/store/audio-store"
+import { useDraftStore } from "@/store/draft-store"
 import {
   useAssetStore,
   useAudioStore,
@@ -853,9 +854,13 @@ export function EditorExportDialog({
         return
       }
 
-      const result = withAutosaveSuppressed(() =>
-        applyLabProjectFile(projectFile, useAssetStore.getState().assets)
-      )
+      const result = withAutosaveSuppressed(() => {
+        // An imported file is a different scene, so it must not save over the
+        // draft that was open before.
+        useDraftStore.getState().clearActiveDraft()
+
+        return applyLabProjectFile(projectFile, useAssetStore.getState().assets)
+      })
 
       requestAutosave()
 

--- a/src/components/editor/editor-shortcuts.tsx
+++ b/src/components/editor/editor-shortcuts.tsx
@@ -31,11 +31,11 @@ export function EditorShortcuts() {
 
     if (
       (event.metaKey || event.ctrlKey) &&
-      !(event.altKey || event.shiftKey) &&
+      !event.altKey &&
       event.key.toLowerCase() === "s"
     ) {
       event.preventDefault()
-      requestDraftSave()
+      requestDraftSave({ asNewDraft: event.shiftKey })
 
       return
     }

--- a/src/components/editor/editor-shortcuts.tsx
+++ b/src/components/editor/editor-shortcuts.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useEffectEvent } from "react"
 import { playUISound } from "@/lib/audio/shader-lab-sounds"
+import { requestDraftSave } from "@/lib/editor/draft-save-bus"
 import { isEditableTarget } from "@/lib/editor/is-editable-target"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
@@ -25,6 +26,19 @@ export function EditorShortcuts() {
 
   const handleKeyDown = useEffectEvent((event: KeyboardEvent) => {
     if (isEditableTarget(event.target)) {
+      return
+    }
+
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      !(event.altKey || event.shiftKey) &&
+      event.key.toLowerCase() === "s"
+    ) {
+      // The browser reads this as "save page", which is never what someone in an
+      // editor meant by it.
+      event.preventDefault()
+      requestDraftSave()
+
       return
     }
 

--- a/src/components/editor/editor-shortcuts.tsx
+++ b/src/components/editor/editor-shortcuts.tsx
@@ -34,8 +34,6 @@ export function EditorShortcuts() {
       !(event.altKey || event.shiftKey) &&
       event.key.toLowerCase() === "s"
     ) {
-      // The browser reads this as "save page", which is never what someone in an
-      // editor meant by it.
       event.preventDefault()
       requestDraftSave()
 

--- a/src/components/editor/use-bottom-offset-above-timeline.ts
+++ b/src/components/editor/use-bottom-offset-above-timeline.ts
@@ -1,0 +1,52 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+const PILL_GAP_PX = 10
+const PILL_FALLBACK_BOTTOM_PX = 68
+
+export function useBottomOffsetAboveTimeline(active: boolean): number {
+  const [offset, setOffset] = useState(PILL_FALLBACK_BOTTOM_PX)
+
+  useEffect(() => {
+    if (!active) {
+      return
+    }
+
+    const shell = document.querySelector("[data-timeline-shell]")
+
+    const measure = () => {
+      if (!shell) {
+        setOffset(PILL_FALLBACK_BOTTOM_PX)
+
+        return
+      }
+
+      const rect = shell.getBoundingClientRect()
+
+      setOffset(
+        Math.max(
+          PILL_GAP_PX,
+          Math.round(window.innerHeight - rect.top + PILL_GAP_PX)
+        )
+      )
+    }
+
+    measure()
+
+    const observer = shell ? new ResizeObserver(measure) : null
+
+    if (shell && observer) {
+      observer.observe(shell)
+    }
+
+    window.addEventListener("resize", measure)
+
+    return () => {
+      observer?.disconnect()
+      window.removeEventListener("resize", measure)
+    }
+  }, [active])
+
+  return offset
+}

--- a/src/components/pages/shader-lab-page.tsx
+++ b/src/components/pages/shader-lab-page.tsx
@@ -1,5 +1,6 @@
 import { AgentBridgeMount } from "@/components/editor/agent-bridge-mount"
 import { AutosaveMount } from "@/components/editor/autosave-mount"
+import { DraftSaveMount } from "@/components/editor/draft-save-mount"
 import { EditorCanvasViewport } from "@/components/editor/editor-canvas-viewport"
 import { MobileEditorDock } from "@/components/editor/mobile-editor-dock"
 import { EditorShortcuts } from "@/components/editor/editor-shortcuts"
@@ -16,6 +17,7 @@ export function ShaderLabPage() {
     >
       <AgentBridgeMount />
       <AutosaveMount />
+      <DraftSaveMount />
       <EditorShortcuts />
       <EditorCanvasViewport />
       <EditorTimelineOverlay />

--- a/src/components/ui/tooltip/index.tsx
+++ b/src/components/ui/tooltip/index.tsx
@@ -45,7 +45,7 @@ export function HoverTooltip({
       <Tooltip.Portal>
         <Tooltip.Positioner
           align={align}
-          className="z-[80]"
+          className="z-[100]"
           side={side}
           sideOffset={sideOffset}
         >

--- a/src/lib/community/__tests__/publish.test.ts
+++ b/src/lib/community/__tests__/publish.test.ts
@@ -2,10 +2,14 @@ import { afterEach, describe, expect, test } from "bun:test"
 import {
   buildSceneSlug,
   dayBucket,
+  decideQuota,
   MAX_DESCRIPTION_LENGTH,
+  MAX_SCENES_PER_DAY,
   MAX_TITLE_LENGTH,
+  MAX_TOTAL_BYTES,
   normalizeDescription,
   normalizeTitle,
+  validateDraftPayload,
   validateProjectFilePayload,
 } from "@/lib/community/publish"
 
@@ -15,31 +19,29 @@ afterEach(() => {
   delete process.env[HOSTS_ENV]
 })
 
-function labFile(assets: unknown[] = []) {
+function labFile(assets: unknown[] = [], layerCount = 1) {
   return JSON.stringify({
     assets,
     composition: { height: 800, width: 1200 },
     format: "shader-lab",
-    layers: [
-      {
-        assetId: null,
-        blendMode: "normal",
-        compositeMode: "filter",
-        expanded: true,
-        hue: 0,
-        id: "layer-1",
-        kind: "source",
-        locked: false,
-        maskConfig: { invert: false, mode: "multiply", source: "luminance" },
-        name: "Gradient",
-        opacity: 1,
-        params: {},
-        runtimeError: null,
-        saturation: 1,
-        type: "gradient",
-        visible: true,
-      },
-    ],
+    layers: Array.from({ length: layerCount }, (_unused, index) => ({
+      assetId: null,
+      blendMode: "normal",
+      compositeMode: "filter",
+      expanded: true,
+      hue: 0,
+      id: `layer-${index + 1}`,
+      kind: "source",
+      locked: false,
+      maskConfig: { invert: false, mode: "multiply", source: "luminance" },
+      name: "Gradient",
+      opacity: 1,
+      params: {},
+      runtimeError: null,
+      saturation: 1,
+      type: "gradient",
+      visible: true,
+    })),
     selectedLayerId: null,
     timeline: { duration: 6, loop: true, tracks: [] },
     version: 5,
@@ -164,5 +166,149 @@ describe("validateProjectFilePayload", () => {
     expect(() => validateProjectFilePayload("x".repeat(9 * 1024 * 1024))).toThrow(
       /too large/
     )
+  })
+})
+
+describe("validateDraftPayload", () => {
+  test("accepts a scene with no layers at all", () => {
+    const result = validateDraftPayload(labFile([], 0))
+
+    expect(result.layerTypes).toEqual([])
+    expect(result.projectFile.layers).toEqual([])
+  })
+
+  test("keeps an asset that was uploaded", () => {
+    process.env[HOSTS_ENV] = "pub-abc.r2.dev"
+
+    const result = validateDraftPayload(
+      labFile([
+        {
+          fileName: "photo.png",
+          id: "a1",
+          kind: "image",
+          url: "https://pub-abc.r2.dev/scenes/x/hash.png",
+        },
+      ])
+    )
+
+    expect(result.projectFile.assets.map((asset) => asset.id)).toEqual(["a1"])
+  })
+
+  test("drops an asset that has no url rather than refusing to save", () => {
+    const result = validateDraftPayload(
+      labFile([{ fileName: "photo.png", id: "a1", kind: "image" }])
+    )
+
+    expect(result.projectFile.assets).toEqual([])
+  })
+
+  test("still refuses a url pointing at an untrusted host", () => {
+    expect(() =>
+      validateDraftPayload(
+        labFile([
+          {
+            fileName: "photo.png",
+            id: "a1",
+            kind: "image",
+            url: "https://evil.test/photo.png",
+          },
+        ])
+      )
+    ).toThrow(/untrusted host/)
+  })
+
+  test("still refuses an oversized payload", () => {
+    expect(() => validateDraftPayload("x".repeat(9 * 1024 * 1024))).toThrow(
+      /too large/
+    )
+  })
+
+  test("still refuses something that is not a project file", () => {
+    expect(() => validateDraftPayload("{}")).toThrow()
+  })
+})
+
+describe("decideQuota", () => {
+  const bucket = "2026-08-17"
+
+  test("allows a first write with no row yet", () => {
+    expect(
+      decideQuota({ addScene: true, bucket, bytes: 1024, current: null }).ok
+    ).toBe(true)
+  })
+
+  test("a draft save is not blocked by the daily scene cap", () => {
+    const current = {
+      bytesUsed: 0,
+      dayBucket: bucket,
+      scenesToday: MAX_SCENES_PER_DAY,
+    }
+
+    expect(decideQuota({ addScene: false, bucket, bytes: 1024, current }).ok).toBe(
+      true
+    )
+    expect(decideQuota({ addScene: true, bucket, bytes: 1024, current }).ok).toBe(
+      false
+    )
+  })
+
+  test("the daily scene cap resets when the bucket rolls over", () => {
+    const current = {
+      bytesUsed: 0,
+      dayBucket: "2026-08-16",
+      scenesToday: MAX_SCENES_PER_DAY,
+    }
+
+    expect(decideQuota({ addScene: true, bucket, bytes: 0, current }).ok).toBe(
+      true
+    )
+  })
+
+  test("the byte cap applies to drafts too, and does not reset daily", () => {
+    const current = {
+      bytesUsed: MAX_TOTAL_BYTES,
+      dayBucket: "2026-08-16",
+      scenesToday: 0,
+    }
+
+    const decision = decideQuota({
+      addScene: false,
+      bucket,
+      bytes: 1,
+      current,
+    })
+
+    expect(decision.ok).toBe(false)
+    expect(decision.reason).toMatch(/storage limit/)
+  })
+
+  test("allows a write that lands exactly on the byte cap", () => {
+    expect(
+      decideQuota({
+        addScene: false,
+        bucket,
+        bytes: 1024,
+        current: {
+          bytesUsed: MAX_TOTAL_BYTES - 1024,
+          dayBucket: bucket,
+          scenesToday: 0,
+        },
+      }).ok
+    ).toBe(true)
+  })
+
+  test("reports the scene cap before the byte cap", () => {
+    const decision = decideQuota({
+      addScene: true,
+      bucket,
+      bytes: MAX_TOTAL_BYTES * 2,
+      current: {
+        bytesUsed: MAX_TOTAL_BYTES,
+        dayBucket: bucket,
+        scenesToday: MAX_SCENES_PER_DAY,
+      },
+    })
+
+    expect(decision.reason).toMatch(/scenes today/)
   })
 })

--- a/src/lib/community/handle-rename.ts
+++ b/src/lib/community/handle-rename.ts
@@ -159,11 +159,6 @@ async function claimHandleAtomically(input: {
   const cutoff = new Date(input.now.getTime() - HANDLE_RENAME_COOLDOWN_MS)
   const db = getDatabase()
 
-  // A conditional update of one row is the only thing Postgres serialises for
-  // us here: concurrent writers block on the row and re-evaluate the predicate,
-  // so exactly one can win. Counting claims in a subquery would not, because
-  // each statement reads its own snapshot and two different target handles
-  // would both pass.
   const won = await db
     .update(profiles)
     .set({ handle: input.handle, handleRenamedAt: input.now, updatedAt: input.now })

--- a/src/lib/community/moderation.ts
+++ b/src/lib/community/moderation.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, ne, sql } from "drizzle-orm"
+import { and, desc, eq, inArray, isNull, ne, sql } from "drizzle-orm"
 import { nanoid } from "nanoid"
 import type { CommunitySession } from "@/lib/auth/server"
 import { isAdminEmail } from "@/lib/community/config"
@@ -75,7 +75,7 @@ async function collectDeletableKeys(sceneId: string): Promise<{
         and(
           eq(sceneAssets.url, asset.url),
           ne(sceneAssets.sceneId, sceneId),
-          eq(scenes.status, "published"),
+          inArray(scenes.status, ["draft", "processing", "published"]),
           isNull(scenes.deletedAt)
         )
       )

--- a/src/lib/community/moderation.ts
+++ b/src/lib/community/moderation.ts
@@ -47,6 +47,12 @@ async function collectDeletableKeys(sceneId: string): Promise<{
     deletable.push(scene.labKey)
   }
 
+  const draftKey = `${ownPrefix}/draft.lab.json`
+
+  if (scene && !deletable.includes(draftKey)) {
+    deletable.push(draftKey)
+  }
+
   const thumbnailKey = scene?.thumbnailImageId
     ? keyFromPublicUrl(scene.thumbnailImageId)
     : null

--- a/src/lib/community/profile.ts
+++ b/src/lib/community/profile.ts
@@ -65,8 +65,6 @@ const RETURNING = {
   userId: profiles.userId,
 }
 
-// A profile written before handles were being claimed has no row here, which
-// would leave its handle unprotected and unable to redirect after a rename.
 async function backfillMissingClaim(
   profile: CommunityProfile
 ): Promise<void> {

--- a/src/lib/community/publish-client.ts
+++ b/src/lib/community/publish-client.ts
@@ -414,8 +414,11 @@ export async function publishScene(input: {
     })
   )
 
+  const activeDraft = useDraftStore.getState().activeDraft
+
   const draftResponse = await fetch("/api/community/drafts", {
     body: JSON.stringify({
+      draftId: activeDraft?.id ?? null,
       uploads: [
         {
           contentLength: thumbnailBytes.byteLength,
@@ -511,6 +514,7 @@ export async function publishScene(input: {
   }
 
   useRemixOriginStore.getState().clearRemixOrigin()
+  useDraftStore.getState().clearActiveDraft()
 
   return { slug: published.scene.slug }
 }

--- a/src/lib/community/publish-client.ts
+++ b/src/lib/community/publish-client.ts
@@ -6,7 +6,9 @@ import {
   type LabProjectFile,
 } from "@/lib/editor/project-file"
 import { useAssetStore } from "@/store/asset-store"
+import { useDraftStore } from "@/store/draft-store"
 import { useRemixOriginStore } from "@/store/remix-origin-store"
+import { useTimelineStore } from "@/store/timeline-store"
 import type { EditorAsset, PresetAssetReference } from "@/types/editor"
 
 export const THUMBNAIL_MAX_TIME_SECONDS = 10
@@ -18,11 +20,12 @@ export interface PublishResult {
 }
 
 interface UploadTarget {
+  alreadyStored?: boolean
   contentType: string
   key: string
   publicUrl: string
   sha256: string
-  uploadUrl: string
+  uploadUrl?: string
 }
 
 export function getThumbnailTimeBounds(duration: number): {
@@ -69,6 +72,14 @@ async function readLocalAssetBytes(url: string): Promise<ArrayBuffer> {
 }
 
 async function upload(target: UploadTarget, bytes: ArrayBuffer): Promise<void> {
+  if (target.alreadyStored) {
+    return
+  }
+
+  if (!target.uploadUrl) {
+    throw new Error("Could not prepare one of the media uploads.")
+  }
+
   const response = await fetch(target.uploadUrl, {
     body: bytes,
     headers: {
@@ -141,6 +152,201 @@ function inspectScene(options: { prune: boolean }): {
 
 export function describePublishPlan(): PublishPlan {
   return inspectScene({ prune: true }).plan
+}
+
+export interface SaveDraftResult {
+  id: string
+  savedAt: string | null
+  skipped: string[]
+  title: string
+}
+
+interface StoredUpload {
+  sha256: string
+  url: string
+}
+
+// Reading and hashing a 100 MB video costs the same whether or not anything
+// changed, so what a draft already holds is remembered for the session. Keyed by
+// draft as well as asset, because the url points inside one draft's prefix.
+const storedUploads = new Map<string, StoredUpload>()
+
+function storedKey(draftId: string, assetId: string): string {
+  return `${draftId}:${assetId}`
+}
+
+async function readDraftUploads(input: {
+  draftId: string | null
+  localAssets: EditorAsset[]
+}): Promise<{
+  known: Map<string, StoredUpload>
+  pending: { asset: EditorAsset; bytes: ArrayBuffer; sha256: string }[]
+  skipped: string[]
+}> {
+  const known = new Map<string, StoredUpload>()
+  const pending: { asset: EditorAsset; bytes: ArrayBuffer; sha256: string }[] =
+    []
+  const skipped: string[] = []
+
+  for (const asset of input.localAssets) {
+    const cached = input.draftId
+      ? storedUploads.get(storedKey(input.draftId, asset.id))
+      : undefined
+
+    if (cached) {
+      known.set(asset.id, cached)
+
+      continue
+    }
+
+    // One file being too large for the server must not stop the rest of the
+    // scene from being saved.
+    if (
+      describeUploadLimit({
+        fileName: asset.fileName,
+        mimeType: asset.mimeType,
+        sizeBytes: asset.sizeBytes,
+      })
+    ) {
+      skipped.push(asset.fileName)
+
+      continue
+    }
+
+    const bytes = await readLocalAssetBytes(asset.url)
+
+    pending.push({ asset, bytes, sha256: await sha256Hex(bytes) })
+  }
+
+  return { known, pending, skipped }
+}
+
+export async function saveDraft(input?: {
+  title?: string
+  withThumbnail?: boolean
+}): Promise<SaveDraftResult> {
+  const { localAssets, projectFile } = inspectScene({ prune: false })
+  const activeDraft = useDraftStore.getState().activeDraft
+  const { known, pending, skipped } = await readDraftUploads({
+    draftId: activeDraft?.id ?? null,
+    localAssets,
+  })
+
+  // Captured on the first save so the drafts list has something to show, and
+  // skipped afterwards: it is a full GPU render behind the preview lock, which
+  // would stutter the editor on every keystroke-fast save.
+  const wantsThumbnail = input?.withThumbnail ?? activeDraft === null
+  let thumbnail: { bytes: ArrayBuffer; sha256: string } | null = null
+
+  if (wantsThumbnail) {
+    const { max } = getThumbnailTimeBounds(projectFile.timeline.duration)
+    const blob = await captureThumbnail(
+      Math.min(max, useTimelineStore.getState().currentTime)
+    )
+    const bytes = await blob.arrayBuffer()
+
+    thumbnail = { bytes, sha256: await sha256Hex(bytes) }
+  }
+
+  const response = await fetch("/api/community/drafts", {
+    body: JSON.stringify({
+      draftId: activeDraft?.id ?? null,
+      uploads: [
+        ...(thumbnail
+          ? [
+              {
+                contentLength: thumbnail.bytes.byteLength,
+                contentType: THUMBNAIL_MIME,
+                kind: "thumbnail",
+                sha256: thumbnail.sha256,
+              },
+            ]
+          : []),
+        ...pending.map((entry) => ({
+          contentLength: entry.bytes.byteLength,
+          contentType: entry.asset.mimeType,
+          kind: entry.asset.kind,
+          sha256: entry.sha256,
+        })),
+      ],
+    }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+
+  const prepared = (await response.json()) as {
+    draftId?: string
+    error?: string
+    uploads?: UploadTarget[]
+  }
+
+  if (!(response.ok && prepared.draftId && prepared.uploads)) {
+    throw new Error(prepared.error ?? "Could not save this draft.")
+  }
+
+  const draftId = prepared.draftId
+  const [thumbnailTarget, ...assetTargets] = thumbnail
+    ? prepared.uploads
+    : [null, ...prepared.uploads]
+
+  if (thumbnail && thumbnailTarget) {
+    await upload(thumbnailTarget, thumbnail.bytes)
+  }
+
+  for (const [index, entry] of pending.entries()) {
+    const target = assetTargets[index]
+
+    if (!target) {
+      throw new Error("Could not prepare one of the media uploads.")
+    }
+
+    await upload(target, entry.bytes)
+
+    const stored = { sha256: target.sha256, url: target.publicUrl }
+
+    storedUploads.set(storedKey(draftId, entry.asset.id), stored)
+    known.set(entry.asset.id, stored)
+  }
+
+  const savable = {
+    ...projectFile,
+    assets: projectFile.assets.flatMap((reference) => {
+      const stored = known.get(reference.id)
+
+      if (stored) {
+        return [{ ...reference, sha256: stored.sha256, url: stored.url }]
+      }
+
+      return reference.url ? [reference] : []
+    }),
+  }
+
+  const saveResponse = await fetch(`/api/community/drafts/${draftId}`, {
+    body: JSON.stringify({
+      projectFile: JSON.stringify(savable),
+      thumbnailUrl: thumbnailTarget?.publicUrl ?? null,
+      title: input?.title ?? activeDraft?.title ?? null,
+    }),
+    headers: { "content-type": "application/json" },
+    method: "PUT",
+  })
+
+  const saved = (await saveResponse.json()) as {
+    draft?: { id: string; savedAt: string; title: string }
+    error?: string
+  }
+
+  if (!(saveResponse.ok && saved.draft)) {
+    throw new Error(saved.error ?? "Could not save this draft.")
+  }
+
+  useDraftStore.getState().setActiveDraft({
+    id: saved.draft.id,
+    savedAt: saved.draft.savedAt,
+    title: saved.draft.title,
+  })
+
+  return { ...saved.draft, skipped }
 }
 
 export async function publishScene(input: {

--- a/src/lib/community/publish-client.ts
+++ b/src/lib/community/publish-client.ts
@@ -166,9 +166,6 @@ interface StoredUpload {
   url: string
 }
 
-// Reading and hashing a 100 MB video costs the same whether or not anything
-// changed, so what a draft already holds is remembered for the session. Keyed by
-// draft as well as asset, because the url points inside one draft's prefix.
 const storedUploads = new Map<string, StoredUpload>()
 
 function storedKey(draftId: string, assetId: string): string {
@@ -199,8 +196,6 @@ async function readDraftUploads(input: {
       continue
     }
 
-    // One file being too large for the server must not stop the rest of the
-    // scene from being saved.
     if (
       describeUploadLimit({
         fileName: asset.fileName,
@@ -232,9 +227,6 @@ export async function saveDraft(input?: {
     localAssets,
   })
 
-  // Captured on the first save so the drafts list has something to show, and
-  // skipped afterwards: it is a full GPU render behind the preview lock, which
-  // would stutter the editor on every keystroke-fast save.
   const wantsThumbnail = input?.withThumbnail ?? activeDraft === null
   let thumbnail: { bytes: ArrayBuffer; sha256: string } | null = null
 

--- a/src/lib/community/publish-client.ts
+++ b/src/lib/community/publish-client.ts
@@ -331,6 +331,7 @@ async function runDraftSave(input: {
 
   const saveResponse = await fetch(`/api/community/drafts/${draftId}`, {
     body: JSON.stringify({
+      forkedFromSlug: useRemixOriginStore.getState().origin?.slug ?? null,
       projectFile: JSON.stringify(savable),
       thumbnailUrl: thumbnailTarget?.publicUrl ?? null,
       title: input.title ?? activeDraft?.title ?? null,

--- a/src/lib/community/publish-client.ts
+++ b/src/lib/community/publish-client.ts
@@ -6,7 +6,7 @@ import {
   type LabProjectFile,
 } from "@/lib/editor/project-file"
 import { useAssetStore } from "@/store/asset-store"
-import { useDraftStore } from "@/store/draft-store"
+import { type ActiveDraft, useDraftStore } from "@/store/draft-store"
 import { useRemixOriginStore } from "@/store/remix-origin-store"
 import { useTimelineStore } from "@/store/timeline-store"
 import type { EditorAsset, PresetAssetReference } from "@/types/editor"
@@ -155,6 +155,7 @@ export function describePublishPlan(): PublishPlan {
 }
 
 export interface SaveDraftResult {
+  created: boolean
   id: string
   savedAt: string | null
   skipped: string[]
@@ -216,29 +217,40 @@ async function readDraftUploads(input: {
   return { known, pending, skipped }
 }
 
-export async function saveDraft(input?: {
-  title?: string
-  withThumbnail?: boolean
-}): Promise<SaveDraftResult> {
-  const { localAssets, projectFile } = inspectScene({ prune: false })
-  const activeDraft = useDraftStore.getState().activeDraft
-  const { known, pending, skipped } = await readDraftUploads({
-    draftId: activeDraft?.id ?? null,
-    localAssets,
-  })
-
-  const wantsThumbnail = input?.withThumbnail ?? activeDraft === null
-  let thumbnail: { bytes: ArrayBuffer; sha256: string } | null = null
-
-  if (wantsThumbnail) {
-    const { max } = getThumbnailTimeBounds(projectFile.timeline.duration)
+async function captureDraftThumbnail(
+  duration: number
+): Promise<{ bytes: ArrayBuffer; sha256: string } | null> {
+  try {
+    const { max } = getThumbnailTimeBounds(duration)
     const blob = await captureThumbnail(
       Math.min(max, useTimelineStore.getState().currentTime)
     )
     const bytes = await blob.arrayBuffer()
 
-    thumbnail = { bytes, sha256: await sha256Hex(bytes) }
+    return { bytes, sha256: await sha256Hex(bytes) }
+  } catch {
+    return null
   }
+}
+
+class DraftGoneError extends Error {}
+
+async function runDraftSave(input: {
+  activeDraft: ActiveDraft | null
+  title?: string
+  withThumbnail?: boolean
+}): Promise<SaveDraftResult> {
+  const { localAssets, projectFile } = inspectScene({ prune: false })
+  const activeDraft = input.activeDraft
+  const { known, pending, skipped } = await readDraftUploads({
+    draftId: activeDraft?.id ?? null,
+    localAssets,
+  })
+
+  const thumbnail =
+    (input.withThumbnail ?? true)
+      ? await captureDraftThumbnail(projectFile.timeline.duration)
+      : null
 
   const response = await fetch("/api/community/drafts", {
     body: JSON.stringify({
@@ -273,6 +285,10 @@ export async function saveDraft(input?: {
   }
 
   if (!(response.ok && prepared.draftId && prepared.uploads)) {
+    if (activeDraft && (response.status === 404 || response.status === 409)) {
+      throw new DraftGoneError()
+    }
+
     throw new Error(prepared.error ?? "Could not save this draft.")
   }
 
@@ -317,7 +333,7 @@ export async function saveDraft(input?: {
     body: JSON.stringify({
       projectFile: JSON.stringify(savable),
       thumbnailUrl: thumbnailTarget?.publicUrl ?? null,
-      title: input?.title ?? activeDraft?.title ?? null,
+      title: input.title ?? activeDraft?.title ?? null,
     }),
     headers: { "content-type": "application/json" },
     method: "PUT",
@@ -329,6 +345,13 @@ export async function saveDraft(input?: {
   }
 
   if (!(saveResponse.ok && saved.draft)) {
+    if (
+      activeDraft &&
+      (saveResponse.status === 404 || saveResponse.status === 409)
+    ) {
+      throw new DraftGoneError()
+    }
+
     throw new Error(saved.error ?? "Could not save this draft.")
   }
 
@@ -338,7 +361,29 @@ export async function saveDraft(input?: {
     title: saved.draft.title,
   })
 
-  return { ...saved.draft, skipped }
+  return { ...saved.draft, created: activeDraft === null, skipped }
+}
+
+export async function saveDraft(input?: {
+  asNewDraft?: boolean
+  title?: string
+  withThumbnail?: boolean
+}): Promise<SaveDraftResult> {
+  const activeDraft = input?.asNewDraft
+    ? null
+    : useDraftStore.getState().activeDraft
+
+  try {
+    return await runDraftSave({ ...input, activeDraft })
+  } catch (cause) {
+    if (!(cause instanceof DraftGoneError)) {
+      throw cause
+    }
+
+    useDraftStore.getState().clearActiveDraft()
+
+    return await runDraftSave({ ...input, activeDraft: null })
+  }
 }
 
 export async function publishScene(input: {

--- a/src/lib/community/publish.ts
+++ b/src/lib/community/publish.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid"
 import { getDatabase } from "@/lib/db"
 import { scenes, uploadQuota } from "@/lib/db/schema"
 import { slugifyHandle } from "@/lib/community/handle"
+import { DEFAULT_DRAFT_TITLE } from "@/lib/community/upload-limits"
 import { isAllowedAssetOrigin } from "@/lib/editor/remote-asset"
 import type { LabProjectFile } from "@/lib/editor/project-file"
 import {
@@ -115,8 +116,6 @@ export function normalizeTitle(value: unknown): string {
 
   return title.slice(0, MAX_TITLE_LENGTH)
 }
-
-export const DEFAULT_DRAFT_TITLE = "Untitled draft"
 
 export function normalizeDraftTitle(value: unknown): string {
   const title = typeof value === "string" ? value.trim() : ""

--- a/src/lib/community/publish.ts
+++ b/src/lib/community/publish.ts
@@ -55,12 +55,41 @@ export interface PublishValidation {
   projectFile: LabProjectFile
 }
 
-export function validateProjectFilePayload(raw: string): PublishValidation {
+function parseScenePayload(raw: string): LabProjectFile {
   if (raw.length > MAX_LAB_BYTES) {
-    throw new Error("This scene is too large to publish.")
+    throw new Error("This scene is too large.")
   }
 
   const projectFile = parseLabProjectFile(raw)
+
+  for (const asset of projectFile.assets) {
+    if (asset.url && !isAllowedAssetOrigin(asset.url)) {
+      throw new Error(`"${asset.fileName}" points at an untrusted host.`)
+    }
+  }
+
+  return projectFile
+}
+
+function describeScene(projectFile: LabProjectFile): PublishValidation {
+  return {
+    hasCustomShader: hasImportedCustomShaderCode(projectFile),
+    layerTypes: [...new Set(projectFile.layers.map((layer) => layer.type))],
+    projectFile,
+  }
+}
+
+export function validateDraftPayload(raw: string): PublishValidation {
+  const projectFile = parseScenePayload(raw)
+
+  return describeScene({
+    ...projectFile,
+    assets: projectFile.assets.filter((asset) => asset.url),
+  })
+}
+
+export function validateProjectFilePayload(raw: string): PublishValidation {
+  const projectFile = parseScenePayload(raw)
 
   if (projectFile.layers.length === 0) {
     throw new Error("A scene needs at least one visible layer.")
@@ -72,19 +101,9 @@ export function validateProjectFilePayload(raw: string): PublishValidation {
         `"${asset.fileName}" was not uploaded, so the scene cannot be published.`
       )
     }
-
-    if (!isAllowedAssetOrigin(asset.url)) {
-      throw new Error(`"${asset.fileName}" points at an untrusted host.`)
-    }
   }
 
-  const layerTypes = [...new Set(projectFile.layers.map((layer) => layer.type))]
-
-  return {
-    hasCustomShader: hasImportedCustomShaderCode(projectFile),
-    layerTypes,
-    projectFile,
-  }
+  return describeScene(projectFile)
 }
 
 export function normalizeTitle(value: unknown): string {
@@ -95,6 +114,16 @@ export function normalizeTitle(value: unknown): string {
   }
 
   return title.slice(0, MAX_TITLE_LENGTH)
+}
+
+export const DEFAULT_DRAFT_TITLE = "Untitled draft"
+
+export function normalizeDraftTitle(value: unknown): string {
+  const title = typeof value === "string" ? value.trim() : ""
+
+  return title.length > 0
+    ? title.slice(0, MAX_TITLE_LENGTH)
+    : DEFAULT_DRAFT_TITLE
 }
 
 export function normalizeDescription(value: unknown): string | null {
@@ -110,58 +139,116 @@ export interface QuotaCheck {
   reason?: string
 }
 
-export async function reserveQuota(
-  userId: string,
-  bytes: number,
-  now = new Date()
-): Promise<QuotaCheck> {
-  const db = getDatabase()
-  const bucket = dayBucket(now)
+export interface QuotaSnapshot {
+  bytesUsed: number
+  dayBucket: string
+  scenesToday: number
+}
 
-  const rows = await db
-    .select()
-    .from(uploadQuota)
-    .where(eq(uploadQuota.userId, userId))
-    .limit(1)
+export function decideQuota(input: {
+  addScene: boolean
+  bucket: string
+  bytes: number
+  current: QuotaSnapshot | null
+}): QuotaCheck {
+  const scenesToday =
+    input.current?.dayBucket === input.bucket ? input.current.scenesToday : 0
 
-  const current = rows[0]
-  const scenesToday = current?.dayBucket === bucket ? current.scenesToday : 0
-  const bytesUsed = current?.bytesUsed ?? 0
-
-  if (scenesToday >= MAX_SCENES_PER_DAY) {
+  if (input.addScene && scenesToday >= MAX_SCENES_PER_DAY) {
     return {
       ok: false,
       reason: `You have published ${MAX_SCENES_PER_DAY} scenes today. Try again tomorrow.`,
     }
   }
 
-  if (bytesUsed + bytes > MAX_TOTAL_BYTES) {
+  if ((input.current?.bytesUsed ?? 0) + input.bytes > MAX_TOTAL_BYTES) {
     return {
       ok: false,
       reason: "You have reached your storage limit for community scenes.",
     }
   }
 
-  if (current) {
-    await db
-      .update(uploadQuota)
-      .set({
-        bytesUsed: bytesUsed + bytes,
-        dayBucket: bucket,
-        scenesToday: scenesToday + 1,
-        updatedAt: now,
-      })
-      .where(eq(uploadQuota.userId, userId))
-  } else {
-    await db.insert(uploadQuota).values({
-      bytesUsed: bytes,
-      dayBucket: bucket,
-      scenesToday: 1,
-      userId,
+  return { ok: true }
+}
+
+async function reserve(input: {
+  addScene: boolean
+  bytes: number
+  now: Date
+  userId: string
+}): Promise<QuotaCheck> {
+  const db = getDatabase()
+  const bucket = dayBucket(input.now)
+
+  const rows = await db
+    .select({
+      bytesUsed: uploadQuota.bytesUsed,
+      dayBucket: uploadQuota.dayBucket,
+      scenesToday: uploadQuota.scenesToday,
     })
+    .from(uploadQuota)
+    .where(eq(uploadQuota.userId, input.userId))
+    .limit(1)
+
+  const decision = decideQuota({
+    addScene: input.addScene,
+    bucket,
+    bytes: input.bytes,
+    current: rows[0] ?? null,
+  })
+
+  if (!decision.ok) {
+    return decision
   }
 
+  const added = input.addScene ? 1 : 0
+
+  // Drafts write here on every save, so the counters move in SQL rather than
+  // being read, added to in JS and written back — two saves in flight would
+  // otherwise agree on the old total and one of them would vanish.
+  await db
+    .insert(uploadQuota)
+    .values({
+      bytesUsed: input.bytes,
+      dayBucket: bucket,
+      scenesToday: added,
+      updatedAt: input.now,
+      userId: input.userId,
+    })
+    .onConflictDoUpdate({
+      set: {
+        bytesUsed: sql`${uploadQuota.bytesUsed} + ${input.bytes}`,
+        dayBucket: bucket,
+        scenesToday: sql`case when ${uploadQuota.dayBucket} = ${bucket} then ${uploadQuota.scenesToday} + ${added} else ${added} end`,
+        updatedAt: input.now,
+      },
+      target: uploadQuota.userId,
+    })
+
   return { ok: true }
+}
+
+export function reserveBytes(
+  userId: string,
+  bytes: number,
+  now = new Date()
+): Promise<QuotaCheck> {
+  return reserve({ addScene: false, bytes, now, userId })
+}
+
+export function reserveSceneSlot(
+  userId: string,
+  now = new Date()
+): Promise<QuotaCheck> {
+  return reserve({ addScene: true, bytes: 0, now, userId })
+}
+
+export function reserveQuota(
+  userId: string,
+  bytes: number,
+  now = new Date()
+): Promise<QuotaCheck> {
+  return reserve({ addScene: true, bytes, now, userId })
 }
 
 export async function countPublishedScenesForAuthor(

--- a/src/lib/community/publish.ts
+++ b/src/lib/community/publish.ts
@@ -170,6 +170,20 @@ export function decideQuota(input: {
   return { ok: true }
 }
 
+async function readQuota(userId: string): Promise<QuotaSnapshot | null> {
+  const rows = await getDatabase()
+    .select({
+      bytesUsed: uploadQuota.bytesUsed,
+      dayBucket: uploadQuota.dayBucket,
+      scenesToday: uploadQuota.scenesToday,
+    })
+    .from(uploadQuota)
+    .where(eq(uploadQuota.userId, userId))
+    .limit(1)
+
+  return rows[0] ?? null
+}
+
 async function reserve(input: {
   addScene: boolean
   bytes: number
@@ -178,31 +192,24 @@ async function reserve(input: {
 }): Promise<QuotaCheck> {
   const db = getDatabase()
   const bucket = dayBucket(input.now)
-
-  const rows = await db
-    .select({
-      bytesUsed: uploadQuota.bytesUsed,
-      dayBucket: uploadQuota.dayBucket,
-      scenesToday: uploadQuota.scenesToday,
-    })
-    .from(uploadQuota)
-    .where(eq(uploadQuota.userId, input.userId))
-    .limit(1)
+  const added = input.addScene ? 1 : 0
 
   const decision = decideQuota({
     addScene: input.addScene,
     bucket,
     bytes: input.bytes,
-    current: rows[0] ?? null,
+    current: await readQuota(input.userId),
   })
 
   if (!decision.ok) {
     return decision
   }
 
-  const added = input.addScene ? 1 : 0
-
-  await db
+  // The caps live in the write, not in the read above. Two saves racing near a
+  // limit both pass a snapshot check, so the predicate has to be re-evaluated by
+  // the row lock that serialises them; the read only exists to name which cap
+  // was hit.
+  const won = await db
     .insert(uploadQuota)
     .values({
       bytesUsed: input.bytes,
@@ -218,10 +225,61 @@ async function reserve(input: {
         scenesToday: sql`case when ${uploadQuota.dayBucket} = ${bucket} then ${uploadQuota.scenesToday} + ${added} else ${added} end`,
         updatedAt: input.now,
       },
+      setWhere: sql`${uploadQuota.bytesUsed} + ${input.bytes} <= ${MAX_TOTAL_BYTES} and (case when ${uploadQuota.dayBucket} = ${bucket} then ${uploadQuota.scenesToday} else 0 end) + ${added} <= ${MAX_SCENES_PER_DAY}`,
       target: uploadQuota.userId,
     })
+    .returning({ userId: uploadQuota.userId })
 
-  return { ok: true }
+  if (won.length > 0) {
+    return { ok: true }
+  }
+
+  const lost = decideQuota({
+    addScene: input.addScene,
+    bucket,
+    bytes: input.bytes,
+    current: await readQuota(input.userId),
+  })
+
+  return lost.ok
+    ? { ok: false, reason: "Could not reserve storage. Please retry." }
+    : lost
+}
+
+async function release(input: {
+  bytes: number
+  now: Date
+  scenes: number
+  userId: string
+}): Promise<void> {
+  if (input.bytes <= 0 && input.scenes <= 0) {
+    return
+  }
+
+  const bucket = dayBucket(input.now)
+
+  await getDatabase()
+    .update(uploadQuota)
+    .set({
+      bytesUsed: sql`greatest(0, ${uploadQuota.bytesUsed} - ${input.bytes})`,
+      scenesToday: sql`case when ${uploadQuota.dayBucket} = ${bucket} then greatest(0, ${uploadQuota.scenesToday} - ${input.scenes}) else ${uploadQuota.scenesToday} end`,
+      updatedAt: input.now,
+    })
+    .where(eq(uploadQuota.userId, input.userId))
+}
+
+// A save that never reached storage must not keep spending the allowance.
+export function releaseQuota(
+  userId: string,
+  input: { bytes?: number; scenes?: number },
+  now = new Date()
+): Promise<void> {
+  return release({
+    bytes: input.bytes ?? 0,
+    now,
+    scenes: input.scenes ?? 0,
+    userId,
+  })
 }
 
 export function reserveBytes(

--- a/src/lib/community/publish.ts
+++ b/src/lib/community/publish.ts
@@ -203,9 +203,6 @@ async function reserve(input: {
 
   const added = input.addScene ? 1 : 0
 
-  // Drafts write here on every save, so the counters move in SQL rather than
-  // being read, added to in JS and written back — two saves in flight would
-  // otherwise agree on the old total and one of them would vanish.
   await db
     .insert(uploadQuota)
     .values({

--- a/src/lib/community/scenes.ts
+++ b/src/lib/community/scenes.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, ilike, isNull, ne, or, sql } from "drizzle-orm"
+import { alias } from "drizzle-orm/pg-core"
 import {
   encodeSceneCursor,
   type SceneCursor,
@@ -256,10 +257,33 @@ export async function listScenesByAuthor(
   return rows.map((row) => ({ ...toSummary(row), status: row.status }))
 }
 
+export async function resolveForkedFromId(
+  slug: unknown
+): Promise<string | null> {
+  if (typeof slug !== "string" || slug.length === 0 || slug.length > 120) {
+    return null
+  }
+
+  const rows = await getDatabase()
+    .select({ id: scenes.id })
+    .from(scenes)
+    .where(
+      and(
+        eq(scenes.slug, slug),
+        eq(scenes.status, "published"),
+        isNull(scenes.deletedAt)
+      )
+    )
+    .limit(1)
+
+  return rows[0]?.id ?? null
+}
+
 export interface DraftSummary {
   compositionHeight: number
   compositionWidth: number
   durationSeconds: number
+  forkedFrom: SceneLineage | null
   id: string
   labUrl: string
   layerTypes: LayerType[]
@@ -272,6 +296,9 @@ export async function listDraftsByAuthor(
   authorId: string,
   limit = 60
 ): Promise<DraftSummary[]> {
+  const parent = alias(scenes, "parent")
+  const parentAuthor = alias(profiles, "parent_author")
+
   const rows = await getDatabase()
     .select({
       compositionHeight: scenes.compositionHeight,
@@ -280,11 +307,25 @@ export async function listDraftsByAuthor(
       id: scenes.id,
       labKey: scenes.labKey,
       layerTypes: scenes.layerTypes,
+      parentAuthorAvatarUrl: parentAuthor.avatarUrl,
+      parentAuthorHandle: parentAuthor.handle,
+      parentAuthorName: parentAuthor.displayName,
+      parentSlug: parent.slug,
+      parentTitle: parent.title,
       thumbnailImageId: scenes.thumbnailImageId,
       title: scenes.title,
       updatedAt: scenes.updatedAt,
     })
     .from(scenes)
+    .leftJoin(
+      parent,
+      and(
+        eq(parent.id, scenes.forkedFromId),
+        eq(parent.status, "published"),
+        isNull(parent.deletedAt)
+      )
+    )
+    .leftJoin(parentAuthor, eq(parentAuthor.userId, parent.authorId))
     .where(
       and(
         eq(scenes.authorId, authorId),
@@ -299,6 +340,16 @@ export async function listDraftsByAuthor(
     compositionHeight: row.compositionHeight,
     compositionWidth: row.compositionWidth,
     durationSeconds: row.durationSeconds,
+    forkedFrom:
+      row.parentSlug && row.parentAuthorHandle
+        ? {
+            authorAvatarUrl: row.parentAuthorAvatarUrl,
+            authorHandle: row.parentAuthorHandle,
+            authorName: row.parentAuthorName,
+            slug: row.parentSlug,
+            title: row.parentTitle ?? "",
+          }
+        : null,
     id: row.id,
     labUrl: resolveLabUrl(row.labKey),
     layerTypes: row.layerTypes as LayerType[],

--- a/src/lib/community/scenes.ts
+++ b/src/lib/community/scenes.ts
@@ -246,9 +246,6 @@ export async function listScenesByAuthor(
     .where(
       and(
         eq(scenes.authorId, authorId),
-        // Drafts belong to the Drafts tab. Excluded by status rather than by
-        // selecting published, so the author still sees processing and takendown
-        // scenes, which is what the status badge is for.
         ne(scenes.status, "draft"),
         isNull(scenes.deletedAt)
       )

--- a/src/lib/community/scenes.ts
+++ b/src/lib/community/scenes.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ilike, isNull, or, sql } from "drizzle-orm"
+import { and, desc, eq, ilike, isNull, ne, or, sql } from "drizzle-orm"
 import {
   encodeSceneCursor,
   type SceneCursor,
@@ -243,7 +243,16 @@ export async function listScenesByAuthor(
     .select({ ...summaryColumns, status: scenes.status })
     .from(scenes)
     .innerJoin(profiles, eq(profiles.userId, scenes.authorId))
-    .where(and(eq(scenes.authorId, authorId), isNull(scenes.deletedAt)))
+    .where(
+      and(
+        eq(scenes.authorId, authorId),
+        // Drafts belong to the Drafts tab. Excluded by status rather than by
+        // selecting published, so the author still sees processing and takendown
+        // scenes, which is what the status badge is for.
+        ne(scenes.status, "draft"),
+        isNull(scenes.deletedAt)
+      )
+    )
     .orderBy(desc(scenes.publishedAt), desc(scenes.createdAt))
     .limit(Math.min(Math.max(limit, 1), 100))
 

--- a/src/lib/community/scenes.ts
+++ b/src/lib/community/scenes.ts
@@ -256,6 +256,58 @@ export async function listScenesByAuthor(
   return rows.map((row) => ({ ...toSummary(row), status: row.status }))
 }
 
+export interface DraftSummary {
+  compositionHeight: number
+  compositionWidth: number
+  durationSeconds: number
+  id: string
+  labUrl: string
+  layerTypes: LayerType[]
+  thumbnailUrl: string | null
+  title: string
+  updatedAt: string
+}
+
+export async function listDraftsByAuthor(
+  authorId: string,
+  limit = 60
+): Promise<DraftSummary[]> {
+  const rows = await getDatabase()
+    .select({
+      compositionHeight: scenes.compositionHeight,
+      compositionWidth: scenes.compositionWidth,
+      durationSeconds: scenes.durationSeconds,
+      id: scenes.id,
+      labKey: scenes.labKey,
+      layerTypes: scenes.layerTypes,
+      thumbnailImageId: scenes.thumbnailImageId,
+      title: scenes.title,
+      updatedAt: scenes.updatedAt,
+    })
+    .from(scenes)
+    .where(
+      and(
+        eq(scenes.authorId, authorId),
+        eq(scenes.status, "draft"),
+        isNull(scenes.deletedAt)
+      )
+    )
+    .orderBy(desc(scenes.updatedAt))
+    .limit(Math.min(Math.max(limit, 1), 100))
+
+  return rows.map((row) => ({
+    compositionHeight: row.compositionHeight,
+    compositionWidth: row.compositionWidth,
+    durationSeconds: row.durationSeconds,
+    id: row.id,
+    labUrl: resolveLabUrl(row.labKey),
+    layerTypes: row.layerTypes as LayerType[],
+    thumbnailUrl: resolveThumbnailUrl(row.thumbnailImageId),
+    title: row.title,
+    updatedAt: row.updatedAt.toISOString(),
+  }))
+}
+
 export interface AuthoredSceneDetail {
   authorId: string
   detail: CommunitySceneDetail

--- a/src/lib/community/upload-limits.ts
+++ b/src/lib/community/upload-limits.ts
@@ -1,4 +1,5 @@
 export const MAX_ASSET_BYTES = 100 * 1024 * 1024
+export const MAX_DRAFTS_PER_AUTHOR = 8
 export const MAX_IMAGE_BYTES = 4 * 1024 * 1024
 
 export function isImageMimeType(mimeType: string): boolean {

--- a/src/lib/community/upload-limits.ts
+++ b/src/lib/community/upload-limits.ts
@@ -1,5 +1,6 @@
 export const MAX_ASSET_BYTES = 100 * 1024 * 1024
 export const MAX_DRAFTS_PER_AUTHOR = 8
+export const DEFAULT_DRAFT_TITLE = "Untitled draft"
 export const MAX_IMAGE_BYTES = 4 * 1024 * 1024
 
 export function isImageMimeType(mimeType: string): boolean {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -104,6 +104,11 @@ export const scenes = pgTable(
       table.status,
       table.publishedAt.desc()
     ),
+    index("scenes_author_status_updated_idx").on(
+      table.authorId,
+      table.status,
+      table.updatedAt.desc()
+    ),
     index("scenes_featured_idx").on(table.featuredAt.desc()),
     index("scenes_forked_from_idx").on(table.forkedFromId),
     index("scenes_layer_types_idx").using("gin", table.layerTypes),

--- a/src/lib/editor/autosave/limits.ts
+++ b/src/lib/editor/autosave/limits.ts
@@ -11,8 +11,6 @@ export const AUTOSAVE_MAX_ASSET_BYTES = 32 * 1024 * 1024
 export const AUTOSAVE_MAX_TOTAL_BYTES = 256 * 1024 * 1024
 export const AUTOSAVE_QUOTA_HEADROOM = 0.8
 
-// Another tab can have imported a blob and not yet written the record that
-// references it. Collecting inside this window would delete live media.
 export const AUTOSAVE_ASSET_GRACE_MS = 5 * 60 * 1000
 
 export const AUTOSAVE_SCHEMA_VERSION = 1

--- a/src/lib/editor/autosave/record.ts
+++ b/src/lib/editor/autosave/record.ts
@@ -5,7 +5,14 @@ import {
 } from "@/lib/editor/autosave/limits"
 import type { LabProjectFile } from "@/lib/editor/project-file"
 
+export interface AutosaveDraft {
+  id: string
+  savedAt: string | null
+  title: string
+}
+
 export interface AutosaveRecord {
+  activeDraft?: AutosaveDraft | null
   projectFile: LabProjectFile
   remixOrigin: { slug: string; title: string } | null
   savedAt: number
@@ -14,6 +21,7 @@ export interface AutosaveRecord {
 }
 
 export function buildAutosaveSignature(input: {
+  activeDraft?: AutosaveDraft | null
   projectFile: LabProjectFile
   remixOrigin: { slug: string; title: string } | null
 }): string {
@@ -21,7 +29,11 @@ export function buildAutosaveSignature(input: {
 
   void exportedAt
 
-  return JSON.stringify({ document: rest, remix: input.remixOrigin })
+  return JSON.stringify({
+    document: rest,
+    draft: input.activeDraft ?? null,
+    remix: input.remixOrigin,
+  })
 }
 
 export function chooseAutosaveRecord(input: {

--- a/src/lib/editor/autosave/store.ts
+++ b/src/lib/editor/autosave/store.ts
@@ -1,6 +1,7 @@
 import { deleteRecord, deleteRecords, readAll } from "@/lib/editor/autosave/idb"
 import { AUTOSAVE_SCHEMA_VERSION } from "@/lib/editor/autosave/limits"
 import {
+  type AutosaveDraft,
   type AutosaveRecord,
   chooseAutosaveRecord,
   planRecordPruning,
@@ -16,11 +17,13 @@ export function autosaveSessionId(): string {
 }
 
 export async function saveAutosaveRecord(input: {
+  activeDraft: AutosaveRecord["activeDraft"]
   projectFile: AutosaveRecord["projectFile"]
   remixOrigin: AutosaveRecord["remixOrigin"]
 }): Promise<boolean> {
   const now = Date.now()
   const written = await writeRecord({
+    activeDraft: input.activeDraft ?? null,
     projectFile: input.projectFile,
     remixOrigin: input.remixOrigin,
     savedAt: now,
@@ -44,6 +47,7 @@ export async function saveAutosaveRecord(input: {
 }
 
 export interface RestorableAutosave {
+  activeDraft: AutosaveDraft | null
   projectFile: AutosaveRecord["projectFile"]
   remixOrigin: AutosaveRecord["remixOrigin"]
   savedAt: number
@@ -69,6 +73,7 @@ export async function findRestorableAutosave(): Promise<RestorableAutosave | nul
 
   try {
     return {
+      activeDraft: candidate.activeDraft ?? null,
       projectFile: parseLabProjectFileValue(candidate.projectFile),
       remixOrigin: candidate.remixOrigin,
       savedAt: candidate.savedAt,

--- a/src/lib/editor/draft-save-bus.ts
+++ b/src/lib/editor/draft-save-bus.ts
@@ -1,0 +1,11 @@
+type Saver = () => void
+
+let saver: Saver | null = null
+
+export function registerDraftSaver(next: Saver | null): void {
+  saver = next
+}
+
+export function requestDraftSave(): void {
+  saver?.()
+}

--- a/src/lib/editor/draft-save-bus.ts
+++ b/src/lib/editor/draft-save-bus.ts
@@ -1,4 +1,8 @@
-type Saver = () => void
+export interface DraftSaveRequest {
+  asNewDraft?: boolean
+}
+
+type Saver = (request: DraftSaveRequest) => void
 
 let saver: Saver | null = null
 
@@ -6,6 +10,6 @@ export function registerDraftSaver(next: Saver | null): void {
   saver = next
 }
 
-export function requestDraftSave(): void {
-  saver?.()
+export function requestDraftSave(request: DraftSaveRequest = {}): void {
+  saver?.(request)
 }

--- a/src/store/asset-store.ts
+++ b/src/store/asset-store.ts
@@ -212,9 +212,6 @@ export const useAssetStore = create<AssetStore>((set, get) => ({
       }
     }
 
-    // Durable before the asset is handed back, so an autosave can never record a
-    // reference to bytes that are still in flight. A refusal is fine and still
-    // yields a usable asset for this session.
     await persistAssetBlob(asset, file)
 
     set((state) => ({

--- a/src/store/draft-store.ts
+++ b/src/store/draft-store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand"
+
+export interface ActiveDraft {
+  id: string
+  savedAt: string | null
+  title: string
+}
+
+interface DraftState {
+  activeDraft: ActiveDraft | null
+  clearActiveDraft: () => void
+  setActiveDraft: (draft: ActiveDraft) => void
+}
+
+export const useDraftStore = create<DraftState>((set) => ({
+  activeDraft: null,
+  clearActiveDraft: () => set({ activeDraft: null }),
+  setActiveDraft: (activeDraft) => set({ activeDraft }),
+}))


### PR DESCRIPTION
Stacked on #126. Fifth in the profiles + autosave series; this is the server half of drafts.

Local autosave only helps on the machine that wrote it, and Safari evicts IndexedDB after 7 days of no visits. `⌘S` now pushes the scene and its media to R2 behind a `scenes` row with `status='draft'` — the same row publishing will later promote, so the R2 prefix never moves and `DELETE /api/community/scenes/{slug}` already works on it.

## Three splits that make it safe

**`validateDraftPayload`.** `validateProjectFilePayload` keeps its two publish-only checks — no layers, and an asset that never uploaded — and loses everything else to a shared parse. An empty scene and a url-less asset are legal in a draft (the asset is dropped rather than refusing the whole save) and still refused at publish. The existing `validateProjectFilePayload` test block passes untouched; that was the point.

**The quota split.** `reserveQuota` bumped `scenesToday` on every call, so twenty draft saves would have spent the day's publish budget. It now has `reserveBytes` and `reserveSceneSlot` siblings over a pure `decideQuota`. Drafts charge bytes only. While in there: the counters now move in SQL rather than being read into JS and written back — drafts write them often enough that two saves in flight would agree on the old total and lose one.

**The lab is charged once, not per save.** It overwrites a single key, so charging `raw.length` on every `⌘S` would leak against the 500 MB cap. Charged on creation, and assets are charged the first time their content hash appears under the draft. This differs from the plan's case 10, which expected `bytes_used` to grow by the lab on each save.

## Two ways a published scene could have been overwritten

The id in a save request decides where the presigned `PUT`s land, so `POST /drafts` proves it is the caller's before signing anything: pattern check, then `authorId`/`status`/`deletedAt`. Unowned ids are allowed (that is how a new draft is minted); someone else's is **404, not 403**, so this cannot be used to ask whether an id exists — matching what the publish route already does.

`PUT /drafts/[id]` asserts `status === 'draft'`. Without it, a `PUT` against a published scene's id would swap its content, skipping Turnstile and leaving no moderation trail. The friendly error comes from a read; the guard that actually holds is `setWhere` on the upsert, so a row that changes hands between the two still cannot be written.

The lab object is written **before** the row, not after. A row can then never point at a lab that is not there, and the failure it trades for — an object with no row — is invisible and overwritten by the next save. Deleting the row on failure (what publish does) would be a data-loss trap here: `!existing` can be stale, and the row deleted could be one a concurrent save just created.

## Leak closed in the same commit

`listScenesByAuthor` filtered `deletedAt` only, so the moment draft rows exist they appear in "My scenes" — where `SceneCard` shows a meaningless like/remix pill, and `desc(publishedAt)` would pin every draft above real work because Postgres puts NULLs first. Filtered with `ne(status, 'draft')` rather than `eq(status, 'published')`, so the author keeps seeing `processing` and `takendown` scenes, which is what the status badge is for.

## Client

`saveDraft()` runs with `prune: false` so hidden layers survive — drafts and published scenes deliberately use different keys (`draft.lab.json` vs `scene.lab.json`), because sharing one would destroy a draft's hidden layers on publish.

Reading and hashing a 100 MB video costs the same whether or not anything changed, so what a draft already holds is remembered per session and skipped entirely on the next save. A file too large for the server is skipped and named in the notice rather than failing the whole save.

`activeDraft` is persisted in the autosave record. Without it every save after a refresh would mint a new draft row and re-upload every asset. Remix and `.lab` import clear it, since both put a different scene on screen and would otherwise save over the draft that was open.

Thumbnails are captured on the first save only. `captureThumbnail` is a full GPU render behind `acquirePreviewRenderLock()`, which would stutter the editor on a shortcut people hit reflexively.

## Verified

`658` unit tests pass, typecheck clean, lint at the pre-existing 2 warnings.

Against the real database and real R2, driving the handlers with a stubbed session: the row shape (`slug = id`, `draft.lab.json`, `published_at NULL`, `Untitled draft`), `scenes_today` unchanged, `bytes_used` +1111 on the first save and **+0** on the second, the stored lab keeping all 3 layers when only 1 was visible, an empty scene and a url-less asset both saving, drafts absent from `listScenesByAuthor`, `PUT`/`POST` against a published scene 409 with the scene unchanged, and `PUT`/`POST` against another author's draft 404 with nothing written into their prefix.

That last pair needed a control: my first run used a 15-character probe id, so the 404s came from the pattern check rather than the ownership guard and proved nothing. A well-formed unclaimed id is now asserted to return 200 alongside it.

In a real browser, signed out: `⌘S` takes the key from the browser, reaches the pill, sits above the timeline, dismisses, and is correctly ignored while a text field has focus. Existing autosave, asset-persistence and pill-position suites all still pass after the pill positioning was extracted for reuse.

**Not verified end to end:** the signed-in browser path — real uploads, the already-stored skip, and the "Draft saved" pill. The debug Chrome has no session and OAuth needs a person. Every server-side branch behind it is covered above.

## Follow-ups this leaves open

- The Drafts tab (`listDraftsByAuthor`, `GET me/drafts`, `drafts-grid`) — nothing lists drafts yet.
- Promote to published, where `collectDeletableKeys` must learn the second lab key, `scene_assets` must become delete-then-insert on the publish path too, and the rollback must stop deleting the draft row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)