### PR TITLE
feat: instrument the WebGPU renderer and align Sentry config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,10 @@ NEXT_PUBLIC_SANITY_API_READ_TOKEN=""
 # sends nothing, so the app runs fine unconfigured.
 NEXT_PUBLIC_SENTRY_DSN=""
 
+# Optional trace sampling override, 0-1. Defaults to 0.05 in production and 0
+# everywhere else. Out-of-range values fall back to the default.
+# NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=""
+
 # Build-time only - uploads source maps so production stack traces are readable.
 # Without it the build silently skips the upload. org/project live in next.config.ts.
 # Create at: https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/

--- a/next.config.ts
+++ b/next.config.ts
@@ -140,11 +140,29 @@ const NextApp = () => {
   return plugins.reduce((config, plugin) => plugin(config), nextConfig)
 }
 
+// Not the token alone: a dev machine can have one in .env.sentry-build-plugin.
+const canPublishSentryArtifacts =
+  process.env.VERCEL === "1" && Boolean(process.env.SENTRY_AUTH_TOKEN)
+
+if (process.env.VERCEL_ENV === "production" && !canPublishSentryArtifacts) {
+  console.warn(
+    "[sentry] SENTRY_AUTH_TOKEN is not set — skipping sourcemap upload and release creation. Production stack traces will be minified."
+  )
+}
+
 export default withSentryConfig(NextApp, {
   org: "basement-studio",
   project: "shader-lab",
-  // Source maps upload only when SENTRY_AUTH_TOKEN is present in the build env.
+  silent: !process.env.VERCEL,
   widenClientFileUpload: true,
   tunnelRoute: "/monitoring",
-  silent: !process.env.CI,
+  sourcemaps: { disable: !canPublishSentryArtifacts },
+  release: {
+    create: canPublishSentryArtifacts,
+    // Must be explicit: @sentry/nextjs skips release name resolution when
+    // `create` is false, leaving tokenless builds with no release tag at all.
+    ...(process.env.VERCEL_GIT_COMMIT_SHA
+      ? { name: process.env.VERCEL_GIT_COMMIT_SHA }
+      : {}),
+  },
 })

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,7 +1,0 @@
-import * as Sentry from "@sentry/nextjs"
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1 : 0.1,
-})

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,8 +1,0 @@
-import * as Sentry from "@sentry/nextjs"
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1 : 0.1,
-  includeLocalVariables: true,
-})

--- a/src/components/editor/editor-canvas-viewport.tsx
+++ b/src/components/editor/editor-canvas-viewport.tsx
@@ -11,26 +11,27 @@ import {
   useSyncExternalStore,
 } from "react"
 import { useEditorRenderer } from "@/hooks/use-editor-renderer"
+import { getCompositionFrame } from "@/lib/editor/composition"
 import { isEditableTarget } from "@/lib/editor/is-editable-target"
 import { inferFileAssetKind } from "@/lib/editor/media-file"
 import {
   isPreviewRenderLocked,
   subscribeToPreviewRenderLock,
 } from "@/lib/editor/preview-render-lock"
+import { getSeedableMediaDuration } from "@/lib/editor/timeline-duration"
 import {
   applyZoomAtPoint,
   clampZoom,
   getWheelZoomFactor,
 } from "@/lib/editor/view-transform"
-import { getCompositionFrame } from "@/lib/editor/composition"
-import { getSeedableMediaDuration } from "@/lib/editor/timeline-duration"
 import { useAssetStore } from "@/store/asset-store"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
 import { useTimelineStore } from "@/store/timeline-store"
 
 export function EditorCanvasViewport() {
-  const { canvasRef, isReady, viewportRef } = useEditorRenderer()
+  const { canvasRef, fallbackMessage, isReady, viewportRef } =
+    useEditorRenderer()
   const previewPaused = useSyncExternalStore(
     subscribeToPreviewRenderLock,
     isPreviewRenderLocked,
@@ -194,7 +195,9 @@ export function EditorCanvasViewport() {
           x: event.clientX - rect.left - rect.width / 2,
           y: event.clientY - rect.top - rect.height / 2,
         }
-        const nextZoom = clampZoom(state.zoom * getWheelZoomFactor(event.deltaY))
+        const nextZoom = clampZoom(
+          state.zoom * getWheelZoomFactor(event.deltaY)
+        )
         const nextState = applyZoomAtPoint(
           state.zoom,
           state.panOffset,
@@ -250,10 +253,12 @@ export function EditorCanvasViewport() {
         return
       }
 
-      useEditorStore.getState().setPan(
-        activePan.startPanX + (event.clientX - activePan.originX),
-        activePan.startPanY + (event.clientY - activePan.originY)
-      )
+      useEditorStore
+        .getState()
+        .setPan(
+          activePan.startPanX + (event.clientX - activePan.originX),
+          activePan.startPanY + (event.clientY - activePan.originY)
+        )
     },
     []
   )
@@ -373,7 +378,24 @@ export function EditorCanvasViewport() {
         ) : null}
       </div>
 
