### PR TITLE
Community moderation: refuse to publish a scene with a bad word in it

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "shader-lab",
@@ -24,6 +23,7 @@
         "mp4-muxer": "^5.2.2",
         "nanoid": "^6.0.1",
         "next": "^16.2.3",
+        "obscenity": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-use": "^17.6.0",
@@ -1628,6 +1628,8 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "obscenity": ["obscenity@0.4.6", "", {}, "sha512-pHk7kNN7j3L3zGhhGnwxjvXIGsPpLrcZl2r58fqWh/V/rH6b/dafscj2sMmAY+A/9/wPsocLmimgGk2DKeKsFQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mp4-muxer": "^5.2.2",
     "nanoid": "^6.0.1",
     "next": "^16.2.3",
+    "obscenity": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-use": "^17.6.0",

--- a/src/app/api/community/drafts/[id]/publish/route.ts
+++ b/src/app/api/community/drafts/[id]/publish/route.ts
@@ -240,7 +240,7 @@ export async function POST(
 
   try {
     await putObject({
-      body: raw,
+      body: validated.body,
       contentType: "application/json",
       key: labKey,
     })

--- a/src/app/api/community/drafts/[id]/route.ts
+++ b/src/app/api/community/drafts/[id]/route.ts
@@ -141,7 +141,7 @@ export async function PUT(
 
   try {
     await putObject({
-      body: raw,
+      body: validated.body,
       contentType: "application/json",
       key: labKey,
     })

--- a/src/lib/community/__tests__/handle.test.ts
+++ b/src/lib/community/__tests__/handle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   buildHandleCandidates,
   deriveHandleSeed,
+  describeHandleInput,
   HANDLE_MAX_LENGTH,
   isLookupableHandle,
   isReservedHandle,
@@ -157,5 +158,41 @@ describe("buildHandleCandidates", () => {
     expect(candidates).not.toContain("admin")
     expect(candidates.length).toBeGreaterThan(0)
     expect(candidates[0]).toBe("admin-2")
+  })
+})
+
+describe("handles and bad language", () => {
+  test("isValidHandle turns down a handle that reads as a slur", () => {
+    for (const handle of ["fuck-you", "shitposter", "fu-ck"]) {
+      expect(isValidHandle(handle)).toBe(false)
+    }
+  })
+
+  test("describeHandleInput says why, instead of failing the shape check", () => {
+    const result = describeHandleInput("fuckyou")
+
+    expect(result).toEqual({
+      reason: "That handle reads as language we do not allow.",
+    })
+  })
+
+  test("a seed derived from a name falls back rather than minting a slur", () => {
+    expect(deriveHandleSeed({ email: null, name: "Fuck Face" })).toBe("maker")
+  })
+
+  test("a bad name falls through to the email before giving up", () => {
+    expect(
+      deriveHandleSeed({ email: "renderfan@example.com", name: "Fuck Face" })
+    ).toBe("renderfan")
+  })
+
+  test("candidates are never empty, so signup cannot deadlock on a bad name", () => {
+    const candidates = buildHandleCandidates({ email: null, name: "Fuck Face" })
+
+    expect(candidates.length).toBeGreaterThan(0)
+
+    for (const candidate of candidates) {
+      expect(isValidHandle(candidate)).toBe(true)
+    }
   })
 })

--- a/src/lib/community/__tests__/language.test.ts
+++ b/src/lib/community/__tests__/language.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test"
+import {
+  censorProjectFile,
+  censorText,
+  hasProfanity,
+} from "@/lib/community/language"
+import { parseLabProjectFile } from "@/lib/editor/project-file"
+
+function layer(overrides: Record<string, unknown> = {}) {
+  return {
+    assetId: null,
+    blendMode: "normal",
+    compositeMode: "filter",
+    expanded: true,
+    hue: 0,
+    id: "layer-1",
+    kind: "source",
+    locked: false,
+    maskConfig: { invert: false, mode: "multiply", source: "luminance" },
+    name: "Gradient",
+    opacity: 1,
+    params: {},
+    runtimeError: null,
+    saturation: 1,
+    type: "gradient",
+    visible: true,
+    ...overrides,
+  }
+}
+
+function labFile(layers: unknown[]) {
+  return JSON.stringify({
+    assets: [],
+    composition: { height: 800, width: 1200 },
+    format: "shader-lab",
+    layers,
+    selectedLayerId: null,
+    timeline: { duration: 6, loop: true, tracks: [] },
+    version: 5,
+  })
+}
+
+describe("censorText", () => {
+  test("masks a slur and leaves the rest of the sentence alone", () => {
+    expect(censorText("fuck this gradient")).toBe("**** this gradient")
+  })
+
+  test("sees through leetspeak and repeated letters", () => {
+    expect(censorText("sh1t")).toBe("****")
+    expect(censorText("fuuuuck")).not.toContain("uuuu")
+  })
+
+  test("returns clean text unchanged, by identity", () => {
+    const clean = "A calm noise field"
+
+    expect(censorText(clean)).toBe(clean)
+  })
+
+  test("does not trip on words that merely contain a smaller word", () => {
+    for (const clean of [
+      "bass drop",
+      "classic pass",
+      "Assassin's Creed",
+      "Scunthorpe skyline",
+      "analysis grid",
+    ]) {
+      expect(censorText(clean)).toBe(clean)
+    }
+  })
+
+  test("handles empty input without building a matcher", () => {
+    expect(censorText("")).toBe("")
+    expect(hasProfanity("")).toBe(false)
+  })
+})
+
+describe("censorProjectFile", () => {
+  test("masks a layer name", () => {
+    const parsed = parseLabProjectFile(
+      labFile([layer({ name: "fuck gradient" })])
+    )
+    const result = censorProjectFile(parsed)
+
+    expect(result.changed).toBe(true)
+    expect(result.projectFile.layers[0]?.name).toBe("**** gradient")
+  })
+
+  test("masks the string a text layer paints on the canvas", () => {
+    const parsed = parseLabProjectFile(
+      labFile([layer({ params: { text: "shit" }, type: "text" })])
+    )
+    const result = censorProjectFile(parsed)
+
+    expect(result.changed).toBe(true)
+    expect(result.projectFile.layers[0]?.params.text).toBe("****")
+  })
+
+  test("leaves a same-named param on a non-text layer alone", () => {
+    const parsed = parseLabProjectFile(
+      labFile([layer({ params: { text: "shit" }, type: "gradient" })])
+    )
+    const result = censorProjectFile(parsed)
+
+    expect(result.changed).toBe(false)
+    expect(result.projectFile.layers[0]?.params.text).toBe("shit")
+  })
+
+  test("reports no change for a clean scene, so the upload stays byte-identical", () => {
+    const parsed = parseLabProjectFile(labFile([layer()]))
+    const result = censorProjectFile(parsed)
+
+    expect(result.changed).toBe(false)
+    expect(result.projectFile).toBe(parsed)
+  })
+
+  test("censors every layer, not just the first", () => {
+    const parsed = parseLabProjectFile(
+      labFile([
+        layer({ id: "layer-1", name: "clean" }),
+        layer({ id: "layer-2", name: "fuck" }),
+      ])
+    )
+    const result = censorProjectFile(parsed)
+
+    expect(result.projectFile.layers[0]?.name).toBe("clean")
+    expect(result.projectFile.layers[1]?.name).toBe("****")
+  })
+
+  test("does not mutate the file it was handed", () => {
+    const parsed = parseLabProjectFile(labFile([layer({ name: "fuck" })]))
+
+    censorProjectFile(parsed)
+
+    expect(parsed.layers[0]?.name).toBe("fuck")
+  })
+
+  test("keeps fields the schema does not know about, at every level", () => {
+    const raw = labFile([
+      layer({
+        futureLayerField: "keep me",
+        name: "fuck",
+        params: { futureParam: 3 },
+      }),
+    ])
+    const withExtras = JSON.parse(raw)
+
+    withExtras.futureTopLevelField = ["a", "b"]
+
+    const censored = censorProjectFile(
+      parseLabProjectFile(JSON.stringify(withExtras))
+    )
+    const stored = JSON.parse(JSON.stringify(censored.projectFile))
+
+    expect(stored.layers[0].name).toBe("****")
+    expect(stored.layers[0].futureLayerField).toBe("keep me")
+    expect(stored.layers[0].params.futureParam).toBe(3)
+    expect(stored.futureTopLevelField).toEqual(["a", "b"])
+  })
+
+  test("survives a round trip through JSON, which is what gets stored", () => {
+    const parsed = parseLabProjectFile(
+      labFile([layer({ name: "fuck", params: { text: "hello" }, type: "text" })])
+    )
+    const stored = JSON.stringify(censorProjectFile(parsed).projectFile)
+    const reparsed = parseLabProjectFile(stored)
+
+    expect(reparsed.layers[0]?.name).toBe("****")
+    expect(reparsed.layers[0]?.params.text).toBe("hello")
+    expect(reparsed.layers).toHaveLength(1)
+  })
+})

--- a/src/lib/community/__tests__/language.test.ts
+++ b/src/lib/community/__tests__/language.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, test } from "bun:test"
 import {
   censorProjectFile,
   censorText,
-  findSevereLanguageInScene,
+  findProfanityInScene,
   hasProfanity,
-  hasSevereLanguage,
 } from "@/lib/community/language"
 import { parseLabProjectFile } from "@/lib/editor/project-file"
 
@@ -172,23 +171,27 @@ describe("censorProjectFile", () => {
   })
 })
 
