### PR TITLE
Add a privacy policy page so the Google OAuth app can leave Testing

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,6 +6,7 @@ import { listAllPublishedScenesForSitemap } from "@/lib/community/public-scenes"
 import {
   COMMUNITY_PATH,
   EDITOR_PATH,
+  PRIVACY_PATH,
   profilePagePath,
   scenePagePath,
 } from "@/lib/community/scene-links"
@@ -17,6 +18,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,
+    },
+    {
+      url: `${APP_BASE_URL}${PRIVACY_PATH}`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.1,
     },
   ]
 

--- a/src/app/tools/shader-lab/privacy/page.tsx
+++ b/src/app/tools/shader-lab/privacy/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { Typography } from "@/components/ui/typography"
 import { APP_BASE_URL } from "@/lib/app"
-import { PRIVACY_PATH } from "@/lib/community/scene-links"
+import { EDITOR_PATH, PRIVACY_PATH } from "@/lib/community/scene-links"
 
 const LAST_UPDATED = "August 25, 2026"
 
-const CONTACT_EMAIL = "tobias@basement.studio"
+const CONTACT_EMAIL = "dev@basement.studio"
 
 const DESCRIPTION =
   "What Shader Lab stores when you sign in or publish a scene, who processes it, and how to have it deleted."
@@ -124,46 +125,75 @@ const SECTIONS: Section[] = [
   },
 ]
 