-      {!isReady ? (
+      {fallbackMessage ? (
+        <div className="absolute inset-0 flex items-center justify-center p-6">
+          <div
+            className="max-w-sm rounded-[var(--ds-radius-panel)] border border-[var(--ds-border-panel)] bg-[rgb(18_18_22_/_0.88)] px-4 py-3 backdrop-blur-[28px]"
+            role="alert"
+          >
+            <p className="mb-1 font-[var(--ds-font-mono)] text-[11px] leading-4 text-[var(--ds-color-text-primary)] uppercase tracking-[0.18em]">
+              Renderer unavailable
+            </p>
+            <p className="text-[12px] text-[var(--ds-color-text-secondary)] leading-5">
+              {fallbackMessage}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Guarded: otherwise this sweeps forever on a dead renderer. */}
+      {!(isReady || fallbackMessage) ? (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-6">
           <div
             aria-hidden="true"

--- a/src/hooks/use-editor-renderer.ts
+++ b/src/hooks/use-editor-renderer.ts
@@ -1,18 +1,26 @@
 "use client"
 
+import * as Sentry from "@sentry/nextjs"
 import { useEffect, useRef, useState } from "react"
 import { registerAgentFramePump } from "@/lib/agent-bridge/frame-pump"
+import { isPreviewRenderLocked } from "@/lib/editor/preview-render-lock"
+import {
+  armRendererBootDeadline,
+  bootMarks,
+  captureRendererBootRecovery,
+  captureRendererBootTimeout,
+  markBootStage,
+  startRendererBootTrace,
+  stopRendererBootTrace,
+} from "@/lib/renderer-boot"
+import { gpuSnapshot, isDeviceLost } from "@/lib/webgpu-diagnostics"
 import { buildRendererFrame, type EditorRenderer } from "@/renderer/contracts"
 import {
   browserSupportsWebGPU,
   createWebGPURenderer,
 } from "@/renderer/create-webgpu-renderer"
-import { isPreviewRenderLocked } from "@/lib/editor/preview-render-lock"
 import { useAssetStore } from "@/store/asset-store"
-import {
-  selectAudioModulationInput,
-  useAudioStore,
-} from "@/store/audio-store"
+import { selectAudioModulationInput, useAudioStore } from "@/store/audio-store"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
 import { useMetricsStore } from "@/store/metrics-store"
@@ -36,6 +44,32 @@ function measureElement(element: HTMLElement): Size {
   return {
     height: Math.max(1, Math.round(bounds.height)),
     width: Math.max(1, Math.round(bounds.width)),
+  }
+}
+
+// Generous: this only waits on adapter and device acquisition.
+const BOOT_TIMEOUT_MS = 20_000
+
+// A persistent GPU fault throws every frame; halt instead of spinning.
+const MAX_CONSECUTIVE_FRAME_FAILURES = 5
+
+function frameFingerprint(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error)
+  }
+
+  return [error.name, error.message, error.stack?.split("\n")[1]?.trim()].join(
+    "|"
+  )
+}
+
+function sceneInfo() {
+  const editor = useEditorStore.getState()
+
+  return {
+    layerCount: useLayerStore.getState().layers.length,
+    outputSize: `${editor.outputSize.width}x${editor.outputSize.height}`,
+    renderScale: editor.renderScale,
   }
 }
 
@@ -66,6 +100,9 @@ export function useEditorRenderer() {
         "This browser does not expose WebGPU yet."
       )
       setFallbackMessage("WebGPU is not available in this browser.")
+      // Not a Sentry event: an unsupported browser is analytics, not an error.
+      // The context rides along on any real error instead.
+      Sentry.setContext("gpu", gpuSnapshot())
       return
     }
 
@@ -76,12 +113,22 @@ export function useEditorRenderer() {
     let frameInFlight = false
     let unregisterFramePump: (() => void) | null = null
     let unsubscribeRenderScale: (() => void) | null = null
+    let consecutiveFrameFailures = 0
+    let loopHalted = false
+    let firstFrameMarked = false
+    const reportedFrameErrors = new Set<string>()
 
     editorStore.setWebGPUStatus("initializing")
+    startRendererBootTrace()
+    markBootStage("webgpu-probed")
+    armRendererBootDeadline(BOOT_TIMEOUT_MS, () => {
+      captureRendererBootTimeout(BOOT_TIMEOUT_MS, sceneInfo())
+    })
 
     async function initializeRenderer() {
       try {
         const renderer = await createWebGPURenderer(canvasElement)
+        markBootStage("renderer-created")
 
         if (isDisposed) {
           renderer.dispose()
@@ -90,6 +137,8 @@ export function useEditorRenderer() {
 
         rendererRef.current = renderer
         await renderer.initialize()
+        markBootStage("device-ready")
+        Sentry.setContext("gpu", gpuSnapshot())
         editorStore.setLiveRenderer(renderer)
         editorStore.setLiveCanvas(canvasElement)
 
@@ -131,13 +180,14 @@ export function useEditorRenderer() {
           }
 
           lastRenderScale = state.renderScale
-          renderer.resize(
-            useEditorStore.getState().canvasSize,
-            getPixelRatio()
-          )
+          renderer.resize(useEditorStore.getState().canvasSize, getPixelRatio())
         })
 
         const scheduleNextFrame = () => {
+          if (isDisposed || loopHalted) {
+            return
+          }
+
           animationFrameRef.current = window.requestAnimationFrame(
             (nextNow) => {
               void renderFrame(nextNow)
@@ -145,14 +195,79 @@ export function useEditorRenderer() {
           )
         }
 
+        const haltLoop = (message: string, deviceLost: boolean) => {
+          loopHalted = true
+          useEditorStore.getState().setWebGPUStatus("error", message)
+          setFallbackMessage(message)
+
+          Sentry.captureMessage("Render loop halted", {
+            extra: { consecutiveFrameFailures, ...sceneInfo() },
+            level: "error",
+            tags: {
+              "halt.device_lost": String(deviceLost),
+              surface: "render-loop-halted",
+            },
+          })
+        }
+
+        const handleFrameFailure = (error: unknown) => {
+          consecutiveFrameFailures += 1
+
+          // By fingerprint, not a flag: a different failure is new information.
+          const fingerprint = frameFingerprint(error)
+
+          if (!reportedFrameErrors.has(fingerprint)) {
+            reportedFrameErrors.add(fingerprint)
+            Sentry.captureException(error, {
+              contexts: { renderer_boot: { marks: bootMarks() } },
+              extra: sceneInfo(),
+              tags: { surface: "render-frame" },
+            })
+          }
+
+          const deviceLost = isDeviceLost()
+
+          if (deviceLost) {
+            haltLoop(
+              "The GPU device was lost. Reload the page to restart the renderer.",
+              true
+            )
+            return
+          }
+
+          if (consecutiveFrameFailures >= MAX_CONSECUTIVE_FRAME_FAILURES) {
+            haltLoop(
+              "The renderer stopped after repeated errors. Reload the page to try again.",
+              false
+            )
+          }
+        }
+
         const renderFrame = async (now: number) => {
           frameInFlight = true
 
+          try {
+            await runFrame(now)
+
+            if (consecutiveFrameFailures > 0) {
+              // Recovered: forget fingerprints so a recurrence reports again.
+              consecutiveFrameFailures = 0
+              reportedFrameErrors.clear()
+            }
+          } catch (error) {
+            handleFrameFailure(error)
+          } finally {
+            // Must be finally: a throw would wedge the agent frame pump.
+            frameInFlight = false
+          }
+
+          scheduleNextFrame()
+        }
+
+        const runFrame = async (now: number) => {
           if (isPreviewRenderLocked()) {
             lastFrameTime = now
-            frameInFlight = false
             useMetricsStore.getState().setFps(0)
-            scheduleNextFrame()
             return
           }
 
@@ -207,8 +322,12 @@ export function useEditorRenderer() {
           }
 
           renderer.render(frame)
-          frameInFlight = false
-          scheduleNextFrame()
+
+          if (!firstFrameMarked) {
+            firstFrameMarked = true
+            markBootStage("first-frame")
+            captureRendererBootRecovery()
+          }
         }
 
         animationFrameRef.current = window.requestAnimationFrame((nextNow) => {
@@ -235,6 +354,10 @@ export function useEditorRenderer() {
 
         useEditorStore.getState().setWebGPUStatus("error", message)
         setFallbackMessage(message)
+        Sentry.captureException(error, {
+          contexts: { renderer_boot: { marks: bootMarks() } },
+          tags: { surface: "webgpu-init" },
+        })
       }
     }
 
@@ -243,6 +366,7 @@ export function useEditorRenderer() {
     return () => {
       isDisposed = true
 
+      stopRendererBootTrace()
       unregisterFramePump?.()
       unsubscribeRenderScale?.()
 

--- a/src/hooks/use-editor-renderer.ts
+++ b/src/hooks/use-editor-renderer.ts
@@ -4,16 +4,7 @@ import * as Sentry from "@sentry/nextjs"
 import { useEffect, useRef, useState } from "react"
 import { registerAgentFramePump } from "@/lib/agent-bridge/frame-pump"
 import { isPreviewRenderLocked } from "@/lib/editor/preview-render-lock"
-import {
-  armRendererBootDeadline,
-  bootMarks,
-  captureRendererBootRecovery,
-  captureRendererBootTimeout,
-  markBootStage,
-  settleRendererBootDeadline,
-  startRendererBootTrace,
-  stopRendererBootTrace,
-} from "@/lib/renderer-boot"
+import { RendererBootTrace } from "@/lib/renderer-boot"
 import { gpuSnapshot } from "@/lib/webgpu-diagnostics"
 import { buildRendererFrame, type EditorRenderer } from "@/renderer/contracts"
 import {
@@ -54,6 +45,15 @@ const BOOT_TIMEOUT_MS = 20_000
 
 // A persistent GPU fault throws every frame; halt instead of spinning.
 const MAX_CONSECUTIVE_FRAME_FAILURES = 5
+
+const HALT_MESSAGE = {
+  "device-lost":
+    "The GPU device was lost. Reload the page to restart the renderer.",
+  "repeated-errors":
+    "The renderer stopped after repeated errors. Reload the page to try again.",
+} as const
+
+type HaltReason = keyof typeof HALT_MESSAGE
 
 function sceneInfo() {
   const editor = useEditorStore.getState()
@@ -111,16 +111,17 @@ export function useEditorRenderer() {
     const reportedFrameErrors = new Set<string>()
 
     editorStore.setWebGPUStatus("initializing")
-    startRendererBootTrace()
-    markBootStage("webgpu-probed")
-    armRendererBootDeadline(BOOT_TIMEOUT_MS, () => {
-      captureRendererBootTimeout(BOOT_TIMEOUT_MS, sceneInfo())
+    const boot = new RendererBootTrace()
+    boot.start()
+    boot.mark("webgpu-probed")
+    boot.armDeadline(BOOT_TIMEOUT_MS, () => {
+      boot.captureTimeout(sceneInfo())
     })
 
     async function initializeRenderer() {
       try {
         const renderer = await createWebGPURenderer(canvasElement)
-        markBootStage("renderer-created")
+        boot.mark("renderer-created")
 
         if (isDisposed) {
           renderer.dispose()
@@ -129,7 +130,7 @@ export function useEditorRenderer() {
 
         rendererRef.current = renderer
         await renderer.initialize()
-        markBootStage("device-ready")
+        boot.mark("device-ready")
         Sentry.setContext("gpu", gpuSnapshot())
         editorStore.setLiveRenderer(renderer)
         editorStore.setLiveCanvas(canvasElement)
@@ -187,7 +188,7 @@ export function useEditorRenderer() {
           )
         }
 
-        const haltLoop = (message: string, deviceLost: boolean) => {
+        const haltLoop = (reason: HaltReason) => {
           if (loopHalted) {
             return
           }
@@ -195,17 +196,16 @@ export function useEditorRenderer() {
           loopHalted = true
           // Terminal before the first frame: otherwise the boot deadline still
           // fires a misleading timeout 20s later.
-          settleRendererBootDeadline()
+          boot.settleDeadline()
+
+          const message = HALT_MESSAGE[reason]
           useEditorStore.getState().setWebGPUStatus("error", message)
           setFallbackMessage(message)
 
           Sentry.captureMessage("Render loop halted", {
             extra: { consecutiveFrameFailures, ...sceneInfo() },
             level: "error",
-            tags: {
-              "halt.device_lost": String(deviceLost),
-              surface: "render-loop-halted",
-            },
+            tags: { "halt.reason": reason, surface: "render-loop-halted" },
           })
         }
 
@@ -217,28 +217,20 @@ export function useEditorRenderer() {
 
           if (!reportedFrameErrors.has(fingerprint)) {
             reportedFrameErrors.add(fingerprint)
+            // The boot breadcrumbs already carry the stage timings.
             Sentry.captureException(error, {
-              contexts: { renderer_boot: { marks: bootMarks() } },
               extra: sceneInfo(),
               tags: { surface: "render-frame" },
             })
           }
 
-          const deviceLost = renderer.isDeviceLost()
-
-          if (deviceLost) {
-            haltLoop(
-              "The GPU device was lost. Reload the page to restart the renderer.",
-              true
-            )
+          if (renderer.isDeviceLost()) {
+            haltLoop("device-lost")
             return
           }
 
           if (consecutiveFrameFailures >= MAX_CONSECUTIVE_FRAME_FAILURES) {
-            haltLoop(
-              "The renderer stopped after repeated errors. Reload the page to try again.",
-              false
-            )
+            haltLoop("repeated-errors")
           }
         }
 
@@ -267,10 +259,7 @@ export function useEditorRenderer() {
           // three's render() returns silently once the device is lost, so this
           // never surfaces as a throw — poll the renderer instead.
           if (renderer.isDeviceLost()) {
-            haltLoop(
-              "The GPU device was lost. Reload the page to restart the renderer.",
-              true
-            )
+            haltLoop("device-lost")
             return
           }
 
@@ -334,9 +323,9 @@ export function useEditorRenderer() {
 
           if (!firstFrameMarked) {
             firstFrameMarked = true
-            markBootStage("first-frame")
-            settleRendererBootDeadline()
-            captureRendererBootRecovery()
+            boot.mark("first-frame")
+            boot.settleDeadline()
+            boot.captureRecovery()
           }
         }
 
@@ -366,11 +355,8 @@ export function useEditorRenderer() {
         setFallbackMessage(message)
         // Terminal: without this the 20s deadline still fires a second, bogus
         // "boot timed out" on top of the real failure.
-        settleRendererBootDeadline()
-        Sentry.captureException(error, {
-          contexts: { renderer_boot: { marks: bootMarks() } },
-          tags: { surface: "webgpu-init" },
-        })
+        boot.settleDeadline()
+        Sentry.captureException(error, { tags: { surface: "webgpu-init" } })
       }
     }
 
@@ -379,7 +365,7 @@ export function useEditorRenderer() {
     return () => {
       isDisposed = true
 
-      stopRendererBootTrace()
+      boot.dispose()
       unregisterFramePump?.()
       unsubscribeRenderScale?.()
 

--- a/src/hooks/use-editor-renderer.ts
+++ b/src/hooks/use-editor-renderer.ts
@@ -10,6 +10,7 @@ import {
   captureRendererBootRecovery,
   captureRendererBootTimeout,
   markBootStage,
+  settleRendererBootDeadline,
   startRendererBootTrace,
   stopRendererBootTrace,
 } from "@/lib/renderer-boot"
@@ -19,6 +20,7 @@ import {
   browserSupportsWebGPU,
   createWebGPURenderer,
 } from "@/renderer/create-webgpu-renderer"
+import { errorFingerprint } from "@/renderer/pass-failure"
 import { useAssetStore } from "@/store/asset-store"
 import { selectAudioModulationInput, useAudioStore } from "@/store/audio-store"
 import { useEditorStore } from "@/store/editor-store"
@@ -52,16 +54,6 @@ const BOOT_TIMEOUT_MS = 20_000
 
 // A persistent GPU fault throws every frame; halt instead of spinning.
 const MAX_CONSECUTIVE_FRAME_FAILURES = 5
-
-function frameFingerprint(error: unknown): string {
-  if (!(error instanceof Error)) {
-    return String(error)
-  }
-
-  return [error.name, error.message, error.stack?.split("\n")[1]?.trim()].join(
-    "|"
-  )
-}
 
 function sceneInfo() {
   const editor = useEditorStore.getState()
@@ -196,6 +188,10 @@ export function useEditorRenderer() {
         }
 
         const haltLoop = (message: string, deviceLost: boolean) => {
+          if (loopHalted) {
+            return
+          }
+
           loopHalted = true
           useEditorStore.getState().setWebGPUStatus("error", message)
           setFallbackMessage(message)
@@ -214,7 +210,7 @@ export function useEditorRenderer() {
           consecutiveFrameFailures += 1
 
           // By fingerprint, not a flag: a different failure is new information.
-          const fingerprint = frameFingerprint(error)
+          const fingerprint = errorFingerprint(error)
 
           if (!reportedFrameErrors.has(fingerprint)) {
             reportedFrameErrors.add(fingerprint)
@@ -265,6 +261,16 @@ export function useEditorRenderer() {
         }
 
         const runFrame = async (now: number) => {
+          // three's render() returns silently once the device is lost, so this
+          // never surfaces as a throw — poll the flag instead.
+          if (isDeviceLost()) {
+            haltLoop(
+              "The GPU device was lost. Reload the page to restart the renderer.",
+              true
+            )
+            return
+          }
+
           if (isPreviewRenderLocked()) {
             lastFrameTime = now
             useMetricsStore.getState().setFps(0)
@@ -326,6 +332,7 @@ export function useEditorRenderer() {
           if (!firstFrameMarked) {
             firstFrameMarked = true
             markBootStage("first-frame")
+            settleRendererBootDeadline()
             captureRendererBootRecovery()
           }
         }
@@ -335,7 +342,7 @@ export function useEditorRenderer() {
         })
 
         unregisterFramePump = registerAgentFramePump(() => {
-          if (isDisposed || frameInFlight) {
+          if (isDisposed || frameInFlight || loopHalted) {
             return
           }
 
@@ -354,6 +361,9 @@ export function useEditorRenderer() {
 
         useEditorStore.getState().setWebGPUStatus("error", message)
         setFallbackMessage(message)
+        // Terminal: without this the 20s deadline still fires a second, bogus
+        // "boot timed out" on top of the real failure.
+        settleRendererBootDeadline()
         Sentry.captureException(error, {
           contexts: { renderer_boot: { marks: bootMarks() } },
           tags: { surface: "webgpu-init" },

--- a/src/hooks/use-editor-renderer.ts
+++ b/src/hooks/use-editor-renderer.ts
@@ -14,7 +14,7 @@ import {
   startRendererBootTrace,
   stopRendererBootTrace,
 } from "@/lib/renderer-boot"
-import { gpuSnapshot, isDeviceLost } from "@/lib/webgpu-diagnostics"
+import { gpuSnapshot } from "@/lib/webgpu-diagnostics"
 import { buildRendererFrame, type EditorRenderer } from "@/renderer/contracts"
 import {
   browserSupportsWebGPU,
@@ -193,6 +193,9 @@ export function useEditorRenderer() {
           }
 
           loopHalted = true
+          // Terminal before the first frame: otherwise the boot deadline still
+          // fires a misleading timeout 20s later.
+          settleRendererBootDeadline()
           useEditorStore.getState().setWebGPUStatus("error", message)
           setFallbackMessage(message)
 
@@ -221,7 +224,7 @@ export function useEditorRenderer() {
             })
           }
 
-          const deviceLost = isDeviceLost()
+          const deviceLost = renderer.isDeviceLost()
 
           if (deviceLost) {
             haltLoop(
@@ -262,8 +265,8 @@ export function useEditorRenderer() {
 
         const runFrame = async (now: number) => {
           // three's render() returns silently once the device is lost, so this
-          // never surfaces as a throw — poll the flag instead.
-          if (isDeviceLost()) {
+          // never surfaces as a throw — poll the renderer instead.
+          if (renderer.isDeviceLost()) {
             haltLoop(
               "The GPU device was lost. Reload the page to restart the renderer.",
               true

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,9 +1,42 @@
 import * as Sentry from "@sentry/nextjs"
+import { resolveTracesSampleRate } from "@/lib/sentry-sampling"
+
+const environment =
+  process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV ?? "development"
+
+const ANONYMOUS_ID_KEY = "sentry-anonymous-id"
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "development" ? 1 : 0.1,
+  environment,
+  enabled: process.env.NODE_ENV === "production",
+  tracesSampleRate: resolveTracesSampleRate(
+    environment,
+    process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE
+  ),
+  denyUrls: [/^(?:chrome|moz|ms-browser|safari(?:-web)?)-extension:\/\//],
+  // BrowserApiErrors wraps requestAnimationFrame by default, costing on every
+  // frame of the render loop. eventTarget stays on: it covers DOM and worker
+  // handlers, which is most of this app.
+  integrations: (defaults) => [
+    ...defaults.filter(({ name }) => name !== "BrowserApiErrors"),
+    Sentry.browserApiErrorsIntegration({ requestAnimationFrame: false }),
+  ],
 })
+
+// Without an id every issue reports "0 users impacted". Pseudonymous, so PII
+// collection stays off.
+try {
+  const stored = sessionStorage.getItem(ANONYMOUS_ID_KEY)
+  const id = stored ?? crypto.randomUUID()
+
+  if (!stored) {
+    sessionStorage.setItem(ANONYMOUS_ID_KEY, id)
+  }
+
+  Sentry.setUser({ id })
+} catch {
+  // Storage throws in hardened-privacy contexts.
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,13 +1,23 @@
 import * as Sentry from "@sentry/nextjs"
+import { resolveTracesSampleRate } from "@/lib/sentry-sampling"
 
-export async function register() {
-  if (process.env.NEXT_RUNTIME === "nodejs") {
-    await import("../sentry.server.config")
-  }
+const environment =
+  process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "development"
 
-  if (process.env.NEXT_RUNTIME === "edge") {
-    await import("../sentry.edge.config")
-  }
+// One init for node and edge; only includeLocalVariables is runtime-specific.
+export function register() {
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    environment,
+    enabled: process.env.NODE_ENV === "production",
+    tracesSampleRate: resolveTracesSampleRate(
+      environment,
+      process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE
+    ),
+    ...(process.env.NEXT_RUNTIME === "nodejs"
+      ? { includeLocalVariables: true }
+      : {}),
+  })
 }
 
 export const onRequestError = Sentry.captureRequestError

--- a/src/lib/editor/export.ts
+++ b/src/lib/editor/export.ts
@@ -1,19 +1,19 @@
 "use client"
-import type { AudioModulationInput } from "@/lib/editor/audio/links"
 import { decodeAudioBuffer } from "@/lib/editor/audio/decode"
 import {
-  encodeExportAudio,
   type ExportAudioTrackConfig,
+  encodeExportAudio,
   getEncoderPrimingSeconds,
   planExportAudioSegments,
   renderExportAudio,
   resolveExportAudioConfig,
 } from "@/lib/editor/audio/export-audio"
+import type { AudioModulationInput } from "@/lib/editor/audio/links"
+import { acquirePreviewRenderLock } from "@/lib/editor/preview-render-lock"
 import {
   createVideoExportEncoder,
   getSupportedVideoExportConfig,
 } from "@/lib/editor/video-export-encoder"
-import { acquirePreviewRenderLock } from "@/lib/editor/preview-render-lock"
 import { buildRendererFrame } from "@/renderer/contracts"
 import {
   browserSupportsWebGPU,
@@ -356,8 +356,7 @@ async function prepareExportAudio(
     loop: projectState.timeline.loop,
     offsetSeconds: source.offsetSeconds,
     sourceDurationSeconds: decoded.duration,
-    startSeconds:
-      options.startTime + getEncoderPrimingSeconds(config.codec),
+    startSeconds: options.startTime + getEncoderPrimingSeconds(config.codec),
     timelineDurationSeconds: projectState.timeline.duration,
   })
 
@@ -473,7 +472,8 @@ async function runVideoExport(
 
   let renderCanvas: HTMLCanvasElement | null = null
   let renderer: Awaited<ReturnType<typeof createExportRenderer>> | null = null
-  let encoder: Awaited<ReturnType<typeof createVideoExportEncoder>> | null = null
+  let encoder: Awaited<ReturnType<typeof createVideoExportEncoder>> | null =
+    null
   let finalized = false
 
   try {
@@ -617,11 +617,7 @@ async function runVideoExport(
       if (isLastFrame || now - lastProgressAt >= PROGRESS_INTERVAL_MS) {
         lastProgressAt = now
         options.onProgress?.({
-          label: buildRenderLabel(
-            frameIndex + 1,
-            totalFrames,
-            renderStartedAt
-          ),
+          label: buildRenderLabel(frameIndex + 1, totalFrames, renderStartedAt),
           value: 0.08 + ((frameIndex + 1) / totalFrames) * 0.88,
         })
       }
@@ -659,7 +655,9 @@ async function createExportRenderer(canvas: HTMLCanvasElement) {
     throw new Error("WebGPU export is not available in this browser.")
   }
 
-  const renderer = await createWebGPURenderer(canvas)
+  const renderer = await createWebGPURenderer(canvas, {
+    strictPassFailures: true,
+  })
   await renderer.initialize()
   return renderer
 }

--- a/src/lib/editor/export.ts
+++ b/src/lib/editor/export.ts
@@ -1,19 +1,19 @@
 "use client"
+import type { AudioModulationInput } from "@/lib/editor/audio/links"
 import { decodeAudioBuffer } from "@/lib/editor/audio/decode"
 import {
-  type ExportAudioTrackConfig,
   encodeExportAudio,
+  type ExportAudioTrackConfig,
   getEncoderPrimingSeconds,
   planExportAudioSegments,
   renderExportAudio,
   resolveExportAudioConfig,
 } from "@/lib/editor/audio/export-audio"
-import type { AudioModulationInput } from "@/lib/editor/audio/links"
-import { acquirePreviewRenderLock } from "@/lib/editor/preview-render-lock"
 import {
   createVideoExportEncoder,
   getSupportedVideoExportConfig,
 } from "@/lib/editor/video-export-encoder"
+import { acquirePreviewRenderLock } from "@/lib/editor/preview-render-lock"
 import { buildRendererFrame } from "@/renderer/contracts"
 import {
   browserSupportsWebGPU,
@@ -356,7 +356,8 @@ async function prepareExportAudio(
     loop: projectState.timeline.loop,
     offsetSeconds: source.offsetSeconds,
     sourceDurationSeconds: decoded.duration,
-    startSeconds: options.startTime + getEncoderPrimingSeconds(config.codec),
+    startSeconds:
+      options.startTime + getEncoderPrimingSeconds(config.codec),
     timelineDurationSeconds: projectState.timeline.duration,
   })
 
@@ -472,8 +473,7 @@ async function runVideoExport(
 
   let renderCanvas: HTMLCanvasElement | null = null
   let renderer: Awaited<ReturnType<typeof createExportRenderer>> | null = null
-  let encoder: Awaited<ReturnType<typeof createVideoExportEncoder>> | null =
-    null
+  let encoder: Awaited<ReturnType<typeof createVideoExportEncoder>> | null = null
   let finalized = false
 
   try {
@@ -617,7 +617,11 @@ async function runVideoExport(
       if (isLastFrame || now - lastProgressAt >= PROGRESS_INTERVAL_MS) {
         lastProgressAt = now
         options.onProgress?.({
-          label: buildRenderLabel(frameIndex + 1, totalFrames, renderStartedAt),
+          label: buildRenderLabel(
+            frameIndex + 1,
+            totalFrames,
+            renderStartedAt
+          ),
           value: 0.08 + ((frameIndex + 1) / totalFrames) * 0.88,
         })
       }

--- a/src/lib/renderer-boot.ts
+++ b/src/lib/renderer-boot.ts
@@ -1,0 +1,239 @@
+import * as Sentry from "@sentry/nextjs"
+import { gpuSnapshot } from "@/lib/webgpu-diagnostics"
+
+// One boot per page load; a retry-boot feature would need the one-shot guards
+// (`marks`, `deadlineFired`) revisited.
+export type BootStage =
+  | "webgpu-probed"
+  | "renderer-created"
+  | "device-ready"
+  | "first-frame"
+
+let startedAt = 0
+let wasHidden = false
+let recoveryReported = false
+const marks: Partial<Record<BootStage, number>> = {}
+
+let visibleSince: number | null = null
+let visibleAccum = 0
+
+let deadlineBudget = 0
+let deadlineExpire: (() => void) | null = null
+let deadlineTimer: ReturnType<typeof setTimeout> | null = null
+let deadlineFired = false
+let subscribed = false
+
+const visibleElapsed = () =>
+  Math.round(
+    visibleAccum +
+      (visibleSince === null ? 0 : performance.now() - visibleSince)
+  )
+
+const toSeconds = (ms: number) => Number((ms / 1000).toFixed(2))
+
+const armDeadline = () => {
+  if (deadlineFired || deadlineExpire === null) {
+    return
+  }
+
+  if (visibleSince === null || deadlineTimer !== null) {
+    return
+  }
+
+  deadlineTimer = setTimeout(
+    () => {
+      deadlineTimer = null
+      deadlineFired = true
+      deadlineExpire?.()
+    },
+    Math.max(0, deadlineBudget - visibleElapsed())
+  )
+}
+
+const disarmDeadline = () => {
+  if (deadlineTimer === null) {
+    return
+  }
+
+  clearTimeout(deadlineTimer)
+  deadlineTimer = null
+}
+
+const syncVisibility = () => {
+  if (document.visibilityState === "hidden") {
+    wasHidden = true
+
+    if (visibleSince !== null) {
+      visibleAccum += performance.now() - visibleSince
+      visibleSince = null
+    }
+
+    disarmDeadline()
+    return
+  }
+
+  if (visibleSince === null) {
+    visibleSince = performance.now()
+    armDeadline()
+  }
+}
+
+export const startRendererBootTrace = () => {
+  if (startedAt === 0) {
+    startedAt = performance.now()
+    wasHidden = document.visibilityState === "hidden"
+    visibleSince = wasHidden ? null : startedAt
+  }
+
+  if (subscribed) {
+    return
+  }
+
+  subscribed = true
+  document.addEventListener("visibilitychange", syncVisibility)
+  syncVisibility()
+}
+
+// Charged only while the tab is visible: a backgrounded tab gets throttled rAF,
+// so wall-clock time there would report a failure nobody saw.
+export const armRendererBootDeadline = (
+  budgetMs: number,
+  onExpire: () => void
+) => {
+  // deadlineFired never resets: re-arming after expiry would file twice.
+  deadlineBudget = budgetMs
+  deadlineExpire = onExpire
+  armDeadline()
+}
+
+export const stopRendererBootTrace = () => {
+  document.removeEventListener("visibilitychange", syncVisibility)
+  disarmDeadline()
+  deadlineExpire = null
+  subscribed = false
+}
+
+export const markBootStage = (stage: BootStage) => {
+  if (marks[stage] !== undefined) {
+    return
+  }
+
+  if (startedAt === 0) {
+    startRendererBootTrace()
+  }
+
+  marks[stage] = toSeconds(performance.now() - startedAt)
+  Sentry.addBreadcrumb({
+    category: "renderer.boot",
+    data: { atSec: marks[stage] },
+    level: "info",
+    message: stage,
+  })
+}
+
+// Written once per stage, so key order is already chronological.
+const lastStage = (): BootStage | "none" => {
+  const seen = Object.keys(marks) as BootStage[]
+  return seen[seen.length - 1] ?? "none"
+}
+
+interface NavigatorWithHints extends Navigator {
+  deviceMemory?: number
+}
+
+const deviceSnapshot = () => {
+  const nav = navigator as NavigatorWithHints
+
+  return {
+    cpuCores: nav.hardwareConcurrency,
+    deviceMemoryGb: nav.deviceMemory,
+    dpr: window.devicePixelRatio,
+    viewport: `${window.innerWidth}x${window.innerHeight}`,
+  }
+}
+
+const memoryBucket = (gb: number | undefined) => {
+  if (gb === undefined) {
+    return "unknown"
+  }
+
+  if (gb <= 2) {
+    return "<=2"
+  }
+
+  if (gb <= 4) {
+    return "4"
+  }
+
+  return ">=8"
+}
+
+const commonFields = () => {
+  const device = deviceSnapshot()
+  const gpu = gpuSnapshot()
+
+  return {
+    contexts: { renderer_boot_device: device, renderer_boot_gpu: gpu },
+    gpu,
+    tags: {
+      "boot.was_hidden": String(wasHidden),
+      "boot.automated": String(navigator.webdriver === true),
+      "device.memory_bucket": memoryBucket(device.deviceMemoryGb),
+      "gpu.adapter_acquired": String(gpu.adapterAcquired),
+    },
+  }
+}
+
+export const captureRendererBootTimeout = (
+  budgetMs: number,
+  sceneInfo: Record<string, unknown>
+) => {
+  if (startedAt === 0) {
+    return
+  }
+
+  const elapsedSec = toSeconds(performance.now() - startedAt)
+  const { tags, contexts } = commonFields()
+
+  Sentry.captureMessage("Renderer boot timed out", {
+    contexts: {
+      // Copied: Sentry serializes async, so a later stage would look earlier.
+      renderer_boot: {
+        budgetSec: toSeconds(budgetMs),
+        elapsedSec,
+        marks: { ...marks },
+        visibleSec: toSeconds(visibleElapsed()),
+        ...sceneInfo,
+      },
+      ...contexts,
+    },
+    level: "warning",
+    tags: { ...tags, "boot.last_stage": lastStage() },
+  })
+}
+
+export const captureRendererBootRecovery = () => {
+  // Guarded on deadlineFired so callers can fire it on every good frame.
+  if (startedAt === 0 || recoveryReported || !deadlineFired) {
+    return
+  }
+
+  recoveryReported = true
+
+  const { tags, contexts } = commonFields()
+
+  Sentry.captureMessage("Renderer boot recovered after timeout", {
+    contexts: {
+      renderer_boot: {
+        elapsedSec: toSeconds(performance.now() - startedAt),
+        marks: { ...marks },
+        visibleSec: toSeconds(visibleElapsed()),
+      },
+      ...contexts,
+    },
+    level: "info",
+    tags,
+  })
+}
+
+export const bootMarks = () => ({ ...marks })

--- a/src/lib/renderer-boot.ts
+++ b/src/lib/renderer-boot.ts
@@ -1,162 +1,13 @@
 import * as Sentry from "@sentry/nextjs"
 import { gpuSnapshot } from "@/lib/webgpu-diagnostics"
 
-// One boot per page load; a retry-boot feature would need the one-shot guards
-// (`marks`, `deadlineFired`) revisited.
 export type BootStage =
   | "webgpu-probed"
   | "renderer-created"
   | "device-ready"
   | "first-frame"
 
-let startedAt = 0
-let wasHidden = false
-let recoveryReported = false
-const marks: Partial<Record<BootStage, number>> = {}
-
-let visibleSince: number | null = null
-let visibleAccum = 0
-
-let deadlineBudget = 0
-let deadlineExpire: (() => void) | null = null
-let deadlineTimer: ReturnType<typeof setTimeout> | null = null
-let deadlineFired = false
-let subscribed = false
-
-const visibleElapsed = () =>
-  Math.round(
-    visibleAccum +
-      (visibleSince === null ? 0 : performance.now() - visibleSince)
-  )
-
 const toSeconds = (ms: number) => Number((ms / 1000).toFixed(2))
-
-const armDeadline = () => {
-  if (deadlineFired || deadlineExpire === null) {
-    return
-  }
-
-  if (visibleSince === null || deadlineTimer !== null) {
-    return
-  }
-
-  deadlineTimer = setTimeout(
-    () => {
-      deadlineTimer = null
-      deadlineFired = true
-      deadlineExpire?.()
-    },
-    Math.max(0, deadlineBudget - visibleElapsed())
-  )
-}
-
-const disarmDeadline = () => {
-  if (deadlineTimer === null) {
-    return
-  }
-
-  clearTimeout(deadlineTimer)
-  deadlineTimer = null
-}
-
-const syncVisibility = () => {
-  if (document.visibilityState === "hidden") {
-    wasHidden = true
-
-    if (visibleSince !== null) {
-      visibleAccum += performance.now() - visibleSince
-      visibleSince = null
-    }
-
-    disarmDeadline()
-    return
-  }
-
-  if (visibleSince === null) {
-    visibleSince = performance.now()
-    armDeadline()
-  }
-}
-
-export const startRendererBootTrace = () => {
-  if (startedAt === 0) {
-    startedAt = performance.now()
-    wasHidden = document.visibilityState === "hidden"
-    visibleSince = wasHidden ? null : startedAt
-  }
-
-  if (subscribed) {
-    return
-  }
-
-  subscribed = true
-  document.addEventListener("visibilitychange", syncVisibility)
-  syncVisibility()
-}
-
-// Charged only while the tab is visible: a backgrounded tab gets throttled rAF,
-// so wall-clock time there would report a failure nobody saw.
-export const armRendererBootDeadline = (
-  budgetMs: number,
-  onExpire: () => void
-) => {
-  // deadlineFired never resets: re-arming after expiry would file twice.
-  deadlineBudget = budgetMs
-  deadlineExpire = onExpire
-  armDeadline()
-}
-
-// Boot reached a terminal state (first frame or init failure). Clearing
-// deadlineExpire also stops syncVisibility from re-arming on the next focus.
-export const settleRendererBootDeadline = () => {
-  deadlineExpire = null
-  disarmDeadline()
-}
-
-export const stopRendererBootTrace = () => {
-  document.removeEventListener("visibilitychange", syncVisibility)
-  settleRendererBootDeadline()
-  subscribed = false
-}
-
-export const markBootStage = (stage: BootStage) => {
-  if (marks[stage] !== undefined) {
-    return
-  }
-
-  if (startedAt === 0) {
-    startRendererBootTrace()
-  }
-
-  marks[stage] = toSeconds(performance.now() - startedAt)
-  Sentry.addBreadcrumb({
-    category: "renderer.boot",
-    data: { atSec: marks[stage] },
-    level: "info",
-    message: stage,
-  })
-}
-
-// Written once per stage, so key order is already chronological.
-const lastStage = (): BootStage | "none" => {
-  const seen = Object.keys(marks) as BootStage[]
-  return seen[seen.length - 1] ?? "none"
-}
-
-interface NavigatorWithHints extends Navigator {
-  deviceMemory?: number
-}
-
-const deviceSnapshot = () => {
-  const nav = navigator as NavigatorWithHints
-
-  return {
-    cpuCores: nav.hardwareConcurrency,
-    deviceMemoryGb: nav.deviceMemory,
-    dpr: window.devicePixelRatio,
-    viewport: `${window.innerWidth}x${window.innerHeight}`,
-  }
-}
 
 const memoryBucket = (gb: number | undefined) => {
   if (gb === undefined) {
@@ -174,72 +25,187 @@ const memoryBucket = (gb: number | undefined) => {
   return ">=8"
 }
 
-const commonFields = () => {
-  const device = deviceSnapshot()
-  const gpu = gpuSnapshot()
-
-  return {
-    contexts: { renderer_boot_device: device, renderer_boot_gpu: gpu },
-    gpu,
-    tags: {
-      "boot.was_hidden": String(wasHidden),
-      "boot.automated": String(navigator.webdriver === true),
-      "device.memory_bucket": memoryBucket(device.deviceMemoryGb),
-      "gpu.adapter_acquired": String(gpu.adapterAcquired),
-    },
-  }
+interface NavigatorWithHints extends Navigator {
+  deviceMemory?: number
 }
 
-export const captureRendererBootTimeout = (
-  budgetMs: number,
-  sceneInfo: Record<string, unknown>
-) => {
-  if (startedAt === 0) {
-    return
+/**
+ * One instance per boot, created by the renderer effect. Module-level state
+ * would survive a remount and file a timeout for the previous mount's clock.
+ */
+export class RendererBootTrace {
+  private startedAt = 0
+  private wasHidden = false
+  private recoveryReported = false
+  private readonly marks: Partial<Record<BootStage, number>> = {}
+
+  private visibleSince: number | null = null
+  private visibleAccum = 0
+
+  private budgetMs = 0
+  private onExpire: (() => void) | null = null
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private expired = false
+
+  private readonly syncVisibility = () => {
+    if (document.visibilityState === "hidden") {
+      this.wasHidden = true
+
+      if (this.visibleSince !== null) {
+        this.visibleAccum += performance.now() - this.visibleSince
+        this.visibleSince = null
+      }
+
+      this.disarm()
+      return
+    }
+
+    if (this.visibleSince === null) {
+      this.visibleSince = performance.now()
+      this.arm()
+    }
   }
 
-  const elapsedSec = toSeconds(performance.now() - startedAt)
-  const { tags, contexts } = commonFields()
+  start(): void {
+    if (this.startedAt === 0) {
+      this.startedAt = performance.now()
+    }
 
-  Sentry.captureMessage("Renderer boot timed out", {
-    contexts: {
-      // Copied: Sentry serializes async, so a later stage would look earlier.
-      renderer_boot: {
-        budgetSec: toSeconds(budgetMs),
-        elapsedSec,
-        marks: { ...marks },
-        visibleSec: toSeconds(visibleElapsed()),
-        ...sceneInfo,
+    document.addEventListener("visibilitychange", this.syncVisibility)
+    this.syncVisibility()
+  }
+
+  /**
+   * Charged only while the tab is visible: a backgrounded tab gets throttled
+   * rAF, so wall-clock time would report a failure nobody saw.
+   */
+  armDeadline(budgetMs: number, onExpire: () => void): void {
+    this.budgetMs = budgetMs
+    this.onExpire = onExpire
+    this.arm()
+  }
+
+  /** Boot reached a terminal state; stop the deadline re-arming on refocus. */
+  settleDeadline(): void {
+    this.onExpire = null
+    this.disarm()
+  }
+
+  dispose(): void {
+    document.removeEventListener("visibilitychange", this.syncVisibility)
+    this.settleDeadline()
+  }
+
+  mark(stage: BootStage): void {
+    if (this.marks[stage] !== undefined) {
+      return
+    }
+
+    this.marks[stage] = toSeconds(performance.now() - this.startedAt)
+    Sentry.addBreadcrumb({
+      category: "renderer.boot",
+      data: { atSec: this.marks[stage] },
+      level: "info",
+      message: stage,
+    })
+  }
+
+  captureTimeout(sceneInfo: Record<string, unknown>): void {
+    this.capture("Renderer boot timed out", "warning", {
+      context: { budgetSec: toSeconds(this.budgetMs), ...sceneInfo },
+      tags: { "boot.last_stage": this.lastStage() },
+    })
+  }
+
+  /** No-ops unless the deadline expired: nothing to recover from otherwise. */
+  captureRecovery(): void {
+    if (this.recoveryReported || !this.expired) {
+      return
+    }
+
+    this.recoveryReported = true
+    this.capture("Renderer boot recovered after timeout", "info")
+  }
+
+  private capture(
+    message: string,
+    level: "info" | "warning",
+    extra: {
+      context?: Record<string, unknown>
+      tags?: Record<string, string>
+    } = {}
+  ): void {
+    const nav = navigator as NavigatorWithHints
+    const device = {
+      cpuCores: nav.hardwareConcurrency,
+      deviceMemoryGb: nav.deviceMemory,
+      dpr: window.devicePixelRatio,
+      viewport: `${window.innerWidth}x${window.innerHeight}`,
+    }
+    const gpu = gpuSnapshot()
+
+    Sentry.captureMessage(message, {
+      contexts: {
+        renderer_boot: {
+          elapsedSec: toSeconds(performance.now() - this.startedAt),
+          // Copied: Sentry serializes async, so a later stage would look earlier.
+          marks: { ...this.marks },
+          visibleSec: toSeconds(this.visibleElapsed()),
+          ...extra.context,
+        },
+        renderer_boot_device: device,
+        renderer_boot_gpu: gpu,
       },
-      ...contexts,
-    },
-    level: "warning",
-    tags: { ...tags, "boot.last_stage": lastStage() },
-  })
-}
-
-export const captureRendererBootRecovery = () => {
-  // Guarded on deadlineFired so callers can fire it on every good frame.
-  if (startedAt === 0 || recoveryReported || !deadlineFired) {
-    return
+      level,
+      tags: {
+        "boot.automated": String(navigator.webdriver === true),
+        "boot.was_hidden": String(this.wasHidden),
+        "device.memory_bucket": memoryBucket(device.deviceMemoryGb),
+        "gpu.adapter_acquired": String(gpu.adapterAcquired),
+        ...extra.tags,
+      },
+    })
   }
 
-  recoveryReported = true
+  private visibleElapsed(): number {
+    return Math.round(
+      this.visibleAccum +
+        (this.visibleSince === null ? 0 : performance.now() - this.visibleSince)
+    )
+  }
 
-  const { tags, contexts } = commonFields()
+  /** Written once per stage, so key order is already chronological. */
+  private lastStage(): BootStage | "none" {
+    const seen = Object.keys(this.marks) as BootStage[]
+    return seen[seen.length - 1] ?? "none"
+  }
 
-  Sentry.captureMessage("Renderer boot recovered after timeout", {
-    contexts: {
-      renderer_boot: {
-        elapsedSec: toSeconds(performance.now() - startedAt),
-        marks: { ...marks },
-        visibleSec: toSeconds(visibleElapsed()),
+  private arm(): void {
+    // `expired` never resets: re-arming after expiry would file twice.
+    if (this.expired || this.onExpire === null) {
+      return
+    }
+
+    if (this.visibleSince === null || this.timer !== null) {
+      return
+    }
+
+    this.timer = setTimeout(
+      () => {
+        this.timer = null
+        this.expired = true
+        this.onExpire?.()
       },
-      ...contexts,
-    },
-    level: "info",
-    tags,
-  })
-}
+      Math.max(0, this.budgetMs - this.visibleElapsed())
+    )
+  }
 
-export const bootMarks = () => ({ ...marks })
+  private disarm(): void {
+    if (this.timer === null) {
+      return
+    }
+
+    clearTimeout(this.timer)
+    this.timer = null
+  }
+}

--- a/src/lib/renderer-boot.ts
+++ b/src/lib/renderer-boot.ts
@@ -106,10 +106,16 @@ export const armRendererBootDeadline = (
   armDeadline()
 }
 
+// Boot reached a terminal state (first frame or init failure). Clearing
+// deadlineExpire also stops syncVisibility from re-arming on the next focus.
+export const settleRendererBootDeadline = () => {
+  deadlineExpire = null
+  disarmDeadline()
+}
+
 export const stopRendererBootTrace = () => {
   document.removeEventListener("visibilitychange", syncVisibility)
-  disarmDeadline()
-  deadlineExpire = null
+  settleRendererBootDeadline()
   subscribed = false
 }
 

--- a/src/lib/sentry-sampling.ts
+++ b/src/lib/sentry-sampling.ts
@@ -1,0 +1,16 @@
+const DEFAULTS: Record<string, number> = { production: 0.05 }
+
+// Shared by the server and client inits so the two can't drift. Out-of-range
+// overrides fall back to the default rather than silently disabling tracing.
+export function resolveTracesSampleRate(
+  environment: string,
+  override: string | undefined
+): number {
+  const parsed = Number.parseFloat(override ?? "")
+
+  if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
+    return parsed
+  }
+
+  return DEFAULTS[environment] ?? 0
+}

--- a/src/lib/webgpu-diagnostics.ts
+++ b/src/lib/webgpu-diagnostics.ts
@@ -1,0 +1,54 @@
+interface GpuDiagnosticsCache {
+  architecture?: string | undefined
+  device?: string | undefined
+  maxTextureDimension2D?: number | undefined
+  vendor?: string | undefined
+}
+
+let cache: GpuDiagnosticsCache = {}
+let deviceLost = false
+
+// A type alias, not an interface: Sentry's `Context` is an index-signature type.
+export type GpuSnapshot = {
+  adapterAcquired: boolean
+  architecture: string | undefined
+  deviceLost: boolean
+  gpuDevice: string | undefined
+  maxTextureDimension2D: number | undefined
+  supportsWebGPU: boolean
+  vendor: string | undefined
+}
+
+export function recordDeviceDiagnostics(device: GPUDevice): void {
+  const info: Partial<GPUAdapterInfo> = device.adapterInfo ?? {}
+
+  cache = {
+    architecture: info.architecture || undefined,
+    device: info.device || undefined,
+    maxTextureDimension2D: device.limits?.maxTextureDimension2D,
+    vendor: info.vendor || undefined,
+  }
+}
+
+export function markDeviceLost(): void {
+  deviceLost = true
+}
+
+export function isDeviceLost(): boolean {
+  return deviceLost
+}
+
+// Synchronous by design: diagnosing a stalled boot must not issue a second
+// requestAdapter(), which would stall the same way and lose the report.
+// `adapterAcquired: false` says the stall is upstream of device acquisition.
+export function gpuSnapshot(): GpuSnapshot {
+  return {
+    adapterAcquired: cache.maxTextureDimension2D !== undefined,
+    architecture: cache.architecture,
+    deviceLost,
+    gpuDevice: cache.device,
+    maxTextureDimension2D: cache.maxTextureDimension2D,
+    supportsWebGPU: typeof navigator !== "undefined" && "gpu" in navigator,
+    vendor: cache.vendor,
+  }
+}

--- a/src/lib/webgpu-diagnostics.ts
+++ b/src/lib/webgpu-diagnostics.ts
@@ -1,12 +1,3 @@
-interface GpuDiagnosticsCache {
-  architecture?: string | undefined
-  device?: string | undefined
-  maxTextureDimension2D?: number | undefined
-  vendor?: string | undefined
-}
-
-let cache: GpuDiagnosticsCache = {}
-
 // A type alias, not an interface: Sentry's `Context` is an index-signature type.
 export type GpuSnapshot = {
   adapterAcquired: boolean
@@ -17,18 +8,29 @@ export type GpuSnapshot = {
   vendor: string | undefined
 }
 
+type GpuFacts = Omit<GpuSnapshot, "adapterAcquired" | "supportsWebGPU">
+
+const UNKNOWN: GpuFacts = {
+  architecture: undefined,
+  gpuDevice: undefined,
+  maxTextureDimension2D: undefined,
+  vendor: undefined,
+}
+
+let facts: GpuFacts | null = null
+
 // First device wins: exports create their own renderer, and the preview's
 // device is the one worth describing.
 export function recordDeviceDiagnostics(device: GPUDevice): void {
-  if (cache.maxTextureDimension2D !== undefined) {
+  if (facts) {
     return
   }
 
   const info: Partial<GPUAdapterInfo> = device.adapterInfo ?? {}
 
-  cache = {
+  facts = {
     architecture: info.architecture || undefined,
-    device: info.device || undefined,
+    gpuDevice: info.device || undefined,
     maxTextureDimension2D: device.limits?.maxTextureDimension2D,
     vendor: info.vendor || undefined,
   }
@@ -39,11 +41,8 @@ export function recordDeviceDiagnostics(device: GPUDevice): void {
 // `adapterAcquired: false` says the stall is upstream of device acquisition.
 export function gpuSnapshot(): GpuSnapshot {
   return {
-    adapterAcquired: cache.maxTextureDimension2D !== undefined,
-    architecture: cache.architecture,
-    gpuDevice: cache.device,
-    maxTextureDimension2D: cache.maxTextureDimension2D,
+    ...(facts ?? UNKNOWN),
+    adapterAcquired: facts !== null,
     supportsWebGPU: typeof navigator !== "undefined" && "gpu" in navigator,
-    vendor: cache.vendor,
   }
 }

--- a/src/lib/webgpu-diagnostics.ts
+++ b/src/lib/webgpu-diagnostics.ts
@@ -6,20 +6,24 @@ interface GpuDiagnosticsCache {
 }
 
 let cache: GpuDiagnosticsCache = {}
-let deviceLost = false
 
 // A type alias, not an interface: Sentry's `Context` is an index-signature type.
 export type GpuSnapshot = {
   adapterAcquired: boolean
   architecture: string | undefined
-  deviceLost: boolean
   gpuDevice: string | undefined
   maxTextureDimension2D: number | undefined
   supportsWebGPU: boolean
   vendor: string | undefined
 }
 
+// First device wins: exports create their own renderer, and the preview's
+// device is the one worth describing.
 export function recordDeviceDiagnostics(device: GPUDevice): void {
+  if (cache.maxTextureDimension2D !== undefined) {
+    return
+  }
+
   const info: Partial<GPUAdapterInfo> = device.adapterInfo ?? {}
 
   cache = {
@@ -30,14 +34,6 @@ export function recordDeviceDiagnostics(device: GPUDevice): void {
   }
 }
 
-export function markDeviceLost(): void {
-  deviceLost = true
-}
-
-export function isDeviceLost(): boolean {
-  return deviceLost
-}
-
 // Synchronous by design: diagnosing a stalled boot must not issue a second
 // requestAdapter(), which would stall the same way and lose the report.
 // `adapterAcquired: false` says the stall is upstream of device acquisition.
@@ -45,7 +41,6 @@ export function gpuSnapshot(): GpuSnapshot {
   return {
     adapterAcquired: cache.maxTextureDimension2D !== undefined,
     architecture: cache.architecture,
-    deviceLost,
     gpuDevice: cache.device,
     maxTextureDimension2D: cache.maxTextureDimension2D,
     supportsWebGPU: typeof navigator !== "undefined" && "gpu" in navigator,

--- a/src/renderer/__tests__/pass-failure.test.ts
+++ b/src/renderer/__tests__/pass-failure.test.ts
@@ -10,9 +10,7 @@ import type { EditorLayer } from "@/types/editor"
 // run, so mocking the layer store leaks into unrelated suites.
 describe("classifyPassFailure", () => {
   test("custom-shader failures are contained, never captured", () => {
-    expect(classifyPassFailure({ kind: "source", type: "custom-shader" })).toBe(
-      "contain"
-    )
+    expect(classifyPassFailure("custom-shader")).toBe("contain")
   })
 
   test("built-in layers are captured", () => {
@@ -27,7 +25,7 @@ describe("classifyPassFailure", () => {
     ]
 
     for (const type of builtIns) {
-      expect(classifyPassFailure({ kind: "source", type })).toBe("capture")
+      expect(classifyPassFailure(type)).toBe("capture")
     }
   })
 
@@ -37,40 +35,32 @@ describe("classifyPassFailure", () => {
 })
 
 describe("nextPassFailureState", () => {
-  const run = (fingerprints: string[], max = 3) => {
+  const run = (fingerprints: string[]) => {
     let state: PassFailureState | undefined
     return fingerprints.map((fingerprint) => {
-      const decision = nextPassFailureState(state, fingerprint, max)
-      state = decision.state
-      return decision
+      state = nextPassFailureState(state, fingerprint)
+      return state
     })
   }
 
-  // The whole point: a pass throwing at 60fps must not send 60 events a second.
-  test("reports the same failure once, however many frames repeat it", () => {
-    const decisions = run(Array.from({ length: 60 }, () => "boom"))
+  // The whole point: callers report only on count === 1, so a pass throwing at
+  // 60fps sends one event, not sixty.
+  test("counts repeats of the same failure so only the first reports", () => {
+    const states = run(Array.from({ length: 60 }, () => "boom"))
 
-    expect(decisions.filter((d) => d.report)).toHaveLength(1)
-    expect(decisions[0]?.report).toBe(true)
+    expect(states.filter((s) => s.count === 1)).toHaveLength(1)
+    expect(states[0]?.count).toBe(1)
+    expect(states.at(-1)?.count).toBe(60)
   })
 
-  test("disables the pass once it hits the limit, and stays disabled", () => {
-    const decisions = run(Array.from({ length: 10 }, () => "boom"))
+  test("a different failure restarts the count, so it reports again", () => {
+    const states = run(["a", "a", "b"])
 
-    expect(decisions.slice(0, 2).some((d) => d.disable)).toBe(false)
-    expect(decisions[2]?.disable).toBe(true)
-    expect(decisions.at(-1)?.disable).toBe(true)
+    expect(states[1]?.count).toBe(2)
+    expect(states[2]?.count).toBe(1)
   })
 
-  test("a different failure reports again and restarts the count", () => {
-    const decisions = run(["a", "a", "b"])
-
-    expect(decisions[2]?.report).toBe(true)
-    expect(decisions[2]?.state.count).toBe(1)
-    expect(decisions[2]?.disable).toBe(false)
-  })
-
-  test("a cleared pass reports again", () => {
-    expect(nextPassFailureState(undefined, "boom", 3).report).toBe(true)
+  test("a cleared pass starts over", () => {
+    expect(nextPassFailureState(undefined, "boom").count).toBe(1)
   })
 })

--- a/src/renderer/__tests__/pass-failure.test.ts
+++ b/src/renderer/__tests__/pass-failure.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import { classifyPassFailure } from "@/renderer/pass-failure"
+import {
+  classifyPassFailure,
+  nextPassFailureState,
+  type PassFailureState,
+} from "@/renderer/pass-failure"
 import type { EditorLayer } from "@/types/editor"
 
 // No module mocks here on purpose: bun's mock.module is global for the whole
@@ -29,5 +33,44 @@ describe("classifyPassFailure", () => {
 
   test("unknown layers are captured rather than silently contained", () => {
     expect(classifyPassFailure(undefined)).toBe("capture")
+  })
+})
+
+describe("nextPassFailureState", () => {
+  const run = (fingerprints: string[], max = 3) => {
+    let state: PassFailureState | undefined
+    return fingerprints.map((fingerprint) => {
+      const decision = nextPassFailureState(state, fingerprint, max)
+      state = decision.state
+      return decision
+    })
+  }
+
+  // The whole point: a pass throwing at 60fps must not send 60 events a second.
+  test("reports the same failure once, however many frames repeat it", () => {
+    const decisions = run(Array.from({ length: 60 }, () => "boom"))
+
+    expect(decisions.filter((d) => d.report)).toHaveLength(1)
+    expect(decisions[0]?.report).toBe(true)
+  })
+
+  test("disables the pass once it hits the limit, and stays disabled", () => {
+    const decisions = run(Array.from({ length: 10 }, () => "boom"))
+
+    expect(decisions.slice(0, 2).some((d) => d.disable)).toBe(false)
+    expect(decisions[2]?.disable).toBe(true)
+    expect(decisions.at(-1)?.disable).toBe(true)
+  })
+
+  test("a different failure reports again and restarts the count", () => {
+    const decisions = run(["a", "a", "b"])
+
+    expect(decisions[2]?.report).toBe(true)
+    expect(decisions[2]?.state.count).toBe(1)
+    expect(decisions[2]?.disable).toBe(false)
+  })
+
+  test("a cleared pass reports again", () => {
+    expect(nextPassFailureState(undefined, "boom", 3).report).toBe(true)
   })
 })

--- a/src/renderer/__tests__/pass-failure.test.ts
+++ b/src/renderer/__tests__/pass-failure.test.ts
@@ -60,7 +60,19 @@ describe("nextPassFailureState", () => {
     expect(states[2]?.count).toBe(1)
   })
 
+  // An error whose message varies per frame must still hit the ceiling,
+  // otherwise `count` resets forever and reporting never stops.
+  test("total ignores the fingerprint so varying errors still get disabled", () => {
+    const states = run(["a", "b", "c", "d"])
+
+    expect(states.map((s) => s.count)).toEqual([1, 1, 1, 1])
+    expect(states.map((s) => s.total)).toEqual([1, 2, 3, 4])
+  })
+
   test("a cleared pass starts over", () => {
-    expect(nextPassFailureState(undefined, "boom").count).toBe(1)
+    expect(nextPassFailureState(undefined, "boom")).toMatchObject({
+      count: 1,
+      total: 1,
+    })
   })
 })

--- a/src/renderer/__tests__/pass-failure.test.ts
+++ b/src/renderer/__tests__/pass-failure.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { classifyPassFailure } from "@/renderer/pass-failure"
+import type { EditorLayer } from "@/types/editor"
+
+// No module mocks here on purpose: bun's mock.module is global for the whole
+// run, so mocking the layer store leaks into unrelated suites.
+describe("classifyPassFailure", () => {
+  test("custom-shader failures are contained, never captured", () => {
+    expect(classifyPassFailure({ kind: "source", type: "custom-shader" })).toBe(
+      "contain"
+    )
+  })
+
+  test("built-in layers are captured", () => {
+    const builtIns: EditorLayer["type"][] = [
+      "crt",
+      "image",
+      "video",
+      "gradient",
+      "fluid",
+      "text",
+      "live",
+    ]
+
+    for (const type of builtIns) {
+      expect(classifyPassFailure({ kind: "source", type })).toBe("capture")
+    }
+  })
+
+  test("unknown layers are captured rather than silently contained", () => {
+    expect(classifyPassFailure(undefined)).toBe("capture")
+  })
+})

--- a/src/renderer/contracts.ts
+++ b/src/renderer/contracts.ts
@@ -1,6 +1,6 @@
 import {
-  type AudioModulationInput,
   applyAudioModulation,
+  type AudioModulationInput,
 } from "@/lib/editor/audio/links"
 import { cloneParameterValues } from "@/lib/editor/parameter-schema"
 import { evaluateTimelineForLayers } from "@/lib/editor/timeline/evaluate"

--- a/src/renderer/contracts.ts
+++ b/src/renderer/contracts.ts
@@ -1,6 +1,6 @@
 import {
-  applyAudioModulation,
   type AudioModulationInput,
+  applyAudioModulation,
 } from "@/lib/editor/audio/links"
 import { cloneParameterValues } from "@/lib/editor/parameter-schema"
 import { evaluateTimelineForLayers } from "@/lib/editor/timeline/evaluate"
@@ -47,6 +47,7 @@ export interface EditorRenderer {
   hasPendingCompilations(): boolean
   hasPendingResources(): boolean
   initialize(): Promise<void>
+  isDeviceLost(): boolean
   prepareForExportFrame(time: number, loop: boolean): Promise<void>
   render(frame: RendererFrame): void
   resize(size: Size, pixelRatio: number): void

--- a/src/renderer/create-webgpu-renderer.ts
+++ b/src/renderer/create-webgpu-renderer.ts
@@ -1,9 +1,6 @@
 import * as Sentry from "@sentry/nextjs"
 import * as THREE from "three/webgpu"
-import {
-  markDeviceLost,
-  recordDeviceDiagnostics,
-} from "@/lib/webgpu-diagnostics"
+import { recordDeviceDiagnostics } from "@/lib/webgpu-diagnostics"
 import type { EditorRenderer, RendererFrame } from "@/renderer/contracts"
 import { PipelineManager } from "@/renderer/pipeline-manager"
 import type { Size } from "@/types/editor"
@@ -38,8 +35,15 @@ function getGpuQueue(instance: THREE.WebGPURenderer): GpuQueueLike | null {
   return queue
 }
 
+export type CreateRendererOptions = {
+  // Exports are deliverables: a pass failure must abort rather than silently
+  // ship a frame with a missing layer.
+  strictPassFailures?: boolean
+}
+
 export async function createWebGPURenderer(
-  canvas: HTMLCanvasElement
+  canvas: HTMLCanvasElement,
+  options: CreateRendererOptions = {}
 ): Promise<EditorRenderer> {
   const renderer = new THREE.WebGPURenderer({
     alpha: false,
@@ -48,6 +52,9 @@ export async function createWebGPURenderer(
   })
   let pipeline: PipelineManager | null = null
   let currentPixelRatio = 1
+  // Per renderer, not module state: preview and export own separate devices, so
+  // a lost export device must not halt a healthy preview.
+  let deviceLost = false
 
   function toDeviceSize(size: Size): Size {
     return {
@@ -58,7 +65,13 @@ export async function createWebGPURenderer(
 
   function renderFrame(frame: RendererFrame) {
     if (!pipeline) {
-      pipeline = new PipelineManager(renderer, toDeviceSize(frame.viewportSize))
+      pipeline = new PipelineManager(
+        renderer,
+        toDeviceSize(frame.viewportSize),
+        {
+          strictPassFailures: options.strictPassFailures === true,
+        }
+      )
     }
 
     pipeline.updateLogicalSize(frame.logicalSize)
@@ -90,7 +103,7 @@ export async function createWebGPURenderer(
       const reportDeviceLost = deviceLostHost.onDeviceLost.bind(renderer)
       deviceLostHost.onDeviceLost = (info) => {
         reportDeviceLost(info)
-        markDeviceLost()
+        deviceLost = true
         Sentry.captureMessage("WebGPU device lost", {
           extra: { message: info.message },
           level: "error",
@@ -110,6 +123,10 @@ export async function createWebGPURenderer(
         }
       ).toneMapping = THREE.NoToneMapping
       renderer.setClearColor("#0a0d10", 1)
+    },
+
+    isDeviceLost() {
+      return deviceLost
     },
 
     hasPendingCompilations() {

--- a/src/renderer/create-webgpu-renderer.ts
+++ b/src/renderer/create-webgpu-renderer.ts
@@ -1,4 +1,9 @@
+import * as Sentry from "@sentry/nextjs"
 import * as THREE from "three/webgpu"
+import {
+  markDeviceLost,
+  recordDeviceDiagnostics,
+} from "@/lib/webgpu-diagnostics"
 import type { EditorRenderer, RendererFrame } from "@/renderer/contracts"
 import { PipelineManager } from "@/renderer/pipeline-manager"
 import type { Size } from "@/types/editor"
@@ -9,6 +14,12 @@ export function browserSupportsWebGPU(): boolean {
 
 type GpuQueueLike = { onSubmittedWorkDone: () => Promise<unknown> }
 type GpuDeviceLike = { destroy?: () => void; queue?: GpuQueueLike }
+
+type DeviceLostInfo = { message: string; reason: string | null }
+// Assignable on the instance, but absent from the bundled three/webgpu types.
+type RendererWithDeviceLost = {
+  onDeviceLost: (info: DeviceLostInfo) => void
+}
 
 function getGpuDevice(instance: THREE.WebGPURenderer): GpuDeviceLike | null {
   return (
@@ -65,6 +76,27 @@ export async function createWebGPURenderer(
   return {
     async initialize() {
       await renderer.init()
+
+      const device = getGpuDevice(renderer)
+
+      if (device) {
+        recordDeviceDiagnostics(device as unknown as GPUDevice)
+      }
+
+      // three owns device.lost and already filters reason === "destroyed" (our
+      // own destroyDevice during export teardown). Wrap rather than replace:
+      // calling through preserves the renderer's _isDeviceLost flag.
+      const deviceLostHost = renderer as unknown as RendererWithDeviceLost
+      const reportDeviceLost = deviceLostHost.onDeviceLost.bind(renderer)
+      deviceLostHost.onDeviceLost = (info) => {
+        reportDeviceLost(info)
+        markDeviceLost()
+        Sentry.captureMessage("WebGPU device lost", {
+          extra: { message: info.message },
+          level: "error",
+          tags: { "gpu.lost_reason": info.reason ?? "unknown" },
+        })
+      }
       ;(
         renderer as THREE.WebGPURenderer & {
           outputColorSpace: string

--- a/src/renderer/custom-shader-pass.ts
+++ b/src/renderer/custom-shader-pass.ts
@@ -1,4 +1,16 @@
-import { clamp, float, pow, texture as tslTexture, type TSLNode, uniform, uv, vec2, vec3, vec4 } from "three/tsl"
+import * as Sentry from "@sentry/nextjs"
+import {
+  clamp,
+  float,
+  pow,
+  type TSLNode,
+  texture as tslTexture,
+  uniform,
+  uv,
+  vec2,
+  vec3,
+  vec4,
+} from "three/tsl"
 import * as THREE from "three/webgpu"
 import { emitCustomShaderCompileResult } from "@/lib/agent-bridge/compile-events"
 import { CUSTOM_SHADER_ENTRY_EXPORT } from "@/lib/editor/custom-shader/shared"
@@ -9,6 +21,21 @@ import type { LayerParameterValues } from "@/types/editor"
 
 type Node = TSLNode
 type TypedNode = TSLNode & { nodeType?: string | null }
+
+// Breadcrumbs only, never captures: broken TSL is expected user input and the
+// sidebar already shows the message. See pass-failure.ts.
+function addCompileBreadcrumb(
+  layerId: string,
+  sourceLength: number,
+  error: string | null
+): void {
+  Sentry.addBreadcrumb({
+    category: "shader.compile",
+    data: { firstDiagnostic: error?.split("\n")[0], layerId, sourceLength },
+    level: error === null ? "info" : "warning",
+    message: error === null ? "custom shader compiled" : "custom shader failed",
+  })
+}
 
 export class CustomShaderPass extends PassNode {
   private compiledSketch: (() => Node) | null = null
@@ -79,11 +106,12 @@ export class CustomShaderPass extends PassNode {
 
         this.compiledSketch = compiled.buildNode
         useLayerStore.getState().setLayerRuntimeError(this.layerId, null)
+        addCompileBreadcrumb(this.layerId, sourceCode.length, null)
         this.rebuildEffectNode()
         emitCustomShaderCompileResult({
           error:
-            useLayerStore.getState().getLayerById(this.layerId)
-              ?.runtimeError ?? null,
+            useLayerStore.getState().getLayerById(this.layerId)?.runtimeError ??
+            null,
           layerId: this.layerId,
           revision: sourceRevision,
         })
@@ -100,6 +128,7 @@ export class CustomShaderPass extends PassNode {
 
         this.compiledSketch = null
         useLayerStore.getState().setLayerRuntimeError(this.layerId, message)
+        addCompileBreadcrumb(this.layerId, sourceCode.length, message)
         this.rebuildEffectNode()
         emitCustomShaderCompileResult({
           error: message,
@@ -146,14 +175,18 @@ export class CustomShaderPass extends PassNode {
 
       return vec4(finalRgb, float(1))
     } catch (error) {
-      useLayerStore
-        .getState()
-        .setLayerRuntimeError(
-          this.layerId,
-          error instanceof Error
-            ? error.message
-            : "Custom shader execution failed."
-        )
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Custom shader execution failed."
+
+      useLayerStore.getState().setLayerRuntimeError(this.layerId, message)
+      Sentry.addBreadcrumb({
+        category: "shader.compile",
+        data: { layerId: this.layerId, surface: "build-effect-node" },
+        level: "warning",
+        message,
+      })
       return vec4(vec3(float(0), float(0), float(0)), float(1))
     }
   }

--- a/src/renderer/custom-shader-pass.ts
+++ b/src/renderer/custom-shader-pass.ts
@@ -15,6 +15,7 @@ import * as THREE from "three/webgpu"
 import { emitCustomShaderCompileResult } from "@/lib/agent-bridge/compile-events"
 import { CUSTOM_SHADER_ENTRY_EXPORT } from "@/lib/editor/custom-shader/shared"
 import { compileCustomShaderModule } from "@/renderer/custom-shader-runtime"
+import { reportPassFailure } from "@/renderer/pass-failure"
 import { PassNode } from "@/renderer/pass-node"
 import { useLayerStore } from "@/store/layer-store"
 import type { LayerParameterValues } from "@/types/editor"
@@ -175,18 +176,12 @@ export class CustomShaderPass extends PassNode {
 
       return vec4(finalRgb, float(1))
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Custom shader execution failed."
-
-      useLayerStore.getState().setLayerRuntimeError(this.layerId, message)
-      Sentry.addBreadcrumb({
-        category: "shader.compile",
-        data: { layerId: this.layerId, surface: "build-effect-node" },
-        level: "warning",
-        message,
-      })
+      reportPassFailure(
+        "custom-shader",
+        this.layerId,
+        "build-effect-node",
+        error
+      )
       return vec4(vec3(float(0), float(0), float(0)), float(1))
     }
   }

--- a/src/renderer/pass-failure.ts
+++ b/src/renderer/pass-failure.ts
@@ -2,42 +2,40 @@ import * as Sentry from "@sentry/nextjs"
 import { useLayerStore } from "@/store/layer-store"
 import type { EditorLayer } from "@/types/editor"
 
-export type LayerMeta = { kind: EditorLayer["kind"]; type: EditorLayer["type"] }
+export type LayerType = EditorLayer["type"]
 
-export type PassFailureSurface = "pass-render" | "pipeline-compile"
+export type PassFailureSurface =
+  | "build-effect-node"
+  | "pass-render"
+  | "pipeline-compile"
+
+const FALLBACK_MESSAGE: Record<PassFailureSurface, string> = {
+  "build-effect-node": "Custom shader execution failed.",
+  "pass-render": "Layer failed to render.",
+  "pipeline-compile": "Shader compilation failed.",
+}
 
 // "contain" runs user-authored code, so its failures are expected input rather
 // than defects and must never become Sentry issues.
 export type PassFailureHandling = "capture" | "contain"
 
 export function classifyPassFailure(
-  meta: LayerMeta | undefined
+  type: LayerType | undefined
 ): PassFailureHandling {
-  return meta?.type === "custom-shader" ? "contain" : "capture"
+  return type === "custom-shader" ? "contain" : "capture"
 }
 
 export type PassFailureState = { count: number; fingerprint: string }
 
-export type PassFailureDecision = {
-  disable: boolean
-  report: boolean
-  state: PassFailureState
-}
-
 // A pass that throws while anything needs continuous rendering throws ~60x a
-// second: report once per fingerprint, then drop the pass from the composite.
+// second, so callers report only on count === 1 and disable at a ceiling.
 export function nextPassFailureState(
   previous: PassFailureState | undefined,
-  fingerprint: string,
-  maxFailures: number
-): PassFailureDecision {
-  const count = previous?.fingerprint === fingerprint ? previous.count + 1 : 1
-
-  return {
-    disable: count >= maxFailures,
-    report: count === 1,
-    state: { count, fingerprint },
-  }
+  fingerprint: string
+): PassFailureState {
+  return previous?.fingerprint === fingerprint
+    ? { count: previous.count + 1, fingerprint }
+    : { count: 1, fingerprint }
 }
 
 export function errorFingerprint(error: unknown): string {
@@ -51,15 +49,15 @@ export function errorFingerprint(error: unknown): string {
 }
 
 export function reportPassFailure(
-  meta: LayerMeta | undefined,
+  type: LayerType | undefined,
   layerId: string,
   surface: PassFailureSurface,
-  error: unknown,
-  fallback: string
+  error: unknown
 ): void {
-  const message = error instanceof Error ? error.message : fallback
+  const message =
+    error instanceof Error ? error.message : FALLBACK_MESSAGE[surface]
 
-  if (classifyPassFailure(meta) === "contain") {
+  if (classifyPassFailure(type) === "contain") {
     useLayerStore.getState().setLayerRuntimeError(layerId, message)
     Sentry.addBreadcrumb({
       category: "shader.compile",
@@ -71,6 +69,6 @@ export function reportPassFailure(
   }
 
   Sentry.captureException(error, {
-    tags: { "layer.type": meta?.type ?? "unknown", surface },
+    tags: { "layer.type": type ?? "unknown", surface },
   })
 }

--- a/src/renderer/pass-failure.ts
+++ b/src/renderer/pass-failure.ts
@@ -1,0 +1,42 @@
+import * as Sentry from "@sentry/nextjs"
+import { useLayerStore } from "@/store/layer-store"
+import type { EditorLayer } from "@/types/editor"
+
+export type LayerMeta = { kind: EditorLayer["kind"]; type: EditorLayer["type"] }
+
+export type PassFailureSurface = "pass-render" | "pipeline-compile"
+
+// "contain" runs user-authored code, so its failures are expected input rather
+// than defects and must never become Sentry issues.
+export type PassFailureHandling = "capture" | "contain"
+
+export function classifyPassFailure(
+  meta: LayerMeta | undefined
+): PassFailureHandling {
+  return meta?.type === "custom-shader" ? "contain" : "capture"
+}
+
+export function reportPassFailure(
+  meta: LayerMeta | undefined,
+  layerId: string,
+  surface: PassFailureSurface,
+  error: unknown,
+  fallback: string
+): void {
+  const message = error instanceof Error ? error.message : fallback
+
+  if (classifyPassFailure(meta) === "contain") {
+    useLayerStore.getState().setLayerRuntimeError(layerId, message)
+    Sentry.addBreadcrumb({
+      category: "shader.compile",
+      data: { layerId, surface },
+      level: "warning",
+      message,
+    })
+    return
+  }
+
+  Sentry.captureException(error, {
+    tags: { "layer.type": meta?.type ?? "unknown", surface },
+  })
+}

--- a/src/renderer/pass-failure.ts
+++ b/src/renderer/pass-failure.ts
@@ -16,6 +16,40 @@ export function classifyPassFailure(
   return meta?.type === "custom-shader" ? "contain" : "capture"
 }
 
+export type PassFailureState = { count: number; fingerprint: string }
+
+export type PassFailureDecision = {
+  disable: boolean
+  report: boolean
+  state: PassFailureState
+}
+
+// A pass that throws while anything needs continuous rendering throws ~60x a
+// second: report once per fingerprint, then drop the pass from the composite.
+export function nextPassFailureState(
+  previous: PassFailureState | undefined,
+  fingerprint: string,
+  maxFailures: number
+): PassFailureDecision {
+  const count = previous?.fingerprint === fingerprint ? previous.count + 1 : 1
+
+  return {
+    disable: count >= maxFailures,
+    report: count === 1,
+    state: { count, fingerprint },
+  }
+}
+
+export function errorFingerprint(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error)
+  }
+
+  return [error.name, error.message, error.stack?.split("\n")[1]?.trim()].join(
+    "|"
+  )
+}
+
 export function reportPassFailure(
   meta: LayerMeta | undefined,
   layerId: string,

--- a/src/renderer/pass-failure.ts
+++ b/src/renderer/pass-failure.ts
@@ -25,17 +25,28 @@ export function classifyPassFailure(
   return type === "custom-shader" ? "contain" : "capture"
 }
 
-export type PassFailureState = { count: number; fingerprint: string }
+export type PassFailureState = {
+  count: number
+  fingerprint: string
+  total: number
+}
 
-// A pass that throws while anything needs continuous rendering throws ~60x a
-// second, so callers report only on count === 1 and disable at a ceiling.
+/**
+ * A pass that throws while anything needs continuous rendering throws ~60x a
+ * second. Callers report only when `count` is 1 — a fingerprint they haven't
+ * seen — and disable the pass once `total` hits a ceiling. `total` ignores the
+ * fingerprint on purpose: an error whose message varies per frame would
+ * otherwise reset `count` forever and never stop reporting.
+ */
 export function nextPassFailureState(
   previous: PassFailureState | undefined,
   fingerprint: string
 ): PassFailureState {
+  const total = (previous?.total ?? 0) + 1
+
   return previous?.fingerprint === fingerprint
-    ? { count: previous.count + 1, fingerprint }
-    : { count: 1, fingerprint }
+    ? { count: previous.count + 1, fingerprint, total }
+    : { count: 1, fingerprint, total }
 }
 
 export function errorFingerprint(error: unknown): string {

--- a/src/renderer/pipeline-manager.ts
+++ b/src/renderer/pipeline-manager.ts
@@ -546,7 +546,7 @@ export class PipelineManager {
   }
 
   private isPassDisabled(layerId: string): boolean {
-    return (this.passFailures.get(layerId)?.count ?? 0) >= MAX_PASS_FAILURES
+    return (this.passFailures.get(layerId)?.total ?? 0) >= MAX_PASS_FAILURES
   }
 
   private handlePassRenderFailure(layerId: string, error: unknown): void {
@@ -566,7 +566,7 @@ export class PipelineManager {
       )
     }
 
-    if (state.count === MAX_PASS_FAILURES) {
+    if (state.total === MAX_PASS_FAILURES) {
       this.markDirty()
     }
   }

--- a/src/renderer/pipeline-manager.ts
+++ b/src/renderer/pipeline-manager.ts
@@ -9,6 +9,7 @@ import { GradientPass } from "@/renderer/gradient-pass"
 import { LivePass } from "@/renderer/live-pass"
 import { MagnifyLensPass } from "@/renderer/magnify-lens-pass"
 import { MediaPass } from "@/renderer/media-pass"
+import { type LayerMeta, reportPassFailure } from "@/renderer/pass-failure"
 import type { PassNode } from "@/renderer/pass-node"
 import { createPassNode } from "@/renderer/pass-node-factory"
 import { PixelTrailPass } from "@/renderer/pixel-trail-pass"
@@ -119,6 +120,8 @@ export class PipelineManager {
   private layerSignatures = new Map<string, string>()
   private compilingPasses = new Set<string>()
   private compiledVersions = new Map<string, number>()
+  // Attributes compile and render failures to a layer type. See pass-failure.ts.
+  private layerMeta = new Map<string, LayerMeta>()
   private pendingMediaLoads = new Set<string>()
   private cachedActivePasses: LayerPassNode[] = []
   private activePassesDirty = true
@@ -196,6 +199,7 @@ export class PipelineManager {
       this.layerSignatures.delete(layerId)
       this.compilingPasses.delete(layerId)
       this.compiledVersions.delete(layerId)
+      this.layerMeta.delete(layerId)
       this.markDirty()
     }
 
@@ -205,6 +209,11 @@ export class PipelineManager {
       const layerId = renderableLayer.layer.id
       const signature = createLayerSignature(renderableLayer)
       let pass = this.passMap.get(layerId)
+
+      this.layerMeta.set(layerId, {
+        kind: renderableLayer.layer.kind,
+        type: renderableLayer.layer.type,
+      })
 
       if (!pass) {
         pass = this.createPass(renderableLayer.layer)
@@ -271,23 +280,36 @@ export class PipelineManager {
     let writeTarget = this.rtB
 
     for (const pass of activePasses) {
-      ;(
-        pass.render as (
-          renderer: THREE.WebGPURenderer,
-          inputTexture: THREE.Texture,
-          outputTarget: THREE.WebGLRenderTarget,
-          time: number,
-          delta: number,
-          timelineTime: number
-        ) => void
-      )(
-        this.renderer,
-        readTarget.texture,
-        writeTarget,
-        time,
-        delta,
-        timelineTime
-      )
+      try {
+        ;(
+          pass.render as (
+            renderer: THREE.WebGPURenderer,
+            inputTexture: THREE.Texture,
+            outputTarget: THREE.WebGLRenderTarget,
+            time: number,
+            delta: number,
+            timelineTime: number
+          ) => void
+        )(
+          this.renderer,
+          readTarget.texture,
+          writeTarget,
+          time,
+          delta,
+          timelineTime
+        )
+      } catch (error) {
+        reportPassFailure(
+          this.layerMeta.get(pass.layerId),
+          pass.layerId,
+          "pass-render",
+          error,
+          "Layer failed to render."
+        )
+        // Skip the swap: the failed pass contributes nothing.
+        continue
+      }
+
       const previousRead = readTarget
       readTarget = writeTarget
       writeTarget = previousRead
@@ -514,8 +536,16 @@ export class PipelineManager {
         this.compiledVersions.set(pass.layerId, pass.getMaterialVersion())
         this.markDirty()
       })
-      .catch(() => {
+      .catch((error: unknown) => {
+        // Keep the delete: dropping it wedges hasPendingCompilations().
         this.compilingPasses.delete(pass.layerId)
+        reportPassFailure(
+          this.layerMeta.get(pass.layerId),
+          pass.layerId,
+          "pipeline-compile",
+          error,
+          "Shader compilation failed."
+        )
       })
   }
 

--- a/src/renderer/pipeline-manager.ts
+++ b/src/renderer/pipeline-manager.ts
@@ -9,7 +9,13 @@ import { GradientPass } from "@/renderer/gradient-pass"
 import { LivePass } from "@/renderer/live-pass"
 import { MagnifyLensPass } from "@/renderer/magnify-lens-pass"
 import { MediaPass } from "@/renderer/media-pass"
-import { type LayerMeta, reportPassFailure } from "@/renderer/pass-failure"
+import {
+  errorFingerprint,
+  type LayerMeta,
+  nextPassFailureState,
+  type PassFailureState,
+  reportPassFailure,
+} from "@/renderer/pass-failure"
 import type { PassNode } from "@/renderer/pass-node"
 import { createPassNode } from "@/renderer/pass-node-factory"
 import { PixelTrailPass } from "@/renderer/pixel-trail-pass"
@@ -18,6 +24,9 @@ import { TextPass } from "@/renderer/text-pass"
 import type { EditorLayer, SceneConfig, Size } from "@/types/editor"
 
 type LayerPassNode = FluidPass | LivePass | MediaPass | PassNode
+
+// Editing the layer re-enables a dropped pass. See pass-failure.ts.
+const MAX_PASS_FAILURES = 3
 
 const RENDER_TARGET_OPTIONS = {
   depthBuffer: false,
@@ -122,6 +131,8 @@ export class PipelineManager {
   private compiledVersions = new Map<string, number>()
   // Attributes compile and render failures to a layer type. See pass-failure.ts.
   private layerMeta = new Map<string, LayerMeta>()
+  private passFailures = new Map<string, PassFailureState>()
+  private failedPasses = new Set<string>()
   private pendingMediaLoads = new Set<string>()
   private cachedActivePasses: LayerPassNode[] = []
   private activePassesDirty = true
@@ -200,6 +211,7 @@ export class PipelineManager {
       this.compilingPasses.delete(layerId)
       this.compiledVersions.delete(layerId)
       this.layerMeta.delete(layerId)
+      this.clearPassFailure(layerId)
       this.markDirty()
     }
 
@@ -224,6 +236,9 @@ export class PipelineManager {
       }
 
       if (this.layerSignatures.get(layerId) !== signature) {
+        // The user changed something: give a disabled pass another chance.
+        this.clearPassFailure(layerId)
+
         const versionBefore = pass.getMaterialVersion()
         this.layerSignatures.set(layerId, signature)
         this.applyLayerState(pass, renderableLayer)
@@ -251,6 +266,7 @@ export class PipelineManager {
       this.cachedActivePasses = this.passes.filter(
         (pass) =>
           pass.enabled &&
+          !this.failedPasses.has(pass.layerId) &&
           (!this.compilingPasses.has(pass.layerId) ||
             this.compiledVersions.has(pass.layerId))
       )
@@ -299,16 +315,12 @@ export class PipelineManager {
           timelineTime
         )
       } catch (error) {
-        reportPassFailure(
-          this.layerMeta.get(pass.layerId),
-          pass.layerId,
-          "pass-render",
-          error,
-          "Layer failed to render."
-        )
+        this.handlePassRenderFailure(pass.layerId, error)
         // Skip the swap: the failed pass contributes nothing.
         continue
       }
+
+      this.passFailures.delete(pass.layerId)
 
       const previousRead = readTarget
       readTarget = writeTarget
@@ -515,6 +527,39 @@ export class PipelineManager {
             this.markDirty()
           })
       }
+    }
+  }
+
+  private handlePassRenderFailure(layerId: string, error: unknown): void {
+    const { disable, report, state } = nextPassFailureState(
+      this.passFailures.get(layerId),
+      errorFingerprint(error),
+      MAX_PASS_FAILURES
+    )
+
+    this.passFailures.set(layerId, state)
+
+    if (report) {
+      reportPassFailure(
+        this.layerMeta.get(layerId),
+        layerId,
+        "pass-render",
+        error,
+        "Layer failed to render."
+      )
+    }
+
+    if (disable) {
+      this.failedPasses.add(layerId)
+      this.markDirty()
+    }
+  }
+
+  private clearPassFailure(layerId: string): void {
+    this.passFailures.delete(layerId)
+
+    if (this.failedPasses.delete(layerId)) {
+      this.markDirty()
     }
   }
 

--- a/src/renderer/pipeline-manager.ts
+++ b/src/renderer/pipeline-manager.ts
@@ -133,6 +133,7 @@ export class PipelineManager {
   private layerMeta = new Map<string, LayerMeta>()
   private passFailures = new Map<string, PassFailureState>()
   private failedPasses = new Set<string>()
+  private readonly strictPassFailures: boolean
   private pendingMediaLoads = new Set<string>()
   private cachedActivePasses: LayerPassNode[] = []
   private activePassesDirty = true
@@ -153,7 +154,12 @@ export class PipelineManager {
   private rtA: THREE.WebGLRenderTarget
   private rtB: THREE.WebGLRenderTarget
 
-  constructor(renderer: THREE.WebGPURenderer, size: Size) {
+  constructor(
+    renderer: THREE.WebGPURenderer,
+    size: Size,
+    options: { strictPassFailures?: boolean } = {}
+  ) {
+    this.strictPassFailures = options.strictPassFailures === true
     this.renderer = renderer
     this.width = Math.max(1, size.width)
     this.height = Math.max(1, size.height)
@@ -236,15 +242,16 @@ export class PipelineManager {
       }
 
       if (this.layerSignatures.get(layerId) !== signature) {
-        // The user changed something: give a disabled pass another chance.
-        this.clearPassFailure(layerId)
-
         const versionBefore = pass.getMaterialVersion()
         this.layerSignatures.set(layerId, signature)
         this.applyLayerState(pass, renderableLayer)
         this.markDirty()
 
         if (pass.getMaterialVersion() !== versionBefore) {
+          // Recover on a material rebuild, not on any signature change: keyframed
+          // and audio-driven values change the signature every frame, which would
+          // reset the failure count before it could ever throttle.
+          this.clearPassFailure(layerId)
           this.scheduleCompile(pass)
         }
       }
@@ -315,6 +322,12 @@ export class PipelineManager {
           timelineTime
         )
       } catch (error) {
+        // Exports must fail loudly: dropping a layer would ship a frame that
+        // looks fine but is wrong.
+        if (this.strictPassFailures) {
+          throw error
+        }
+
         this.handlePassRenderFailure(pass.layerId, error)
         // Skip the swap: the failed pass contributes nothing.
         continue

--- a/src/renderer/pipeline-manager.ts
+++ b/src/renderer/pipeline-manager.ts
@@ -11,7 +11,7 @@ import { MagnifyLensPass } from "@/renderer/magnify-lens-pass"
 import { MediaPass } from "@/renderer/media-pass"
 import {
   errorFingerprint,
-  type LayerMeta,
+  type LayerType,
   nextPassFailureState,
   type PassFailureState,
   reportPassFailure,
@@ -130,9 +130,8 @@ export class PipelineManager {
   private compilingPasses = new Set<string>()
   private compiledVersions = new Map<string, number>()
   // Attributes compile and render failures to a layer type. See pass-failure.ts.
-  private layerMeta = new Map<string, LayerMeta>()
+  private layerTypes = new Map<string, LayerType>()
   private passFailures = new Map<string, PassFailureState>()
-  private failedPasses = new Set<string>()
   private readonly strictPassFailures: boolean
   private pendingMediaLoads = new Set<string>()
   private cachedActivePasses: LayerPassNode[] = []
@@ -216,7 +215,7 @@ export class PipelineManager {
       this.layerSignatures.delete(layerId)
       this.compilingPasses.delete(layerId)
       this.compiledVersions.delete(layerId)
-      this.layerMeta.delete(layerId)
+      this.layerTypes.delete(layerId)
       this.clearPassFailure(layerId)
       this.markDirty()
     }
@@ -228,10 +227,7 @@ export class PipelineManager {
       const signature = createLayerSignature(renderableLayer)
       let pass = this.passMap.get(layerId)
 
-      this.layerMeta.set(layerId, {
-        kind: renderableLayer.layer.kind,
-        type: renderableLayer.layer.type,
-      })
+      this.layerTypes.set(layerId, renderableLayer.layer.type)
 
       if (!pass) {
         pass = this.createPass(renderableLayer.layer)
@@ -273,7 +269,7 @@ export class PipelineManager {
       this.cachedActivePasses = this.passes.filter(
         (pass) =>
           pass.enabled &&
-          !this.failedPasses.has(pass.layerId) &&
+          !this.isPassDisabled(pass.layerId) &&
           (!this.compilingPasses.has(pass.layerId) ||
             this.compiledVersions.has(pass.layerId))
       )
@@ -323,8 +319,14 @@ export class PipelineManager {
         )
       } catch (error) {
         // Exports must fail loudly: dropping a layer would ship a frame that
-        // looks fine but is wrong.
+        // looks fine but is wrong. Still report, so the abort is diagnosable.
         if (this.strictPassFailures) {
+          reportPassFailure(
+            this.layerTypes.get(pass.layerId),
+            pass.layerId,
+            "pass-render",
+            error
+          )
           throw error
         }
 
@@ -543,35 +545,37 @@ export class PipelineManager {
     }
   }
 
+  private isPassDisabled(layerId: string): boolean {
+    return (this.passFailures.get(layerId)?.count ?? 0) >= MAX_PASS_FAILURES
+  }
+
   private handlePassRenderFailure(layerId: string, error: unknown): void {
-    const { disable, report, state } = nextPassFailureState(
+    const state = nextPassFailureState(
       this.passFailures.get(layerId),
-      errorFingerprint(error),
-      MAX_PASS_FAILURES
+      errorFingerprint(error)
     )
 
     this.passFailures.set(layerId, state)
 
-    if (report) {
+    if (state.count === 1) {
       reportPassFailure(
-        this.layerMeta.get(layerId),
+        this.layerTypes.get(layerId),
         layerId,
         "pass-render",
-        error,
-        "Layer failed to render."
+        error
       )
     }
 
-    if (disable) {
-      this.failedPasses.add(layerId)
+    if (state.count === MAX_PASS_FAILURES) {
       this.markDirty()
     }
   }
 
   private clearPassFailure(layerId: string): void {
+    const wasDisabled = this.isPassDisabled(layerId)
     this.passFailures.delete(layerId)
 
-    if (this.failedPasses.delete(layerId)) {
+    if (wasDisabled) {
       this.markDirty()
     }
   }
@@ -598,11 +602,10 @@ export class PipelineManager {
         // Keep the delete: dropping it wedges hasPendingCompilations().
         this.compilingPasses.delete(pass.layerId)
         reportPassFailure(
-          this.layerMeta.get(pass.layerId),
+          this.layerTypes.get(pass.layerId),
           pass.layerId,
           "pipeline-compile",
-          error,
-          "Shader compilation failed."
+          error
         )
       })
   }


### PR DESCRIPTION
Stacked on #134 — **merge that first.**

Aligns Sentry config with `basementstudio/website-2k25`, then instruments this project's actual failure surfaces. Shader Lab is WebGPU (`three/webgpu` + TSL), not R3F, so its failures are device- and compile-bound rather than asset-bound.

## Config

- `src/lib/sentry-sampling.ts` — shared helper so client and server rates can't drift (0.05 prod, 0 elsewhere)
- One `register()` for node + edge; this app has no route handlers, server actions or API routes
- Production-only reporting, extension `denyUrls`, pseudonymous `setUser`
- **`BrowserApiErrors` no longer wraps `requestAnimationFrame`** — it costs on every frame of the render loop. `eventTarget` stays on (unlike website-2k25): DOM and worker handlers are most of this app
- Source maps and release creation gated on `VERCEL === "1" && SENTRY_AUTH_TOKEN`. `release.name` is set explicitly, because `@sentry/nextjs` skips release *name* resolution entirely when `create` is false — which would otherwise leave every tokenless build with no release tag

## What now gets reported

Four renderer failures that previously left a black or frozen canvas with no signal:

| Failure | Handling |
|---|---|
| WebGPU init throws | `captureException`, tag `surface: webgpu-init` |
| Material compile fails | `captureException` with `layer.type` (was a bare `.catch`) |
| Pass throws while rendering | attributed to its layer, reported once per fingerprint, pass dropped after 3 failures |
| GPU device loss | wraps three's `onDeviceLost`; loop halts and surfaces a fallback |

Device loss needs polling rather than a `catch`: three's `render()` returns silently once `_isDeviceLost` is set, so it never throws.

## Boot tracing

`RendererBootTrace` emits a breadcrumb per boot stage (`webgpu-probed` → `renderer-created` → `device-ready` → `first-frame`) and files a timeout if boot stalls past 20s of *visible* time — a backgrounded tab gets throttled rAF, so wall-clock time would report failures nobody saw. One instance per boot, so a remount can't reuse the previous clock.

`webgpu-diagnostics.ts` caches adapter info from the real init path so timeout reporting stays synchronous. Issuing a second `requestAdapter()` while diagnosing a stalled adapter would stall the same way and lose the report; `adapterAcquired: false` is what tells you the stall is upstream of device acquisition.

## Custom shaders never create issues

Broken TSL is expected input, not a defect. `CustomShaderPass` compiles through the same path as every other pass and rebuilds its node graph outside the transpile `.catch`, so containment is enforced centrally in `pass-failure.ts` at every surface — compile, render, and node-graph build. Those failures get a breadcrumb plus the layer's existing sidebar error, never a Sentry issue. Locked by tests.

Recovery keys on a material rebuild rather than any layer-signature change: keyframed and audio-driven values change the signature every frame, which would reset the failure count before it could throttle.

## Exports fail loudly

Exports share `PipelineManager` with the preview, so containing a pass failure there would ship a frame that looks fine but is missing a layer. The export renderer opts into `strictPassFailures` and rethrows after reporting.

## Also

`fallbackMessage` is now rendered — it was computed and discarded, so a user without WebGPU saw an infinite loading sweep.

## Test plan

- [x] `bun run check` clean; `bun test` 383 pass / 0 fail
- [x] Production build against a local envelope sink: all four boot breadcrumbs fire once each in order, `environment: production`, release tag present, user set, `gpu` context populated from the real init path (`vendor: apple`, `maxTextureDimension2D: 8192`)
- [x] `requestAnimationFrame` confirmed unwrapped in-browser, `addEventListener` wrapping retained
- [x] Device-loss halt exercised with a temporary injected trigger: one halt, frames stop, fallback renders
- [x] Healthy boot confirmed to emit no timeout after 26s
- [ ] Not exercised: the consecutive-frame-failure halt, the strict-export rethrow, and the animated-layer recovery path

## Before merge

- Confirm the Sentry project slug in `next.config.ts` — carried over unverified from #134, and a wrong slug fails source-map upload silently.
- `ci.yml` only triggers on PRs targeting `main`, so `validate` has not run on this PR. It will once #134 merges and this retargets.