-describe("the severe tier", () => {
-  test("blocks slurs", () => {
+describe("what counts as a bad word", () => {
+  test("catches slurs", () => {
     for (const value of ["NIGGER", "faggot", "a chink joke", "spic", "wetback"]) {
-      expect(hasSevereLanguage(value)).toBe(true)
+      expect(hasProfanity(value)).toBe(true)
     }
   })
 
-  test("lets ordinary swearing through, so it gets censored instead", () => {
+  test("catches ordinary swearing too, now that everything blocks", () => {
     for (const value of ["fuck this gradient", "shitty scene", "ass", "twat"]) {
-      expect(hasSevereLanguage(value)).toBe(false)
+      expect(hasProfanity(value)).toBe(true)
+    }
+  })
+
+  test("catches the house additions", () => {
+    for (const value of ["goy", "goyim", "uncircumcised", "uncircumsized"]) {
       expect(hasProfanity(value)).toBe(true)
     }
   })
 
   test("says nothing about words the dataset does not carry", () => {
     expect(hasProfanity("damn")).toBe(false)
-    expect(hasSevereLanguage("damn")).toBe(false)
   })
 
   test("the house list is word-bounded, not a substring match", () => {
@@ -205,27 +208,27 @@ describe("the severe tier", () => {
       "custard",
       "bean field",
     ]) {
-      expect(hasSevereLanguage(clean)).toBe(false)
+      expect(hasProfanity(clean)).toBe(false)
     }
   })
 
   test("still sees through leetspeak and casing", () => {
-    expect(hasSevereLanguage("N1GG3R")).toBe(true)
+    expect(hasProfanity("N1GG3R")).toBe(true)
   })
 })
 
-describe("findSevereLanguageInScene", () => {
+describe("findProfanityInScene", () => {
   const clean = () => parseLabProjectFile(labFile([layer()]))
 
   test("names the title", () => {
     expect(
-      findSevereLanguageInScene({ projectFile: clean(), title: "nigger" })
+      findProfanityInScene({ projectFile: clean(), title: "nigger" })
     ).toBe("the title")
   })
 
   test("names the description", () => {
     expect(
-      findSevereLanguageInScene({
+      findProfanityInScene({
         description: "a scene about faggots",
         projectFile: clean(),
         title: "Fine",
@@ -238,7 +241,7 @@ describe("findSevereLanguageInScene", () => {
       labFile([layer({ params: { text: "NIGGER" }, type: "text" })])
     )
 
-    expect(findSevereLanguageInScene({ projectFile, title: "Fine" })).toBe(
+    expect(findProfanityInScene({ projectFile, title: "Fine" })).toBe(
       "the text on one of your text layers"
     )
   })
@@ -246,7 +249,7 @@ describe("findSevereLanguageInScene", () => {
   test("names layer names", () => {
     const projectFile = parseLabProjectFile(labFile([layer({ name: "kike" })]))
 
-    expect(findSevereLanguageInScene({ projectFile, title: "Fine" })).toBe(
+    expect(findProfanityInScene({ projectFile, title: "Fine" })).toBe(
       "your layer names"
     )
   })
@@ -255,14 +258,14 @@ describe("findSevereLanguageInScene", () => {
     const projectFile = parseLabProjectFile(
       labFile([layer({ params: { text: "NIGGER" }, type: "text" })])
     )
-    const where = findSevereLanguageInScene({ projectFile, title: "Fine" })
+    const where = findProfanityInScene({ projectFile, title: "Fine" })
 
     expect(where?.toLowerCase()).not.toContain("nig")
   })
 
   test("passes a clean scene", () => {
     expect(
-      findSevereLanguageInScene({
+      findProfanityInScene({
         description: "a calm noise field",
         projectFile: clean(),
         title: "Drift",
@@ -270,13 +273,16 @@ describe("findSevereLanguageInScene", () => {
     ).toBeNull()
   })
 
-  test("lets an ordinary swear through, so it is censored not blocked", () => {
+  test("catches an ordinary swear too, not just slurs", () => {
     const projectFile = parseLabProjectFile(
       labFile([layer({ params: { text: "fuck" }, type: "text" })])
     )
 
+    expect(findProfanityInScene({ projectFile, title: "Fine" })).toBe(
+      "the text on one of your text layers"
+    )
     expect(
-      findSevereLanguageInScene({ projectFile, title: "fucking gradient" })
-    ).toBeNull()
+      findProfanityInScene({ projectFile: clean(), title: "fucking gradient" })
+    ).toBe("the title")
   })
 })

--- a/src/lib/community/__tests__/language.test.ts
+++ b/src/lib/community/__tests__/language.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test"
 import {
   censorProjectFile,
   censorText,
+  findSevereLanguageInScene,
   hasProfanity,
+  hasSevereLanguage,
 } from "@/lib/community/language"
 import { parseLabProjectFile } from "@/lib/editor/project-file"
 
@@ -167,5 +169,114 @@ describe("censorProjectFile", () => {
     expect(reparsed.layers[0]?.name).toBe("****")
     expect(reparsed.layers[0]?.params.text).toBe("hello")
     expect(reparsed.layers).toHaveLength(1)
+  })
+})
+
+describe("the severe tier", () => {
+  test("blocks slurs", () => {
+    for (const value of ["NIGGER", "faggot", "a chink joke", "spic", "wetback"]) {
+      expect(hasSevereLanguage(value)).toBe(true)
+    }
+  })
+
+  test("lets ordinary swearing through, so it gets censored instead", () => {
+    for (const value of ["fuck this gradient", "shitty scene", "ass", "twat"]) {
+      expect(hasSevereLanguage(value)).toBe(false)
+      expect(hasProfanity(value)).toBe(true)
+    }
+  })
+
+  test("says nothing about words the dataset does not carry", () => {
+    expect(hasProfanity("damn")).toBe(false)
+    expect(hasSevereLanguage("damn")).toBe(false)
+  })
+
+  test("the house list is word-bounded, not a substring match", () => {
+    for (const clean of [
+      "raccoon study",
+      "cocoon",
+      "tycoon gradient",
+      "spice rack",
+      "suspicious noise",
+      "conspicuous",
+      "gobbledygook",
+      "packing list",
+      "Pakistan skyline",
+      "custard",
+      "bean field",
+    ]) {
+      expect(hasSevereLanguage(clean)).toBe(false)
+    }
+  })
+
+  test("still sees through leetspeak and casing", () => {
+    expect(hasSevereLanguage("N1GG3R")).toBe(true)
+  })
+})
+
+describe("findSevereLanguageInScene", () => {
+  const clean = () => parseLabProjectFile(labFile([layer()]))
+
+  test("names the title", () => {
+    expect(
+      findSevereLanguageInScene({ projectFile: clean(), title: "nigger" })
+    ).toBe("the title")
+  })
+
+  test("names the description", () => {
+    expect(
+      findSevereLanguageInScene({
+        description: "a scene about faggots",
+        projectFile: clean(),
+        title: "Fine",
+      })
+    ).toBe("the description")
+  })
+
+  test("names the text layer", () => {
+    const projectFile = parseLabProjectFile(
+      labFile([layer({ params: { text: "NIGGER" }, type: "text" })])
+    )
+
+    expect(findSevereLanguageInScene({ projectFile, title: "Fine" })).toBe(
+      "the text on one of your text layers"
+    )
+  })
+
+  test("names layer names", () => {
+    const projectFile = parseLabProjectFile(labFile([layer({ name: "kike" })]))
+
+    expect(findSevereLanguageInScene({ projectFile, title: "Fine" })).toBe(
+      "your layer names"
+    )
+  })
+
+  test("never echoes the word back at the person", () => {
+    const projectFile = parseLabProjectFile(
+      labFile([layer({ params: { text: "NIGGER" }, type: "text" })])
+    )
+    const where = findSevereLanguageInScene({ projectFile, title: "Fine" })
+
+    expect(where?.toLowerCase()).not.toContain("nig")
+  })
+
+  test("passes a clean scene", () => {
+    expect(
+      findSevereLanguageInScene({
+        description: "a calm noise field",
+        projectFile: clean(),
+        title: "Drift",
+      })
+    ).toBeNull()
+  })
+
+  test("lets an ordinary swear through, so it is censored not blocked", () => {
+    const projectFile = parseLabProjectFile(
+      labFile([layer({ params: { text: "fuck" }, type: "text" })])
+    )
+
+    expect(
+      findSevereLanguageInScene({ projectFile, title: "fucking gradient" })
+    ).toBeNull()
   })
 })

--- a/src/lib/community/__tests__/language.test.ts
+++ b/src/lib/community/__tests__/language.test.ts
@@ -185,7 +185,7 @@ describe("what counts as a bad word", () => {
   })
 
   test("catches the house additions", () => {
-    for (const value of ["goy", "goyim", "uncircumcised", "uncircumsized"]) {
+    for (const value of ["goy", "goys", "goyim"]) {
       expect(hasProfanity(value)).toBe(true)
     }
   })

--- a/src/lib/community/__tests__/profile.test.ts
+++ b/src/lib/community/__tests__/profile.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import { isUniqueViolation } from "@/lib/community/profile"
+import {
+  isUniqueViolation,
+  MAX_DISPLAY_NAME_LENGTH,
+  normalizeDisplayName,
+} from "@/lib/community/profile"
 
 function pgError(code: string) {
   return Object.assign(new Error("insert failed"), { code })
@@ -48,5 +52,27 @@ describe("isUniqueViolation", () => {
     looped.cause = looped
 
     expect(isUniqueViolation(looped)).toBe(false)
+  })
+})
+
+describe("normalizeDisplayName", () => {
+  test("masks a slur an identity provider handed us", () => {
+    expect(normalizeDisplayName("Fuck Face")).toBe("**** Face")
+  })
+
+  test("trims and caps a name that arrives unbounded", () => {
+    expect(normalizeDisplayName(`  ${"n".repeat(400)}  `)).toHaveLength(
+      MAX_DISPLAY_NAME_LENGTH
+    )
+  })
+
+  test("returns null for anything that is not a usable name", () => {
+    for (const value of ["", "   ", null, undefined, 42, {}]) {
+      expect(normalizeDisplayName(value)).toBeNull()
+    }
+  })
+
+  test("leaves an ordinary name alone", () => {
+    expect(normalizeDisplayName("Tobi Moccagatta")).toBe("Tobi Moccagatta")
   })
 })

--- a/src/lib/community/__tests__/profile.test.ts
+++ b/src/lib/community/__tests__/profile.test.ts
@@ -76,3 +76,25 @@ describe("normalizeDisplayName", () => {
     expect(normalizeDisplayName("Tobi Moccagatta")).toBe("Tobi Moccagatta")
   })
 })
+
+describe("normalizeDisplayName on a stored value", () => {
+  test("masks a legacy name that predates moderation", () => {
+    expect(normalizeDisplayName("Fuck Face")).toBe("**** Face")
+  })
+
+  test("is idempotent, so a healed row stops rewriting itself", () => {
+    const once = normalizeDisplayName("Fuck Face")
+
+    expect(normalizeDisplayName(once)).toBe(once)
+  })
+
+  test("leaves a clean stored name identical, so no pointless write", () => {
+    const stored = "Tobi Moccagatta"
+
+    expect(normalizeDisplayName(stored)).toBe(stored)
+  })
+
+  test("a null stored name stays null rather than becoming a write", () => {
+    expect(normalizeDisplayName(null)).toBeNull()
+  })
+})

--- a/src/lib/community/__tests__/publish.test.ts
+++ b/src/lib/community/__tests__/publish.test.ts
@@ -641,75 +641,40 @@ describe("findAssetOutsideScenePrefixes", () => {
   })
 })
 
-describe("moderating what gets stored", () => {
-  test("normalizeTitle masks a slur rather than rejecting the publish", () => {
-    expect(normalizeTitle("  fuck this gradient  ")).toBe("**** this gradient")
-  })
-
-  test("normalizeDraftTitle masks the same way", () => {
-    expect(normalizeDraftTitle("shit sketch")).toBe("**** sketch")
-  })
-
-  test("normalizeDescription masks", () => {
-    expect(normalizeDescription("a fucking noise field")).toBe(
-      "a ****ing noise field"
-    )
-  })
-
-  test("length caps still apply after masking", () => {
-    expect(normalizeTitle("a".repeat(200))).toHaveLength(MAX_TITLE_LENGTH)
-    expect(normalizeDescription("b".repeat(900))).toHaveLength(
-      MAX_DESCRIPTION_LENGTH
-    )
-  })
-
-  test("the slug never carries the word the title was masked for", () => {
-    const slug = buildSceneSlug(normalizeTitle("fuck gradients"))
-
-    expect(slug).toMatch(/^gradients-[a-z0-9]{6}$/)
-  })
-
-  test("a title that is nothing but a slur still yields a usable slug", () => {
-    expect(normalizeTitle("fuck")).toBe("****")
-    expect(buildSceneSlug(normalizeTitle("fuck"))).toMatch(
-      /^scene-[a-z0-9]{6}$/
-    )
-  })
-
-  test("validateProjectFilePayload hands back a censored body to store", () => {
-    const raw = labFile()
-    const dirty = raw.replace('"name":"Gradient"', '"name":"fuck"')
-    const validated = validateProjectFilePayload(dirty)
-
-    expect(validated.projectFile.layers[0]?.name).toBe("****")
-    expect(validated.body).not.toContain("fuck")
-    expect(JSON.parse(validated.body).layers[0].name).toBe("****")
-  })
-
-  test("a clean scene is stored byte-for-byte as it arrived", () => {
-    const raw = labFile()
-
-    expect(validateProjectFilePayload(raw).body).toBe(raw)
-    expect(validateDraftPayload(raw).body).toBe(raw)
-  })
-})
-
-describe("blocking a scene outright", () => {
-  test("a slur in the title stops the publish instead of masking it", () => {
+describe("publishing refuses a bad word outright", () => {
+  test("a slur in the title stops the publish", () => {
     expect(() => normalizeTitle("nigger")).toThrow(
       /we can't publish that.*the title/i
     )
   })
 
-  test("a slur in the description stops the publish", () => {
-    expect(() => normalizeDescription("a scene about faggots")).toThrow(
+  test("ordinary swearing stops it too, now that everything blocks", () => {
+    expect(() => normalizeTitle("fuck this gradient")).toThrow(
+      /we can't publish that.*the title/i
+    )
+    expect(() => normalizeDescription("a fucking noise field")).toThrow(
       /we can't publish that.*the description/i
     )
   })
 
-  test("the block runs before the censor, which would otherwise hide it", () => {
+  test("the house additions stop it", () => {
+    for (const word of ["goy", "goyim", "uncircumcised", "uncircumsized"]) {
+      expect(() => normalizeTitle(word)).toThrow(/we can't publish that/i)
+    }
+  })
+
+  test("a bad word anywhere in the scene stops it", () => {
     const raw = labFile()
     const dirty = raw.replace('"name":"Gradient"', '"name":"NIGGER"')
+
+    expect(() => validateProjectFilePayload(dirty)).toThrow(
+      /we can't publish that/i
+    )
+  })
+
+  test("the block reads the payload before the censor can hide it", () => {
+    const raw = labFile()
+    const dirty = raw.replace('"name":"Gradient"', '"name":"fuck"')
 
     expect(() => validateProjectFilePayload(dirty)).toThrow(
       /we can't publish that/i
@@ -728,18 +693,47 @@ describe("blocking a scene outright", () => {
     expect(message).not.toMatch(/nig/i)
   })
 
-  test("ordinary swearing is still censored, not blocked", () => {
-    expect(normalizeTitle("fuck this gradient")).toBe("**** this gradient")
-    expect(normalizeDescription("a fucking noise field")).toBe(
-      "a ****ing noise field"
+  test("a clean title and description pass through untouched", () => {
+    expect(normalizeTitle("  Drift Study  ")).toBe("Drift Study")
+    expect(normalizeDescription("  a calm noise field  ")).toBe(
+      "a calm noise field"
     )
   })
 
-  test("a draft can still hold what a publish will not", () => {
+  test("length caps still apply", () => {
+    expect(normalizeTitle("a".repeat(200))).toHaveLength(MAX_TITLE_LENGTH)
+    expect(normalizeDescription("b".repeat(900))).toHaveLength(
+      MAX_DESCRIPTION_LENGTH
+    )
+  })
+
+  test("a clean scene is stored byte-for-byte as it arrived", () => {
+    const raw = labFile()
+
+    expect(validateProjectFilePayload(raw).body).toBe(raw)
+    expect(validateDraftPayload(raw).body).toBe(raw)
+  })
+})
+
+describe("drafts stay permissive, and censor instead", () => {
+  test("a draft still saves what a publish will not", () => {
     const raw = labFile()
     const dirty = raw.replace('"name":"Gradient"', '"name":"NIGGER"')
 
     expect(() => validateDraftPayload(dirty)).not.toThrow()
+  })
+
+  test("a draft title is masked, not refused", () => {
     expect(normalizeDraftTitle("nigger")).toBe("******")
+    expect(normalizeDraftTitle("shit sketch")).toBe("**** sketch")
+  })
+
+  test("the draft body it stores is censored", () => {
+    const raw = labFile()
+    const dirty = raw.replace('"name":"Gradient"', '"name":"fuck"')
+    const validated = validateDraftPayload(dirty)
+
+    expect(validated.projectFile.layers[0]?.name).toBe("****")
+    expect(validated.body).not.toContain("fuck")
   })
 })

--- a/src/lib/community/__tests__/publish.test.ts
+++ b/src/lib/community/__tests__/publish.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_TITLE_LENGTH,
   MAX_TOTAL_BYTES,
   normalizeDescription,
+  normalizeDraftTitle,
   normalizeThumbnailUrl,
   normalizeTitle,
   planUploads,
@@ -637,5 +638,58 @@ describe("findAssetOutsideScenePrefixes", () => {
         new Set([scenePrefixFor("scn_own")])
       )
     ).toBeNull()
+  })
+})
+
+describe("moderating what gets stored", () => {
+  test("normalizeTitle masks a slur rather than rejecting the publish", () => {
+    expect(normalizeTitle("  fuck this gradient  ")).toBe("**** this gradient")
+  })
+
+  test("normalizeDraftTitle masks the same way", () => {
+    expect(normalizeDraftTitle("shit sketch")).toBe("**** sketch")
+  })
+
+  test("normalizeDescription masks", () => {
+    expect(normalizeDescription("a fucking noise field")).toBe(
+      "a ****ing noise field"
+    )
+  })
+
+  test("length caps still apply after masking", () => {
+    expect(normalizeTitle("a".repeat(200))).toHaveLength(MAX_TITLE_LENGTH)
+    expect(normalizeDescription("b".repeat(900))).toHaveLength(
+      MAX_DESCRIPTION_LENGTH
+    )
+  })
+
+  test("the slug never carries the word the title was masked for", () => {
+    const slug = buildSceneSlug(normalizeTitle("fuck gradients"))
+
+    expect(slug).toMatch(/^gradients-[a-z0-9]{6}$/)
+  })
+
+  test("a title that is nothing but a slur still yields a usable slug", () => {
+    expect(normalizeTitle("fuck")).toBe("****")
+    expect(buildSceneSlug(normalizeTitle("fuck"))).toMatch(
+      /^scene-[a-z0-9]{6}$/
+    )
+  })
+
+  test("validateProjectFilePayload hands back a censored body to store", () => {
+    const raw = labFile()
+    const dirty = raw.replace('"name":"Gradient"', '"name":"fuck"')
+    const validated = validateProjectFilePayload(dirty)
+
+    expect(validated.projectFile.layers[0]?.name).toBe("****")
+    expect(validated.body).not.toContain("fuck")
+    expect(JSON.parse(validated.body).layers[0].name).toBe("****")
+  })
+
+  test("a clean scene is stored byte-for-byte as it arrived", () => {
+    const raw = labFile()
+
+    expect(validateProjectFilePayload(raw).body).toBe(raw)
+    expect(validateDraftPayload(raw).body).toBe(raw)
   })
 })

--- a/src/lib/community/__tests__/publish.test.ts
+++ b/src/lib/community/__tests__/publish.test.ts
@@ -658,7 +658,7 @@ describe("publishing refuses a bad word outright", () => {
   })
 
   test("the house additions stop it", () => {
-    for (const word of ["goy", "goyim", "uncircumcised", "uncircumsized"]) {
+    for (const word of ["goy", "goys", "goyim"]) {
       expect(() => normalizeTitle(word)).toThrow(/we can't publish that/i)
     }
   })

--- a/src/lib/community/__tests__/publish.test.ts
+++ b/src/lib/community/__tests__/publish.test.ts
@@ -693,3 +693,53 @@ describe("moderating what gets stored", () => {
     expect(validateDraftPayload(raw).body).toBe(raw)
   })
 })
+
+describe("blocking a scene outright", () => {
+  test("a slur in the title stops the publish instead of masking it", () => {
+    expect(() => normalizeTitle("nigger")).toThrow(
+      /we can't publish that.*the title/i
+    )
+  })
+
+  test("a slur in the description stops the publish", () => {
+    expect(() => normalizeDescription("a scene about faggots")).toThrow(
+      /we can't publish that.*the description/i
+    )
+  })
+
+  test("the block runs before the censor, which would otherwise hide it", () => {
+    const raw = labFile()
+    const dirty = raw.replace('"name":"Gradient"', '"name":"NIGGER"')
+
+    expect(() => validateProjectFilePayload(dirty)).toThrow(
+      /we can't publish that/i
+    )
+  })
+
+  test("the message never repeats the word back", () => {
+    let message = ""
+
+    try {
+      normalizeTitle("nigger")
+    } catch (cause) {
+      message = cause instanceof Error ? cause.message : ""
+    }
+
+    expect(message).not.toMatch(/nig/i)
+  })
+
+  test("ordinary swearing is still censored, not blocked", () => {
+    expect(normalizeTitle("fuck this gradient")).toBe("**** this gradient")
+    expect(normalizeDescription("a fucking noise field")).toBe(
+      "a ****ing noise field"
+    )
+  })
+
+  test("a draft can still hold what a publish will not", () => {
+    const raw = labFile()
+    const dirty = raw.replace('"name":"Gradient"', '"name":"NIGGER"')
+
+    expect(() => validateDraftPayload(dirty)).not.toThrow()
+    expect(normalizeDraftTitle("nigger")).toBe("******")
+  })
+})

--- a/src/lib/community/handle.ts
+++ b/src/lib/community/handle.ts
@@ -1,3 +1,5 @@
+import { hasProfanity } from "@/lib/community/language"
+
 export const HANDLE_MIN_LENGTH = 3
 export const HANDLE_MAX_LENGTH = 30
 
@@ -69,7 +71,11 @@ export function isLookupableHandle(handle: string): boolean {
 }
 
 export function isValidHandle(handle: string): boolean {
-  return isLookupableHandle(handle) && !isReservedHandle(handle)
+  return (
+    isLookupableHandle(handle) &&
+    !isReservedHandle(handle) &&
+    !hasProfanity(handle)
+  )
 }
 
 const MAX_RAW_HANDLE_INPUT = 60
@@ -104,6 +110,10 @@ export function describeHandleInput(
     }
   }
 
+  if (hasProfanity(handle)) {
+    return { reason: "That handle reads as language we do not allow." }
+  }
+
   return { handle }
 }
 
@@ -121,13 +131,13 @@ export function deriveHandleSeed(input: {
 }): string {
   const fromName = slugifyHandle(input.name ?? "")
 
-  if (fromName.length >= HANDLE_MIN_LENGTH) {
+  if (fromName.length >= HANDLE_MIN_LENGTH && !hasProfanity(fromName)) {
     return fromName
   }
 
   const fromEmail = emailLocalPart(input.email)
 
-  if (fromEmail.length >= HANDLE_MIN_LENGTH) {
+  if (fromEmail.length >= HANDLE_MIN_LENGTH && !hasProfanity(fromEmail)) {
     return fromEmail
   }
 

--- a/src/lib/community/language.ts
+++ b/src/lib/community/language.ts
@@ -2,6 +2,7 @@ import {
   asteriskCensorStrategy,
   DataSet,
   englishDataset,
+  type EnglishProfaneWord,
   englishRecommendedTransformers,
   pattern,
   RegExpMatcher,
@@ -28,7 +29,9 @@ function getCensor(): TextCensor {
   return censor
 }
 
-const SEVERE_DATASET_WORDS = new Set([
+const SEVERE_DATASET_WORDS: ReadonlySet<EnglishProfaneWord> = new Set<
+  EnglishProfaneWord
+>([
   "abeed",
   "abo",
   "africoon",
@@ -71,17 +74,16 @@ const SEVERE_HOUSE_PATTERNS = [
 
 function getSevereMatcher(): RegExpMatcher {
   if (!severeMatcher) {
-    const dataset = new DataSet<{ originalWord: string }>()
+    const dataset = new DataSet<{ originalWord: EnglishProfaneWord }>()
       .addAll(englishDataset)
-      .removePhrasesIf(
-        (phrase) =>
-          !SEVERE_DATASET_WORDS.has(phrase.metadata?.originalWord ?? "")
-      )
+      .removePhrasesIf((phrase) => {
+        const word = phrase.metadata?.originalWord
+
+        return !(word && SEVERE_DATASET_WORDS.has(word))
+      })
 
     for (const raw of SEVERE_HOUSE_PATTERNS) {
-      dataset.addPhrase((phrase) =>
-        phrase.setMetadata({ originalWord: "house" }).addPattern(raw)
-      )
+      dataset.addPhrase((phrase) => phrase.addPattern(raw))
     }
 
     severeMatcher = new RegExpMatcher({

--- a/src/lib/community/language.ts
+++ b/src/lib/community/language.ts
@@ -1,7 +1,9 @@
 import {
   asteriskCensorStrategy,
+  DataSet,
   englishDataset,
   englishRecommendedTransformers,
+  pattern,
   RegExpMatcher,
   TextCensor,
 } from "obscenity"
@@ -9,6 +11,7 @@ import type { LabProjectFile } from "@/lib/editor/project-file"
 
 let matcher: RegExpMatcher | null = null
 let censor: TextCensor | null = null
+let severeMatcher: RegExpMatcher | null = null
 
 function getMatcher(): RegExpMatcher {
   matcher ??= new RegExpMatcher({
@@ -25,8 +28,77 @@ function getCensor(): TextCensor {
   return censor
 }
 
+const SEVERE_DATASET_WORDS = new Set([
+  "abeed",
+  "abo",
+  "africoon",
+  "arabush",
+  "boonga",
+  "chingchong",
+  "chink",
+  "dyke",
+  "fag",
+  "kike",
+  "negro",
+  "nigger",
+  "retard",
+  "spastic",
+  "tranny",
+])
+
+const SEVERE_HOUSE_PATTERNS = [
+  pattern`|spic|`,
+  pattern`|spics|`,
+  pattern`|coon|`,
+  pattern`|coons|`,
+  pattern`|gook|`,
+  pattern`|gooks|`,
+  pattern`|paki|`,
+  pattern`|pakis|`,
+  pattern`|beaner|`,
+  pattern`|beaners|`,
+  pattern`|wetback|`,
+  pattern`|wetbacks|`,
+  pattern`|towelhead|`,
+  pattern`|towelheads|`,
+  pattern`|raghead|`,
+  pattern`|ragheads|`,
+  pattern`|shemale|`,
+  pattern`|shemales|`,
+  pattern`|mongoloid|`,
+  pattern`|mongoloids|`,
+]
+
+function getSevereMatcher(): RegExpMatcher {
+  if (!severeMatcher) {
+    const dataset = new DataSet<{ originalWord: string }>()
+      .addAll(englishDataset)
+      .removePhrasesIf(
+        (phrase) =>
+          !SEVERE_DATASET_WORDS.has(phrase.metadata?.originalWord ?? "")
+      )
+
+    for (const raw of SEVERE_HOUSE_PATTERNS) {
+      dataset.addPhrase((phrase) =>
+        phrase.setMetadata({ originalWord: "house" }).addPattern(raw)
+      )
+    }
+
+    severeMatcher = new RegExpMatcher({
+      ...dataset.build(),
+      ...englishRecommendedTransformers,
+    })
+  }
+
+  return severeMatcher
+}
+
 export function hasProfanity(value: string): boolean {
   return value.length > 0 && getMatcher().hasMatch(value)
+}
+
+export function hasSevereLanguage(value: string): boolean {
+  return value.length > 0 && getSevereMatcher().hasMatch(value)
 }
 
 export function censorText(value: string): string {
@@ -40,6 +112,51 @@ export function censorText(value: string): string {
 }
 
 const TEXT_LAYER_PARAM = "text"
+
+export const BLOCKED_LANGUAGE_MESSAGE =
+  "We're all for free speech, but we can't publish that."
+
+export function describeBlockedLanguage(where: string): string {
+  return `${BLOCKED_LANGUAGE_MESSAGE} Have a look at ${where}.`
+}
+
+export function findSevereLanguageInProjectFile(
+  projectFile: LabProjectFile
+): string | null {
+  for (const layer of projectFile.layers) {
+    const rendered = layer.params[TEXT_LAYER_PARAM]
+
+    if (
+      layer.type === "text" &&
+      typeof rendered === "string" &&
+      hasSevereLanguage(rendered)
+    ) {
+      return "the text on one of your text layers"
+    }
+
+    if (hasSevereLanguage(layer.name)) {
+      return "your layer names"
+    }
+  }
+
+  return null
+}
+
+export function findSevereLanguageInScene(input: {
+  description?: string | null
+  projectFile: LabProjectFile
+  title?: string | null
+}): string | null {
+  if (input.title && hasSevereLanguage(input.title)) {
+    return "the title"
+  }
+
+  if (input.description && hasSevereLanguage(input.description)) {
+    return "the description"
+  }
+
+  return findSevereLanguageInProjectFile(input.projectFile)
+}
 
 export interface CensoredProjectFile {
   changed: boolean

--- a/src/lib/community/language.ts
+++ b/src/lib/community/language.ts
@@ -12,44 +12,8 @@ import type { LabProjectFile } from "@/lib/editor/project-file"
 
 let matcher: RegExpMatcher | null = null
 let censor: TextCensor | null = null
-let severeMatcher: RegExpMatcher | null = null
 
-function getMatcher(): RegExpMatcher {
-  matcher ??= new RegExpMatcher({
-    ...englishDataset.build(),
-    ...englishRecommendedTransformers,
-  })
-
-  return matcher
-}
-
-function getCensor(): TextCensor {
-  censor ??= new TextCensor().setStrategy(asteriskCensorStrategy())
-
-  return censor
-}
-
-const SEVERE_DATASET_WORDS: ReadonlySet<EnglishProfaneWord> = new Set<
-  EnglishProfaneWord
->([
-  "abeed",
-  "abo",
-  "africoon",
-  "arabush",
-  "boonga",
-  "chingchong",
-  "chink",
-  "dyke",
-  "fag",
-  "kike",
-  "negro",
-  "nigger",
-  "retard",
-  "spastic",
-  "tranny",
-])
-
-const SEVERE_HOUSE_PATTERNS = [
+const HOUSE_PATTERNS = [
   pattern`|spic|`,
   pattern`|spics|`,
   pattern`|coon|`,
@@ -70,37 +34,40 @@ const SEVERE_HOUSE_PATTERNS = [
   pattern`|shemales|`,
   pattern`|mongoloid|`,
   pattern`|mongoloids|`,
+  pattern`|goy|`,
+  pattern`|goys|`,
+  pattern`|goyim|`,
+  pattern`|uncircumcised|`,
+  pattern`|uncircumsized|`,
 ]
 
-function getSevereMatcher(): RegExpMatcher {
-  if (!severeMatcher) {
-    const dataset = new DataSet<{ originalWord: EnglishProfaneWord }>()
-      .addAll(englishDataset)
-      .removePhrasesIf((phrase) => {
-        const word = phrase.metadata?.originalWord
+function getMatcher(): RegExpMatcher {
+  if (!matcher) {
+    const dataset = new DataSet<{ originalWord: EnglishProfaneWord }>().addAll(
+      englishDataset
+    )
 
-        return !(word && SEVERE_DATASET_WORDS.has(word))
-      })
-
-    for (const raw of SEVERE_HOUSE_PATTERNS) {
+    for (const raw of HOUSE_PATTERNS) {
       dataset.addPhrase((phrase) => phrase.addPattern(raw))
     }
 
-    severeMatcher = new RegExpMatcher({
+    matcher = new RegExpMatcher({
       ...dataset.build(),
       ...englishRecommendedTransformers,
     })
   }
 
-  return severeMatcher
+  return matcher
+}
+
+function getCensor(): TextCensor {
+  censor ??= new TextCensor().setStrategy(asteriskCensorStrategy())
+
+  return censor
 }
 
 export function hasProfanity(value: string): boolean {
   return value.length > 0 && getMatcher().hasMatch(value)
-}
-
-export function hasSevereLanguage(value: string): boolean {
-  return value.length > 0 && getSevereMatcher().hasMatch(value)
 }
 
 export function censorText(value: string): string {
@@ -122,7 +89,7 @@ export function describeBlockedLanguage(where: string): string {
   return `${BLOCKED_LANGUAGE_MESSAGE} Have a look at ${where}.`
 }
 
-export function findSevereLanguageInProjectFile(
+export function findProfanityInProjectFile(
   projectFile: LabProjectFile
 ): string | null {
   for (const layer of projectFile.layers) {
@@ -131,12 +98,12 @@ export function findSevereLanguageInProjectFile(
     if (
       layer.type === "text" &&
       typeof rendered === "string" &&
-      hasSevereLanguage(rendered)
+      hasProfanity(rendered)
     ) {
       return "the text on one of your text layers"
     }
 
-    if (hasSevereLanguage(layer.name)) {
+    if (hasProfanity(layer.name)) {
       return "your layer names"
     }
   }
@@ -144,20 +111,20 @@ export function findSevereLanguageInProjectFile(
   return null
 }
 
-export function findSevereLanguageInScene(input: {
+export function findProfanityInScene(input: {
   description?: string | null
   projectFile: LabProjectFile
   title?: string | null
 }): string | null {
-  if (input.title && hasSevereLanguage(input.title)) {
+  if (input.title && hasProfanity(input.title)) {
     return "the title"
   }
 
-  if (input.description && hasSevereLanguage(input.description)) {
+  if (input.description && hasProfanity(input.description)) {
     return "the description"
   }
 
-  return findSevereLanguageInProjectFile(input.projectFile)
+  return findProfanityInProjectFile(input.projectFile)
 }
 
 export interface CensoredProjectFile {

--- a/src/lib/community/language.ts
+++ b/src/lib/community/language.ts
@@ -1,0 +1,81 @@
+import {
+  asteriskCensorStrategy,
+  englishDataset,
+  englishRecommendedTransformers,
+  RegExpMatcher,
+  TextCensor,
+} from "obscenity"
+import type { LabProjectFile } from "@/lib/editor/project-file"
+
+let matcher: RegExpMatcher | null = null
+let censor: TextCensor | null = null
+
+function getMatcher(): RegExpMatcher {
+  matcher ??= new RegExpMatcher({
+    ...englishDataset.build(),
+    ...englishRecommendedTransformers,
+  })
+
+  return matcher
+}
+
+function getCensor(): TextCensor {
+  censor ??= new TextCensor().setStrategy(asteriskCensorStrategy())
+
+  return censor
+}
+
+export function hasProfanity(value: string): boolean {
+  return value.length > 0 && getMatcher().hasMatch(value)
+}
+
+export function censorText(value: string): string {
+  if (value.length === 0) {
+    return value
+  }
+
+  const matches = getMatcher().getAllMatches(value, true)
+
+  return matches.length === 0 ? value : getCensor().applyTo(value, matches)
+}
+
+const TEXT_LAYER_PARAM = "text"
+
+export interface CensoredProjectFile {
+  changed: boolean
+  projectFile: LabProjectFile
+}
+
+export function censorProjectFile(
+  projectFile: LabProjectFile
+): CensoredProjectFile {
+  let changed = false
+
+  const layers = projectFile.layers.map((layer) => {
+    const name = censorText(layer.name)
+    const rendered = layer.params[TEXT_LAYER_PARAM]
+    const text =
+      layer.type === "text" && typeof rendered === "string"
+        ? censorText(rendered)
+        : rendered
+
+    if (name === layer.name && text === rendered) {
+      return layer
+    }
+
+    changed = true
+
+    return {
+      ...layer,
+      name,
+      params:
+        text === rendered
+          ? layer.params
+          : { ...layer.params, [TEXT_LAYER_PARAM]: text },
+    }
+  }) as LabProjectFile["layers"]
+
+  return changed
+    ? { changed, projectFile: { ...projectFile, layers } }
+    : { changed, projectFile }
+}

--- a/src/lib/community/language.ts
+++ b/src/lib/community/language.ts
@@ -37,8 +37,6 @@ const HOUSE_PATTERNS = [
   pattern`|goy|`,
   pattern`|goys|`,
   pattern`|goyim|`,
-  pattern`|uncircumcised|`,
-  pattern`|uncircumsized|`,
 ]
 
 function getMatcher(): RegExpMatcher {

--- a/src/lib/community/profile.ts
+++ b/src/lib/community/profile.ts
@@ -1,7 +1,18 @@
 import { eq } from "drizzle-orm"
 import { buildHandleCandidates } from "@/lib/community/handle"
+import { censorText } from "@/lib/community/language"
 import { getDatabase } from "@/lib/db"
 import { handleClaims, profiles } from "@/lib/db/schema"
+
+export const MAX_DISPLAY_NAME_LENGTH = 80
+
+export function normalizeDisplayName(value: unknown): string | null {
+  const name = typeof value === "string" ? value.trim() : ""
+
+  return name.length > 0
+    ? censorText(name.slice(0, MAX_DISPLAY_NAME_LENGTH))
+    : null
+}
 
 export interface ProfileSeed {
   avatarUrl?: string | null
@@ -90,7 +101,7 @@ export async function ensureProfile(
   if (existing) {
     await backfillMissingClaim(existing)
 
-    const displayName = seed.name ?? existing.displayName
+    const displayName = normalizeDisplayName(seed.name) ?? existing.displayName
     const avatarUrl = seed.avatarUrl ?? existing.avatarUrl
 
     if (
@@ -116,7 +127,7 @@ export async function ensureProfile(
           .insert(profiles)
           .values({
             avatarUrl: seed.avatarUrl ?? null,
-            displayName: seed.name ?? null,
+            displayName: normalizeDisplayName(seed.name),
             handle,
             userId,
           })

--- a/src/lib/community/profile.ts
+++ b/src/lib/community/profile.ts
@@ -101,7 +101,9 @@ export async function ensureProfile(
   if (existing) {
     await backfillMissingClaim(existing)
 
-    const displayName = normalizeDisplayName(seed.name) ?? existing.displayName
+    const displayName =
+      normalizeDisplayName(seed.name) ??
+      normalizeDisplayName(existing.displayName)
     const avatarUrl = seed.avatarUrl ?? existing.avatarUrl
 
     if (

--- a/src/lib/community/publish-client.ts
+++ b/src/lib/community/publish-client.ts
@@ -1,7 +1,7 @@
 import { buildRenderProjectState } from "@/lib/agent-bridge/screenshot"
 import {
   describeBlockedLanguage,
-  findSevereLanguageInScene,
+  findProfanityInScene,
 } from "@/lib/community/language"
 import { describeUploadLimit } from "@/lib/community/upload-limits"
 import {
@@ -403,7 +403,7 @@ export async function publishScene(input: {
     throw new Error(plan.problem)
   }
 
-  const severeLocation = findSevereLanguageInScene({
+  const severeLocation = findProfanityInScene({
     description: input.description,
     projectFile,
     title: input.title,

--- a/src/lib/community/publish-client.ts
+++ b/src/lib/community/publish-client.ts
@@ -1,4 +1,8 @@
 import { buildRenderProjectState } from "@/lib/agent-bridge/screenshot"
+import {
+  describeBlockedLanguage,
+  findSevereLanguageInScene,
+} from "@/lib/community/language"
 import { describeUploadLimit } from "@/lib/community/upload-limits"
 import {
   buildLabProjectFile,
@@ -397,6 +401,16 @@ export async function publishScene(input: {
 
   if (plan.problem) {
     throw new Error(plan.problem)
+  }
+
+  const severeLocation = findSevereLanguageInScene({
+    description: input.description,
+    projectFile,
+    title: input.title,
+  })
+
+  if (severeLocation) {
+    throw new Error(describeBlockedLanguage(severeLocation))
   }
 
   const thumbnailBlob = await captureThumbnail(input.thumbnailTime)

--- a/src/lib/community/publish.ts
+++ b/src/lib/community/publish.ts
@@ -7,8 +7,8 @@ import {
   censorProjectFile,
   censorText,
   describeBlockedLanguage,
-  findSevereLanguageInProjectFile,
-  hasSevereLanguage,
+  findProfanityInProjectFile,
+  hasProfanity,
 } from "@/lib/community/language"
 import { keyFromPublicUrl, scenePrefixOf } from "@/lib/community/r2"
 import {
@@ -160,7 +160,7 @@ export interface PublishValidation {
 function parseScenePayload(raw: string): {
   body: string
   projectFile: LabProjectFile
-  severeLocation: string | null
+  profanityLocation: string | null
 } {
   if (raw.length > MAX_LAB_BYTES) {
     throw new Error("This scene is too large.")
@@ -174,13 +174,13 @@ function parseScenePayload(raw: string): {
     }
   }
 
-  const severeLocation = findSevereLanguageInProjectFile(parsed)
+  const profanityLocation = findProfanityInProjectFile(parsed)
   const censored = censorProjectFile(parsed)
 
   return {
     body: censored.changed ? JSON.stringify(censored.projectFile) : raw,
     projectFile: censored.projectFile,
-    severeLocation,
+    profanityLocation,
   }
 }
 
@@ -209,10 +209,10 @@ export function validateDraftPayload(raw: string): PublishValidation {
 }
 
 export function validateProjectFilePayload(raw: string): PublishValidation {
-  const { body, projectFile, severeLocation } = parseScenePayload(raw)
+  const { body, projectFile, profanityLocation } = parseScenePayload(raw)
 
-  if (severeLocation) {
-    throw new Error(describeBlockedLanguage(severeLocation))
+  if (profanityLocation) {
+    throw new Error(describeBlockedLanguage(profanityLocation))
   }
 
   if (projectFile.layers.length === 0) {
@@ -239,11 +239,11 @@ export function normalizeTitle(value: unknown): string {
 
   const capped = title.slice(0, MAX_TITLE_LENGTH)
 
-  if (hasSevereLanguage(capped)) {
+  if (hasProfanity(capped)) {
     throw new Error(describeBlockedLanguage("the title"))
   }
 
-  return censorText(capped)
+  return capped
 }
 
 export function normalizeDraftTitle(value: unknown): string {
@@ -327,11 +327,11 @@ export function normalizeDescription(value: unknown): string | null {
 
   const capped = description.slice(0, MAX_DESCRIPTION_LENGTH)
 
-  if (hasSevereLanguage(capped)) {
+  if (hasProfanity(capped)) {
     throw new Error(describeBlockedLanguage("the description"))
   }
 
-  return censorText(capped)
+  return capped
 }
 
 export interface QuotaCheck {

--- a/src/lib/community/publish.ts
+++ b/src/lib/community/publish.ts
@@ -3,7 +3,13 @@ import { customAlphabet } from "nanoid"
 import { getDatabase } from "@/lib/db"
 import { scenes, uploadQuota } from "@/lib/db/schema"
 import { slugifyHandle } from "@/lib/community/handle"
-import { censorProjectFile, censorText } from "@/lib/community/language"
+import {
+  censorProjectFile,
+  censorText,
+  describeBlockedLanguage,
+  findSevereLanguageInProjectFile,
+  hasSevereLanguage,
+} from "@/lib/community/language"
 import { keyFromPublicUrl, scenePrefixOf } from "@/lib/community/r2"
 import {
   DEFAULT_DRAFT_TITLE,
@@ -154,6 +160,7 @@ export interface PublishValidation {
 function parseScenePayload(raw: string): {
   body: string
   projectFile: LabProjectFile
+  severeLocation: string | null
 } {
   if (raw.length > MAX_LAB_BYTES) {
     throw new Error("This scene is too large.")
@@ -167,11 +174,13 @@ function parseScenePayload(raw: string): {
     }
   }
 
+  const severeLocation = findSevereLanguageInProjectFile(parsed)
   const censored = censorProjectFile(parsed)
 
   return {
     body: censored.changed ? JSON.stringify(censored.projectFile) : raw,
     projectFile: censored.projectFile,
+    severeLocation,
   }
 }
 
@@ -200,7 +209,11 @@ export function validateDraftPayload(raw: string): PublishValidation {
 }
 
 export function validateProjectFilePayload(raw: string): PublishValidation {
-  const { body, projectFile } = parseScenePayload(raw)
+  const { body, projectFile, severeLocation } = parseScenePayload(raw)
+
+  if (severeLocation) {
+    throw new Error(describeBlockedLanguage(severeLocation))
+  }
 
   if (projectFile.layers.length === 0) {
     throw new Error("A scene needs at least one visible layer.")
@@ -224,7 +237,13 @@ export function normalizeTitle(value: unknown): string {
     throw new Error("A title is required.")
   }
 
-  return censorText(title.slice(0, MAX_TITLE_LENGTH))
+  const capped = title.slice(0, MAX_TITLE_LENGTH)
+
+  if (hasSevereLanguage(capped)) {
+    throw new Error(describeBlockedLanguage("the title"))
+  }
+
+  return censorText(capped)
 }
 
 export function normalizeDraftTitle(value: unknown): string {
@@ -302,9 +321,17 @@ export async function collectAllowedScenePrefixes(input: {
 export function normalizeDescription(value: unknown): string | null {
   const description = typeof value === "string" ? value.trim() : ""
 
-  return description.length > 0
-    ? censorText(description.slice(0, MAX_DESCRIPTION_LENGTH))
-    : null
+  if (description.length === 0) {
+    return null
+  }
+
+  const capped = description.slice(0, MAX_DESCRIPTION_LENGTH)
+
+  if (hasSevereLanguage(capped)) {
+    throw new Error(describeBlockedLanguage("the description"))
+  }
+
+  return censorText(capped)
 }
 
 export interface QuotaCheck {

--- a/src/lib/community/publish.ts
+++ b/src/lib/community/publish.ts
@@ -3,6 +3,7 @@ import { customAlphabet } from "nanoid"
 import { getDatabase } from "@/lib/db"
 import { scenes, uploadQuota } from "@/lib/db/schema"
 import { slugifyHandle } from "@/lib/community/handle"
+import { censorProjectFile, censorText } from "@/lib/community/language"
 import { keyFromPublicUrl, scenePrefixOf } from "@/lib/community/r2"
 import {
   DEFAULT_DRAFT_TITLE,
@@ -144,29 +145,42 @@ export function dayBucket(now: Date): string {
 }
 
 export interface PublishValidation {
+  body: string
   hasCustomShader: boolean
   layerTypes: string[]
   projectFile: LabProjectFile
 }
 
-function parseScenePayload(raw: string): LabProjectFile {
+function parseScenePayload(raw: string): {
+  body: string
+  projectFile: LabProjectFile
+} {
   if (raw.length > MAX_LAB_BYTES) {
     throw new Error("This scene is too large.")
   }
 
-  const projectFile = parseLabProjectFile(raw)
+  const parsed = parseLabProjectFile(raw)
 
-  for (const asset of projectFile.assets) {
+  for (const asset of parsed.assets) {
     if (asset.url && !isAllowedAssetOrigin(asset.url)) {
       throw new Error(`"${asset.fileName}" points at an untrusted host.`)
     }
   }
 
-  return projectFile
+  const censored = censorProjectFile(parsed)
+
+  return {
+    body: censored.changed ? JSON.stringify(censored.projectFile) : raw,
+    projectFile: censored.projectFile,
+  }
 }
 
-function describeScene(projectFile: LabProjectFile): PublishValidation {
+function describeScene(
+  projectFile: LabProjectFile,
+  body: string
+): PublishValidation {
   return {
+    body,
     hasCustomShader: hasImportedCustomShaderCode(projectFile),
     layerTypes: [...new Set(projectFile.layers.map((layer) => layer.type))],
     projectFile,
@@ -174,16 +188,19 @@ function describeScene(projectFile: LabProjectFile): PublishValidation {
 }
 
 export function validateDraftPayload(raw: string): PublishValidation {
-  const projectFile = parseScenePayload(raw)
+  const { body, projectFile } = parseScenePayload(raw)
 
-  return describeScene({
-    ...projectFile,
-    assets: projectFile.assets.filter((asset) => asset.url),
-  })
+  return describeScene(
+    {
+      ...projectFile,
+      assets: projectFile.assets.filter((asset) => asset.url),
+    },
+    body
+  )
 }
 
 export function validateProjectFilePayload(raw: string): PublishValidation {
-  const projectFile = parseScenePayload(raw)
+  const { body, projectFile } = parseScenePayload(raw)
 
   if (projectFile.layers.length === 0) {
     throw new Error("A scene needs at least one visible layer.")
@@ -197,7 +214,7 @@ export function validateProjectFilePayload(raw: string): PublishValidation {
     }
   }
 
-  return describeScene(projectFile)
+  return describeScene(projectFile, body)
 }
 
 export function normalizeTitle(value: unknown): string {
@@ -207,14 +224,14 @@ export function normalizeTitle(value: unknown): string {
     throw new Error("A title is required.")
   }
 
-  return title.slice(0, MAX_TITLE_LENGTH)
+  return censorText(title.slice(0, MAX_TITLE_LENGTH))
 }
 
 export function normalizeDraftTitle(value: unknown): string {
   const title = typeof value === "string" ? value.trim() : ""
 
   return title.length > 0
-    ? title.slice(0, MAX_TITLE_LENGTH)
+    ? censorText(title.slice(0, MAX_TITLE_LENGTH))
     : DEFAULT_DRAFT_TITLE
 }
 
@@ -286,7 +303,7 @@ export function normalizeDescription(value: unknown): string | null {
   const description = typeof value === "string" ? value.trim() : ""
 
   return description.length > 0
-    ? description.slice(0, MAX_DESCRIPTION_LENGTH)
+    ? censorText(description.slice(0, MAX_DESCRIPTION_LENGTH))
     : null
 }
 


### PR DESCRIPTION
Stacked on #118.

Adds [obscenity](https://github.com/jo3-l/obscenity) and gates every free-text field a person can type. **Publishing refuses on any bad word.** Drafts and display names censor instead, because refusing there would break something rather than moderate it.

## Behaviour

| Field | Path | Behaviour |
|---|---|---|
| Scene title | `normalizeTitle` | **refuse** |
| Scene description | `normalizeDescription` | **refuse** |
| Layer names | `findProfanityInProjectFile` | **refuse** |
| Text-layer canvas string | `findProfanityInProjectFile` | **refuse** |
| Handle (user-chosen) | `describeHandleInput` | **refuse** |
| Draft title + draft `.lab.json` | `censorText` / `censorProjectFile` | censor — your own workspace, autosave shouldn't fail on you |
| Profile display name | `normalizeDisplayName` | censor — comes from the identity provider, refusing = failed signup |
| Handle (auto-derived) | `deriveHandleSeed` | falls back to email, then `maker` |

The message is `We're all for free speech, but we can't publish that.` plus **where** to look — the title, the description, a layer name, the text on a text layer. It names the place and never echoes the word back.

## Enforced twice, on purpose

- **Client** (`publish-client.ts:406`) — runs before `captureThumbnail`, so a refused scene never rasterizes a frame and never uploads anything.
- **Server** (publish route) — the authority. A client check is a suggestion; anyone can curl the endpoint.

## Using the library, extended through its own API

From obscenity: `englishDataset` (69 words, ~119 patterns, **plus a 66-term whitelist** — that's what saves `Scunthorpe`, `assassin`, `bass`, `cocktail`, `grapes`), `englishRecommendedTransformers` (leetspeak, unicode confusables, casing, repeat-collapsing), `RegExpMatcher`, `TextCensor`, and `DataSet`/`pattern` for extension.

Ours: 23 house patterns for words the dataset omits — `spic`, `coon`, `gook`, `paki`, `beaner`, `wetback`, `towelhead`, `raghead`, `shemale`, `mongoloid`, `goy`/`goys`/`goyim` — each written `` pattern`|word|` `` so they match whole words only. Without the boundaries, `coon` eats `raccoon`, `spic` eats `suspicious`, `paki` eats `Pakistan`. All verified passing.

No severity tiering: obscenity ships none (metadata is `{ originalWord }`, a flat union), and everything blocks equally now anyway.

## The ordering constraint

In `parseScenePayload`, this order is load-bearing:

```ts
const profanityLocation = findProfanityInProjectFile(parsed)  // FIRST
const censored = censorProjectFile(parsed)                    // then
```

Flip them and the censor masks the word, the check reads the masked copy, finds nothing, and the feature **silently stops working with every test still green**. There's a test pinned on exactly that.

## Cost of blocking everything

Measured on 43 realistic scene titles — **10 refuse**: `Dick Tracy`, `Moby Dick`, `Sex Pistols`, `Cockpit HUD`, `Shiitake texture`, `Wankel rotary engine`, `Blue-footed booby`, `Rapeseed field`, `Slutsky equation`, `Cummings poem`.

The whitelist holds on the classic traps (`Cocktail`, `Bass drop`, `Scunthorpe`, `Assassin's Creed`, `Analysis`, `Titan`, `Peacock`, `Titmouse`, `Negroni`, `Sexagesimal`, `Goya`). Deliberate trade, requested.

Handles are the harshest case: someone named Dickson or Cummings can't take their own name. They get `maker-2` on signup and can't rename to it.

## The stored `.lab.json`

Only re-serialized when the censor actually changed something — `censorProjectFile` reports `changed`, and a clean scene uploads its original bytes. That scopes the zod round-trip risk to scenes that have something to mask. A test asserts unknown/future passthrough keys survive re-serialization at every level, since `looseObject` carrying unrecognized fields is what would quietly eat data.

## Known gaps

- **Thumbnails are images, not text.** The thumbnail is a client-rendered JPEG PUT straight to R2; the server never sees the pixels. Blocking text does clean the *published* thumbnail (it's a render of the scene, and the client check fires before capture) — but a scene can be offensive with no words at all: shapes arranged into something vile, or an uploaded image asset. No wordlist reaches that.
- **Draft saves still upload a thumbnail.** `runDraftSave` has no gate, so a dirty scene's JPEG lands on public R2 at an unguessable URL even though the publish is refused. Cheap to close; deliberately left for now.
- **Legacy display names in scene listings.** `scenes.ts:87/329/425` join `profiles.displayName` directly and never call `ensureProfile`, so a pre-moderation name on a scene card persists until that author next authenticates. Needs a one-off backfill, not a code path.
- **Separator bypasses** — `f.u.c.k` and `f u c k` get through. Documented obscenity tradeoff; the fix causes worse false positives.
- Custom shader source and report notes are deliberately untouched (masking code breaks compilation; quoting the abuse is the point of a report).

## Verification

- `bun test` — **797 pass, 0 fail** (~55 new)
- `bun run typecheck`, `bun run lint` — clean on touched files
- `bun run build` — production build succeeds
- obscenity confirmed free of Node builtins, so the new client-path import is browser-safe
- `/tools/shader-lab` and `/community` both serve 200 with no new console errors
- Negative controls run on the house patterns (stock obscenity does **not** match them, so they're load-bearing) and on the unicode handling (emoji, CJK, astral-plane all censor without mangling surrogates)

Not exercised against the live Neon DB / R2 — that would mean writing real profane rows and objects to shared dev infra.