+function EmailText({ text }: { text: string }) {
+  const [before, after] = text.split(CONTACT_EMAIL)
+
+  if (after === undefined) {
+    return text
+  }
+
+  return (
+    <>
+      {before}
+      <Link
+        className="text-[var(--ds-color-text-primary)] underline decoration-[var(--ds-border-panel)] underline-offset-[3px] transition-colors hover:decoration-[var(--ds-color-text-primary)]"
+        href={`mailto:${CONTACT_EMAIL}`}
+      >
+        {CONTACT_EMAIL}
+      </Link>
+      {after}
+    </>
+  )
+}
+
 export default function PrivacyPolicyPage() {
   return (
-    <main className="mx-auto flex w-full max-w-[720px] flex-col gap-[var(--ds-space-10)] px-4 py-10 sm:px-6">
-      <header className="flex flex-col items-start gap-[var(--ds-space-4)] pt-[var(--ds-space-4)]">
+    <main className="mx-auto w-full max-w-[70ch] px-5 py-[var(--ds-space-16)] sm:px-6">
+      <header className="flex flex-col items-start gap-[var(--ds-space-4)]">
+        <Link
+          className="text-[var(--ds-color-text-tertiary)] transition-colors hover:text-[var(--ds-color-text-primary)] type-mono-xs"
+          href={EDITOR_PATH}
+        >
+          ← Shader Lab
+        </Link>
         <Typography as="h1" variant="display">
           Privacy Policy
         </Typography>
-        <Typography as="p" tone="tertiary" variant="caption">
+        <Typography as="p" tone="tertiary" variant="monoXs">
           Last updated {LAST_UPDATED}
         </Typography>
       </header>
 
-      <div className="flex flex-col gap-[var(--ds-space-9)]">
+      <hr className="my-[var(--ds-space-10)] border-0 border-[var(--ds-border-divider)] border-t" />
+
+      <div className="flex flex-col gap-[var(--ds-space-10)]">
         {SECTIONS.map((section) => (
           <section
             className="flex flex-col gap-[var(--ds-space-4)]"
             key={section.heading}
           >
-            <Typography as="h2" variant="title">
+            <Typography as="h2" variant="heading">
               {section.heading}
             </Typography>
 
             {section.body?.map((paragraph) => (
               <Typography
                 as="p"
-                className="text-pretty"
+                className="text-pretty leading-[1.65]"
                 key={paragraph}
                 tone="secondary"
                 variant="body"
               >
-                {paragraph}
+                <EmailText text={paragraph} />
               </Typography>
             ))}
 
             {section.items ? (
-              <ul className="flex list-disc flex-col gap-[var(--ds-space-3)] pl-[var(--ds-space-5)]">
+              <ul className="list-disc space-y-[var(--ds-space-4)] pl-[var(--ds-space-5)]">
                 {section.items.map((item) => (
                   <Typography
                     as="li"
-                    className="text-pretty"
+                    className="text-pretty leading-[1.65] marker:text-[var(--ds-color-text-muted)]"
                     key={item}
                     tone="secondary"
                     variant="body"

--- a/src/app/tools/shader-lab/privacy/page.tsx
+++ b/src/app/tools/shader-lab/privacy/page.tsx
@@ -33,7 +33,7 @@ const SECTIONS: Section[] = [
   {
     body: [
       "Shader Lab is a browser-based tool for creating, stacking and animating shaders, built and operated by basement.studio. This policy covers the editor and the community gallery.",
-      "You can use the editor without an account. Scenes you never publish stay in your browser. Everything below applies only once you sign in or publish something.",
+      "You can use the editor without an account. While you do, your work stays on your machine: the editor autosaves into your browser's own IndexedDB storage and sends us nothing. Everything below applies once you sign in and save or publish something.",
     ],
     heading: "The short version",
   },
@@ -53,8 +53,11 @@ const SECTIONS: Section[] = [
     heading: "Your profile",
   },
   {
-    body: ["Publishing a scene stores:"],
-    heading: "What you publish",
+    body: [
+      "Saving a draft to your account and publishing a scene both send that scene to us. A draft is private — it stays out of the gallery until you publish it — but it lives on our servers either way, not only in your browser.",
+      "Either one stores:",
+    ],
+    heading: "Scenes you save or publish",
     items: [
       "The scene itself: title, description, layer setup, composition size and duration.",
       "Any file you added to it: audio, 3D models, images and video. These are stored on Cloudflare and served publicly.",
@@ -76,7 +79,7 @@ const SECTIONS: Section[] = [
       "Vercel Analytics and Speed Insights, for page views and performance. Aggregate, and not used to track you across other sites.",
       "Sentry, in production only, for crashes and errors. A report can include the page you were on, your browser, and — server side — local variable values from the stack trace.",
       "We do not run Sentry Session Replay. We never record your screen, your pointer or your keystrokes.",
-      "Vercel BotID on the publish, like, remix and report endpoints, to keep automated abuse out.",
+      "Vercel BotID on every endpoint that writes something — saving a draft, publishing, deleting a scene, liking, remixing, reporting and changing your handle — to keep automated abuse out.",
     ],
   },
   {

--- a/src/app/tools/shader-lab/privacy/page.tsx
+++ b/src/app/tools/shader-lab/privacy/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from "next"
+import { Typography } from "@/components/ui/typography"
+import { APP_BASE_URL } from "@/lib/app"
+import { PRIVACY_PATH } from "@/lib/community/scene-links"
+
+const LAST_UPDATED = "August 25, 2026"
+
+const CONTACT_EMAIL = "tobias@basement.studio"
+
+const DESCRIPTION =
+  "What Shader Lab stores when you sign in or publish a scene, who processes it, and how to have it deleted."
+
+export const metadata: Metadata = {
+  alternates: { canonical: PRIVACY_PATH },
+  description: DESCRIPTION,
+  openGraph: {
+    description: DESCRIPTION,
+    title: "Privacy Policy",
+    type: "website",
+    url: `${APP_BASE_URL}${PRIVACY_PATH}`,
+  },
+  title: "Privacy Policy",
+}
+
+type Section = {
+  body?: string[]
+  heading: string
+  items?: string[]
+}
+
+const SECTIONS: Section[] = [
+  {
+    body: [
+      "Shader Lab is a browser-based tool for creating, stacking and animating shaders, built and operated by basement.studio. This policy covers the editor and the community gallery.",
+      "You can use the editor without an account. Scenes you never publish stay in your browser. Everything below applies only once you sign in or publish something.",
+    ],
+    heading: "The short version",
+  },
+  {
+    body: [
+      "You sign in with Google or GitHub. We never see or store a password.",
+      "From Google we request three scopes and nothing else: openid, email and profile. That gives us your email address, name and avatar. We do not ask for Drive, contacts, calendar or any other Google data.",
+      "Authentication is brokered by Neon Auth, which means the sign-in screen and the OAuth callback are hosted on Neon's infrastructure rather than ours. Neon stores your email address, name, avatar URL and provider account ID on our behalf.",
+    ],
+    heading: "Signing in",
+  },
+  {
+    body: [
+      "Signing in creates a public profile: a handle, an optional display name, and your avatar. These appear next to every scene you publish.",
+      "If you rename your handle we keep a record of the handles you previously claimed, so old links keep resolving and a handle can't be recycled to impersonate you.",
+    ],
+    heading: "Your profile",
+  },
+  {
+    body: ["Publishing a scene stores:"],
+    heading: "What you publish",
+    items: [
+      "The scene itself: title, description, layer setup, composition size and duration.",
+      "Any file you added to it: audio, 3D models, images and video. These are stored on Cloudflare and served publicly.",
+      "Remix lineage, so a scene built from someone else's credits the original.",
+      "Which scenes you liked.",
+      "Daily counters for how much you have uploaded, so we can enforce publishing limits.",
+    ],
+  },
+  {
+    body: [
+      "Published scenes are public by design. Deleting a scene removes it from the gallery.",
+      "If you report a scene we store your account ID, the reason you picked and any note you wrote. A short allowlist of basement.studio staff can read the report queue and take scenes down.",
+    ],
+    heading: "Moderation",
+  },
+  {
+    heading: "Analytics and error monitoring",
+    items: [
+      "Vercel Analytics and Speed Insights, for page views and performance. Aggregate, and not used to track you across other sites.",
+      "Sentry, in production only, for crashes and errors. A report can include the page you were on, your browser, and — server side — local variable values from the stack trace.",
+      "We do not run Sentry Session Replay. We never record your screen, your pointer or your keystrokes.",
+      "Vercel BotID on the publish, like, remix and report endpoints, to keep automated abuse out.",
+    ],
+  },
+  {
+    body: [
+      "We use your IP address for exactly one thing: not double-counting remixes from people who aren't signed in.",
+      "We don't store it. It is combined with the current date and a server-side secret, hashed with HMAC-SHA256, and only that hash is written to the database. Because the date is part of the input, today's hash cannot be matched against yesterday's.",
+      "Our infrastructure providers see raw IP addresses in their own request logs, under their own policies.",
+    ],
+    heading: "IP addresses",
+  },
+  {
+    heading: "What we don't do",
+    items: [
+      "We don't sell or rent your data.",
+      "We don't run advertising or ad trackers.",
+      "We don't record your session.",
+      "We don't send you marketing email.",
+    ],
+  },
+  {
+    body: ["Data is processed on our behalf by:"],
+    heading: "Who else touches it",
+    items: [
+      "Vercel — hosting, analytics, bot protection.",
+      "Neon — Postgres database and managed authentication.",
+      "Cloudflare — storage and delivery for uploaded assets.",
+      "Sentry — error monitoring.",
+      "Google or GitHub — only the one you chose to sign in with.",
+    ],
+  },
+  {
+    body: [
+      "You can delete any of your scenes from your profile at any time.",
+      `There is no self-serve account deletion yet. Email ${CONTACT_EMAIL} and we will remove your account, which also removes your profile, your scenes, your likes and your upload counters.`,
+      "Scenes that other people remixed from yours are their own work and stay published.",
+      "Depending on where you live you may have the right to access, correct, export or delete the personal data we hold about you. Email us and we will take care of it.",
+    ],
+    heading: "Deleting your data",
+  },
+  {
+    body: [
+      `Questions about any of this: ${CONTACT_EMAIL}.`,
+      "If we change this policy materially, we'll update the date at the top.",
+    ],
+    heading: "Contact",
+  },
+]
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-[720px] flex-col gap-[var(--ds-space-10)] px-4 py-10 sm:px-6">
+      <header className="flex flex-col items-start gap-[var(--ds-space-4)] pt-[var(--ds-space-4)]">
+        <Typography as="h1" variant="display">
+          Privacy Policy
+        </Typography>
+        <Typography as="p" tone="tertiary" variant="caption">
+          Last updated {LAST_UPDATED}
+        </Typography>
+      </header>
+
+      <div className="flex flex-col gap-[var(--ds-space-9)]">
+        {SECTIONS.map((section) => (
+          <section
+            className="flex flex-col gap-[var(--ds-space-4)]"
+            key={section.heading}
+          >
+            <Typography as="h2" variant="title">
+              {section.heading}
+            </Typography>
+
+            {section.body?.map((paragraph) => (
+              <Typography
+                as="p"
+                className="text-pretty"
+                key={paragraph}
+                tone="secondary"
+                variant="body"
+              >
+                {paragraph}
+              </Typography>
+            ))}
+
+            {section.items ? (
+              <ul className="flex list-disc flex-col gap-[var(--ds-space-3)] pl-[var(--ds-space-5)]">
+                {section.items.map((item) => (
+                  <Typography
+                    as="li"
+                    className="text-pretty"
+                    key={item}
+                    tone="secondary"
+                    variant="body"
+                  >
+                    {item}
+                  </Typography>
+                ))}
+              </ul>
+            ) : null}
+          </section>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/src/lib/community/scene-links.ts
+++ b/src/lib/community/scene-links.ts
@@ -4,6 +4,8 @@ export const EDITOR_PATH = "/tools/shader-lab"
 
 export const COMMUNITY_PATH = `${EDITOR_PATH}/community`
 
+export const PRIVACY_PATH = `${EDITOR_PATH}/privacy`
+
 export function editorSceneHref(slug: string): string {
   return `${EDITOR_PATH}?scene=${encodeURIComponent(slug)}`
 }


### PR DESCRIPTION
Stacked on #144.

## Why

The reported symptom was "the Google login screen still says neon.tech". Chasing it turned up a worse problem sitting next to it.

I pulled the real authorize URL out of production:

```
client_id     = 724687310779-8uu18qos19dtt2ih2j7qqs53a4v0bhj3.apps.googleusercontent.com
redirect_uri  = https://ep-wild-pond-avwiq72h.neonauth.…aws.neon.tech/neondb/auth/callback/google
scope         = email profile openid
app_domain    = https://ep-wild-pond-avwiq72h.neonauth.…aws.neon.tech
```

Two conclusions:

1. **Neon is configured correctly.** Prod uses our own Google client, on the right branch (`ep-wild-pond` = main). Nothing to fix there.
2. **The `neon.tech` label is `app_domain`, which Google derives from the redirect URI host.** Our App name ("Shader Lab") is set correctly, it just isn't what that line renders. Neon requires the provider callback to be `{NEON_AUTH_BASE_URL}/callback/{provider}`, so the host is permanently `*.aws.neon.tech`. **Not fixable without moving off Neon-managed Better Auth** — filed as a known limitation, not addressed here.

The actual bug: the OAuth app is in **Testing** status with External audience, so **only allowlisted test users can sign in.** Everyone else gets "Access blocked". It looked fine to us because both our accounts are test users.

Publishing to production needs no Google verification (our scopes are all non-sensitive), but it does require a privacy policy URL on an authorized domain — and there was no privacy policy anywhere on basement.studio. `/privacy`, `/privacy-policy`, `/legal/privacy` and `/terms` all 404.

## What this adds

A privacy policy at `/tools/shader-lab/privacy`, plus a `PRIVACY_PATH` constant and a sitemap entry.

The copy is written from the code, not from a template:

- the three Google scopes we actually request, and that auth is brokered by Neon
- the `profiles` / `handle_claims` behaviour, including why old handles are retained
- `scenes`, `scene_assets`, `likes`, `remixes`, `reports`, `upload_quota`
- Cloudflare for asset storage, Vercel Analytics + Speed Insights, BotID on the eight protected routes
- Sentry, production only, **and explicitly that we do not run Session Replay**
- the IP handling in `resolveActorKey` — HMAC-SHA256 over a day bucket + server secret, raw IP never stored. This is a genuinely good design and worth saying out loud.
- no self-serve account deletion yet, so the policy says to email us rather than claiming a button that doesn't exist

Deliberately **not** gated on `isCommunityEnabled()` — Google needs the URL reachable on every deployment.

## Verified

- `bun run typecheck` clean
- `biome lint` clean on all three files
- rendered at `localhost:3000/tools/shader-lab/privacy` → HTTP 200, full content present
- `/sitemap.xml` includes the new URL

## Needs a human before this ships

- **Legal review of the copy.** I wrote it accurate to the code, but I am not the right party to sign off on a public legal commitment. In particular: I used `basement.studio` rather than guessing a legal entity name, and `tobias@basement.studio` as the contact because that is the configured OAuth support email — a shared inbox is probably better.
- **Discoverability.** Nothing links to this page yet. Google doesn't require a link, but a policy nobody can find is weak. Where it belongs is a design call.
- **Terms of service is still empty** in the Branding config. Google lists it as optional so it isn't blocking, but for a UGC gallery with takedowns and remix licensing it is worth having.

## After merge

Google Auth Platform → Branding → paste the privacy policy URL → Audience → **Publish app**. That is what unblocks sign-in for real users.