### PR TITLE
Community scroll/CTA fixes, CRT opacity fix, duplicate + replace-image layers

### DIFF
--- a/.changeset/crt-opacity-blends-to-input.md
+++ b/.changeset/crt-opacity-blends-to-input.md
@@ -1,0 +1,11 @@
+---
+"@basementstudio/shader-lab": patch
+---
+
+Fix CRT layer opacity fading to black instead of becoming transparent.
+
+`CrtPass.render` re-implemented the base `PassNode.render` body but never
+assigned `this.inputNode.value`, so the opacity blend mixed toward an empty
+placeholder texture (black) rather than the upstream composite. It now calls
+`super.render(...)` before capturing history, which also fixes `multiply` /
+`darken` blend modes and `mask` composite mode at full opacity.

--- a/packages/shader-lab-react/src/renderer/crt-pass.ts
+++ b/packages/shader-lab-react/src/renderer/crt-pass.ts
@@ -170,14 +170,7 @@ export class CrtPass extends PassNode {
       node.value = historyTexture
     }
 
-    this.lastRenderer = renderer
-    this.lastOutputTarget = outputTarget
-    this.beforeRender(time, delta)
-
-    this.renderBloomCompositor(renderer, outputTarget)
-
-    renderer.setRenderTarget(outputTarget)
-    renderer.render(this.scene, this.camera)
+    super.render(renderer, inputTexture, outputTarget, time, delta)
 
     this.captureHistory(renderer, outputTarget)
   }

--- a/src/components/community/community-hero.tsx
+++ b/src/components/community/community-hero.tsx
@@ -1,24 +1,58 @@
-import { HeartIcon } from "@radix-ui/react-icons"
-import type { Route } from "next"
-import Link from "next/link"
-import { AuthorAvatar } from "@/components/community/author-avatar"
-import { HeroBackdrop } from "@/components/community/hero-backdrop"
-import { BasementWordmark } from "@/components/editor/made-by-basement"
-import { Typography } from "@/components/ui/typography"
-import type { HeroScene } from "@/lib/community/public-scenes"
-import { scenePagePath } from "@/lib/community/scene-links"
+import { HeartIcon } from "@radix-ui/react-icons";
+import type { Route } from "next";
+import Link from "next/link";
+import { AuthorAvatar } from "@/components/community/author-avatar";
+import { HeroBackdrop } from "@/components/community/hero-backdrop";
+import { BasementWordmark } from "@/components/editor/made-by-basement";
+import { ButtonLink } from "@/components/ui/button/link";
+import { Typography } from "@/components/ui/typography";
+import type { HeroScene } from "@/lib/community/public-scenes";
+import { EDITOR_PATH, scenePagePath } from "@/lib/community/scene-links";
 
 export function CommunityHero({
   hero,
   title,
 }: {
-  hero: HeroScene | null
-  title: string
+  hero: HeroScene | null;
+  title: string;
 }) {
-  const detail = hero?.detail ?? null
+  const detail = hero?.detail ?? null;
 
   return (
     <section className="relative flex min-h-[84svh] flex-col justify-end overflow-hidden px-4 pt-[var(--ds-space-16)] pb-[var(--ds-space-6)] sm:px-6 sm:pb-[var(--ds-space-8)]">
+      {detail ? (
+        <Link
+          className="z-10 absolute top-8 right-8 inline-flex min-w-0 items-center gap-2 rounded-[var(--ds-radius-control)] border border-[var(--ds-border-divider)] bg-[rgb(8_9_12_/_0.68)] px-2.5 py-1.5 backdrop-blur-[8px] transition-colors duration-160 ease-[var(--ease-out-cubic)] hover:border-[var(--ds-border-hover)]"
+          href={scenePagePath(detail.slug) as Route}
+        >
+          <Typography as="span" tone="tertiary" variant="monoXs">
+            {hero && hero.recentLikes > 0 ? "Most liked today" : "Most liked"}
+          </Typography>
+          <span
+            aria-hidden="true"
+            className="h-2.5 w-px bg-[var(--ds-border-divider)]"
+          />
+          <AuthorAvatar
+            avatarUrl={detail.authorAvatarUrl}
+            name={detail.authorName ?? detail.authorHandle}
+            size={16}
+          />
+          <Typography
+            as="span"
+            className="overflow-hidden text-ellipsis whitespace-nowrap"
+            variant="caption"
+          >
+            {detail.title}
+          </Typography>
+          <span className="inline-flex items-center gap-1 text-[var(--ds-color-text-tertiary)]">
+            <HeartIcon height={11} width={11} />
+            <Typography as="span" tone="tertiary" variant="monoXs">
+              {detail.likeCount}
+            </Typography>
+          </span>
+        </Link>
+      ) : null}
+
       {detail ? (
         <HeroBackdrop
           hasCameraLayer={detail.layerTypes.includes("live")}
@@ -28,51 +62,27 @@ export function CommunityHero({
       ) : null}
 
       <div className="relative z-[1] flex flex-wrap items-end justify-between gap-[var(--ds-space-4)]">
-        <div className="flex flex-col items-start gap-[var(--ds-space-4)]">
-          <span className="text-[var(--ds-color-text-secondary)] ml-2">
-            <BasementWordmark height={12} />
-          </span>
-
-          <h1 className="type-display m-0 text-balance text-left text-[clamp(44px,8.5vw,80px)] leading-[0.85] tracking-[-0.04em]">
-            Made By <br/> The Community
-          </h1>
-        </div>
-
-        {detail ? (
-          <Link
-            className="inline-flex min-w-0 items-center gap-2 rounded-[var(--ds-radius-control)] border border-[var(--ds-border-divider)] bg-[rgb(8_9_12_/_0.68)] px-2.5 py-1.5 backdrop-blur-[8px] transition-colors duration-160 ease-[var(--ease-out-cubic)] hover:border-[var(--ds-border-hover)]"
-            href={scenePagePath(detail.slug) as Route}
-          >
-            <Typography as="span" tone="tertiary" variant="monoXs">
-              {hero && hero.recentLikes > 0 ? "Most liked today" : "Most liked"}
-            </Typography>
-            <span
-              aria-hidden="true"
-              className="h-2.5 w-px bg-[var(--ds-border-divider)]"
-            />
-            <AuthorAvatar
-              avatarUrl={detail.authorAvatarUrl}
-              name={detail.authorName ?? detail.authorHandle}
-              size={16}
-            />
-            <Typography
-              as="span"
-              className="overflow-hidden text-ellipsis whitespace-nowrap"
-              variant="caption"
-            >
-              {detail.title}
-            </Typography>
-            <span className="inline-flex items-center gap-1 text-[var(--ds-color-text-tertiary)]">
-              <HeartIcon height={11} width={11} />
-              <Typography as="span" tone="tertiary" variant="monoXs">
-                {detail.likeCount}
-              </Typography>
+        <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8 w-full">
+          <div className="flex flex-col items-start gap-[var(--ds-space-4)]">
+            <span className="text-[var(--ds-color-text-secondary)] ml-2">
+              <BasementWordmark height={12} />
             </span>
-          </Link>
-        ) : null}
+
+            <h1 className="type-display m-0 text-balance text-left text-[clamp(44px,8.5vw,80px)] leading-[0.85] tracking-[-0.04em]">
+              Made By <br /> The Community
+            </h1>
+          </div>
+          <ButtonLink
+            className="ml-2"
+            href={EDITOR_PATH as Route}
+            variant="primary"
+          >
+            Open Shader Lab
+          </ButtonLink>
+        </div>
+        <span className="sr-only">{title}</span>
       </div>
 
-      <span className="sr-only">{title}</span>
     </section>
-  )
+  );
 }

--- a/src/components/community/public-scene-effect-filter.tsx
+++ b/src/components/community/public-scene-effect-filter.tsx
@@ -34,6 +34,7 @@ export function PublicSceneEffectFilter({
             : "border-[var(--ds-border-active)] bg-[var(--ds-color-surface-active)] text-[var(--ds-color-text-primary)]"
         )}
         href={COMMUNITY_PATH as Route}
+        scroll={false}
       >
         <Typography as="span" variant="label">
           All
@@ -59,6 +60,7 @@ export function PublicSceneEffectFilter({
             )}
             href={communityEffectsPath(nextEffects) as Route}
             key={effectType}
+            scroll={false}
           >
             <Typography as="span" variant="label">
               {getLayerLabel(effectType)}

--- a/src/components/editor/editor-shortcuts.tsx
+++ b/src/components/editor/editor-shortcuts.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useEffectEvent } from "react"
 import { playUISound } from "@/lib/audio/shader-lab-sounds"
 import { requestDraftSave } from "@/lib/editor/draft-save-bus"
+import { duplicateLayers } from "@/lib/editor/duplicate-layers"
 import { isEditableTarget } from "@/lib/editor/is-editable-target"
 import { useEditorStore } from "@/store/editor-store"
 import { useLayerStore } from "@/store/layer-store"
@@ -54,6 +55,18 @@ export function EditorShortcuts() {
         enterImmersiveCanvas()
         playUISound("action.hideUI")
       }
+
+      return
+    }
+
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      !event.altKey &&
+      event.key.toLowerCase() === "d" &&
+      selectedLayerIds.length > 0
+    ) {
+      event.preventDefault()
+      duplicateLayers(selectedLayerIds)
 
       return
     }

--- a/src/components/editor/layer-sidebar.tsx
+++ b/src/components/editor/layer-sidebar.tsx
@@ -37,7 +37,8 @@ import { HoverTooltip } from "@/components/ui/tooltip"
 import { Typography } from "@/components/ui/typography"
 import { playUISound } from "@/lib/audio/shader-lab-sounds"
 import { cn } from "@/lib/cn"
-import { AUDIO_FILE_ACCEPT, inferFileAssetKind } from "@/lib/editor/media-file"
+import { duplicateLayers } from "@/lib/editor/duplicate-layers"
+import { getAssetAccept, inferFileAssetKind } from "@/lib/editor/media-file"
 import { getSeedableMediaDuration } from "@/lib/editor/timeline-duration"
 import { useAssetStore } from "@/store/asset-store"
 import { useEditorStore } from "@/store/editor-store"
@@ -45,7 +46,7 @@ import { useLayerStore } from "@/store/layer-store"
 import { useTimelineStore } from "@/store/timeline-store"
 import type { AssetKind, EditorAsset, EditorLayer } from "@/types/editor"
 
-type LayerAction = "delete" | "reset"
+type LayerAction = "delete" | "duplicate" | "reset"
 
 const thumbnailBaseClassName =
   "relative size-7 overflow-hidden rounded-[var(--ds-radius-thumb)] border border-[var(--ds-border-divider)]"
@@ -111,19 +112,6 @@ function getExpectedAssetKind(layer: EditorLayer): AssetKind | null {
   return null
 }
 
-function getAcceptForAssetKind(kind: AssetKind): string {
-  switch (kind) {
-    case "image":
-      return "image/png,image/jpeg,image/webp,image/gif,image/svg+xml,.svg"
-    case "video":
-      return "video/mp4,video/webm,video/quicktime,.mov"
-    case "model":
-      return ".glb,.gltf,.obj,model/gltf-binary,model/gltf+json,model/obj,application/octet-stream"
-    case "audio":
-      return AUDIO_FILE_ACCEPT
-  }
-}
-
 function inferSelectedFileKind(file: File): AssetKind | null {
   return inferFileAssetKind(file)
 }
@@ -145,6 +133,7 @@ type LayerListItemProps = {
 }
 
 const LAYER_ACTION_OPTIONS = [
+  { label: "Duplicate layer", value: "duplicate" },
   { label: "Reset properties", value: "reset" },
   { label: "Delete layer", value: "delete" },
 ] as const satisfies readonly {
@@ -550,6 +539,8 @@ export function LayerSidebar() {
     if (action === "delete") {
       removeLayers(targetLayerIds)
       playUISound("action.deleteLayer")
+    } else if (action === "duplicate") {
+      duplicateLayers(targetLayerIds)
     } else {
       targetLayerIds.forEach((targetLayerId) => {
         resetLayerParams(targetLayerId)
@@ -642,7 +633,7 @@ export function LayerSidebar() {
     }
 
     if (relinkInputRef.current) {
-      relinkInputRef.current.accept = getAcceptForAssetKind(expectedKind)
+      relinkInputRef.current.accept = getAssetAccept(expectedKind)
       relinkInputRef.current.click()
     }
   }

--- a/src/components/editor/properties-sidebar-content.tsx
+++ b/src/components/editor/properties-sidebar-content.tsx
@@ -258,6 +258,7 @@ export function SelectedLayerPropertiesContent({
   layerRuntimeError,
   layerSubtitle,
   layerType,
+  onReplaceImage,
   onToggleParamGroup,
   onTimelineKeyframe,
   opacity,
@@ -289,6 +290,7 @@ export function SelectedLayerPropertiesContent({
   layerRuntimeError: string | null
   layerSubtitle: string
   layerType: LayerType
+  onReplaceImage: () => void
   onToggleParamGroup: (groupId: string) => void
   onTimelineKeyframe: (
     binding: AnimatedPropertyBinding,
@@ -687,6 +689,31 @@ export function SelectedLayerPropertiesContent({
             updateLayerParam={updateLayerParam}
             values={values}
           />
+        ) : null}
+
+        {layerType === "image" ? (
+          <section className="flex flex-col gap-3 border-t border-[var(--ds-border-divider)] px-4 pt-[14px] pb-4 first:border-t-0">
+            <Typography
+              className="uppercase"
+              tone="secondary"
+              variant="overline"
+            >
+              Source
+            </Typography>
+            <div className="flex items-center justify-between gap-3">
+              <Typography tone="muted" variant="caption">
+                Swap in a different image and keep this layer's settings.
+              </Typography>
+              <Button
+                onClick={onReplaceImage}
+                size="compact"
+                uiSound="action.relinkAsset"
+                variant="secondary"
+              >
+                Replace
+              </Button>
+            </div>
+          </section>
         ) : null}
 
         {layerType === "gradient" ? (

--- a/src/components/editor/properties-sidebar.tsx
+++ b/src/components/editor/properties-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { DragHandleDots2Icon } from "@radix-ui/react-icons"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
+import type { ChangeEvent } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { FloatingDesktopPanel } from "@/components/editor/floating-desktop-panel"
 import { GlassPanel } from "@/components/ui/glass-panel"
@@ -10,7 +11,11 @@ import { IconButton } from "@/components/ui/icon-button"
 import { Typography } from "@/components/ui/typography"
 import { cn } from "@/lib/cn"
 import { getLayerDefinition } from "@/lib/editor/config/layer-registry"
-import { isSvgMediaSource } from "@/lib/editor/media-file"
+import {
+  getAssetAccept,
+  inferFileAssetKind,
+  isSvgMediaSource,
+} from "@/lib/editor/media-file"
 import { evaluateTimelineForLayers } from "@/lib/editor/timeline/evaluate"
 import { useAssetStore } from "@/store/asset-store"
 import { useEditorStore } from "@/store/editor-store"
@@ -50,6 +55,8 @@ export function PropertiesSidebar() {
   }>({ params: {} })
   const [panelHeight, setPanelHeight] = useState<number | null>(null)
   const viewResizeObserverRef = useRef<ResizeObserver | null>(null)
+  const replaceImageInputRef = useRef<HTMLInputElement | null>(null)
+  const replaceImageLayerIdRef = useRef<string | null>(null)
   const rightSidebarVisible = useEditorStore((state) => state.sidebars.right)
   const mobilePanel = useEditorStore((state) => state.mobilePanel)
   const sidebarView = useEditorStore((state) => state.sidebarView)
@@ -78,9 +85,15 @@ export function PropertiesSidebar() {
   )
   const setLayerSaturation = useLayerStore((state) => state.setLayerSaturation)
   const updateLayerParam = useLayerStore((state) => state.updateLayerParam)
+  const setLayerAsset = useLayerStore((state) => state.setLayerAsset)
+  const setLayerRuntimeError = useLayerStore(
+    (state) => state.setLayerRuntimeError
+  )
   const timelineTracks = useTimelineStore((state) => state.tracks)
   const upsertKeyframe = useTimelineStore((state) => state.upsertKeyframe)
   const assets = useAssetStore((state) => state.assets)
+  const loadAsset = useAssetStore((state) => state.loadAsset)
+  const removeAsset = useAssetStore((state) => state.removeAsset)
   const activeGestureDepthRef = useRef(0)
   const activeGestureTimeRef = useRef<number | null>(null)
   const mobilePanelVisible =
@@ -513,6 +526,55 @@ export function PropertiesSidebar() {
     [handleTimelineAwareParamChange, selectedLayerId]
   )
 
+  const handleReplaceImagePick = useCallback(() => {
+    if (!selectedLayerId) {
+      return
+    }
+
+    replaceImageLayerIdRef.current = selectedLayerId
+    replaceImageInputRef.current?.click()
+  }, [selectedLayerId])
+
+  const handleReplaceImageChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0]
+      const layerId = replaceImageLayerIdRef.current
+
+      event.currentTarget.value = ""
+      replaceImageLayerIdRef.current = null
+
+      if (!(file && layerId)) {
+        return
+      }
+
+      if (inferFileAssetKind(file) !== "image") {
+        setLayerRuntimeError(layerId, "Expected an image file.")
+
+        return
+      }
+
+      try {
+        const asset = await loadAsset(file)
+
+        if (asset.kind !== "image") {
+          removeAsset(asset.id)
+          setLayerRuntimeError(layerId, "Expected an image file.")
+
+          return
+        }
+
+        setLayerAsset(layerId, asset.id)
+        setLayerRuntimeError(layerId, null)
+      } catch (error) {
+        setLayerRuntimeError(
+          layerId,
+          error instanceof Error ? error.message : "Failed to replace image."
+        )
+      }
+    },
+    [loadAsset, removeAsset, setLayerAsset, setLayerRuntimeError]
+  )
+
   const selectedLayerContentProps = selectedLayer
     ? {
         blendMode: selectedLayer.blendMode,
@@ -535,6 +597,7 @@ export function PropertiesSidebar() {
             ? selectedLayer.params.sourceFileName
             : ""),
         layerType: selectedLayer.type,
+        onReplaceImage: handleReplaceImagePick,
         onToggleParamGroup: handleToggleParamGroup,
         onTimelineKeyframe: handleTimelineKeyframe,
         opacity: displayedLayerState?.opacity ?? selectedLayer.opacity,
@@ -607,6 +670,14 @@ export function PropertiesSidebar() {
 
   return (
     <>
+      <input
+        accept={getAssetAccept("image")}
+        className="hidden"
+        onChange={handleReplaceImageChange}
+        ref={replaceImageInputRef}
+        type="file"
+      />
+
       <aside
         className={cn(
           "pointer-events-none fixed right-3 bottom-[88px] left-3 z-45 translate-y-0 transition-[opacity,translate] duration-[220ms,260ms] ease-[ease-out,cubic-bezier(0.22,1,0.36,1)] min-[900px]:hidden",

--- a/src/lib/agent-bridge/commands.ts
+++ b/src/lib/agent-bridge/commands.ts
@@ -1,6 +1,7 @@
 import { subscribeToCustomShaderCompiles } from "@/lib/agent-bridge/compile-events"
 import { pumpAgentFrame } from "@/lib/agent-bridge/frame-pump"
 import { getLayerDefinition, getLayerDefinitions } from "@/lib/editor/config/layer-registry"
+import { duplicateLayers } from "@/lib/editor/duplicate-layers"
 import { isParameterAnimatable } from "@/lib/editor/parameter-schema"
 import { getSeedableMediaDuration } from "@/lib/editor/timeline-duration"
 import { useEditorStore } from "@/store/editor-store"
@@ -659,7 +660,7 @@ const COMMAND_HANDLERS: Record<string, CommandHandler> = {
 
   duplicate_layer: (payload) => {
     const layer = requireLayer(requireString(payload, "id"))
-    const newId = useLayerStore.getState().duplicateLayer(layer.id)
+    const [newId] = duplicateLayers([layer.id])
 
     if (!newId) {
       throw new AgentCommandError(`Could not duplicate layer \`${layer.id}\`.`)

--- a/src/lib/editor/duplicate-layers.ts
+++ b/src/lib/editor/duplicate-layers.ts
@@ -1,0 +1,31 @@
+import { playUISound } from "@/lib/audio/shader-lab-sounds"
+import { useLayerStore } from "@/store/layer-store"
+import { useTimelineStore } from "@/store/timeline-store"
+
+export function duplicateLayers(layerIds: readonly string[]): string[] {
+  const targetIds = new Set(layerIds)
+  const { duplicateLayer, layers } = useLayerStore.getState()
+  const { duplicateLayerTracks } = useTimelineStore.getState()
+  const duplicatedIds: string[] = []
+
+  for (const layer of layers) {
+    if (!targetIds.has(layer.id)) {
+      continue
+    }
+
+    const duplicatedId = duplicateLayer(layer.id)
+
+    if (!duplicatedId) {
+      continue
+    }
+
+    duplicateLayerTracks(layer.id, duplicatedId)
+    duplicatedIds.push(duplicatedId)
+  }
+
+  if (duplicatedIds.length > 0) {
+    playUISound("action.addLayer")
+  }
+
+  return duplicatedIds
+}

--- a/src/lib/editor/media-file.ts
+++ b/src/lib/editor/media-file.ts
@@ -37,6 +37,19 @@ export function isAudioFileName(fileName: string | null | undefined): boolean {
   return AUDIO_FILE_EXTENSIONS.some((extension) => lower.endsWith(extension))
 }
 
+export function getAssetAccept(kind: AssetKind): string {
+  switch (kind) {
+    case "image":
+      return "image/png,image/jpeg,image/webp,image/gif,image/svg+xml,.svg"
+    case "video":
+      return "video/mp4,video/webm,video/quicktime,.mov"
+    case "model":
+      return ".glb,.gltf,.obj,model/gltf-binary,model/gltf+json,model/obj,application/octet-stream"
+    case "audio":
+      return AUDIO_FILE_ACCEPT
+  }
+}
+
 export function inferFileAssetKind(file: File): AssetKind | null {
   const mimeType = file.type.toLowerCase()
   const fileName = file.name.toLowerCase()

--- a/src/renderer/crt-pass.ts
+++ b/src/renderer/crt-pass.ts
@@ -170,14 +170,7 @@ export class CrtPass extends PassNode {
       node.value = historyTexture
     }
 
-    this.lastRenderer = renderer
-    this.lastOutputTarget = outputTarget
-    this.beforeRender(time, delta)
-
-    this.renderBloomCompositor(renderer, outputTarget)
-
-    renderer.setRenderTarget(outputTarget)
-    renderer.render(this.scene, this.camera)
+    super.render(renderer, inputTexture, outputTarget, time, delta)
 
     this.captureHistory(renderer, outputTarget)
   }

--- a/src/store/timeline-store.ts
+++ b/src/store/timeline-store.ts
@@ -62,6 +62,7 @@ export interface TimelineStoreActions {
   ) => void
   advance: (delta: number) => void
   clearLayerTracks: (layerId: string) => void
+  duplicateLayerTracks: (sourceLayerId: string, targetLayerId: string) => void
   getTrackForBinding: (
     layerId: string,
     binding: AnimatedPropertyBinding,
@@ -926,6 +927,34 @@ export const useTimelineStore = create<TimelineStore>((set, get) => ({
         }),
         tracks: nextTracks,
       }
+    })
+  },
+
+  duplicateLayerTracks: (sourceLayerId, targetLayerId) => {
+    set((state) => {
+      const sourceTracks = state.tracks.filter(
+        (track) => track.layerId === sourceLayerId,
+      )
+
+      if (sourceTracks.length === 0) {
+        return state
+      }
+
+      const duplicatedTracks = sourceTracks.map((track) => {
+        const clone = cloneTrack(track)
+
+        return {
+          ...clone,
+          id: crypto.randomUUID(),
+          keyframes: clone.keyframes.map((keyframe) => ({
+            ...keyframe,
+            id: crypto.randomUUID(),
+          })),
+          layerId: targetLayerId,
+        }
+      })
+
+      return { tracks: [...state.tracks, ...duplicatedTracks] }
     })
   },
 


### PR DESCRIPTION
Five fixes across the community page, the renderer, and the layer editor.

## Community page

**Switching effect filter no longer scrolls to the top.** The filter pills are `next/link`s and App Router defaults to `scroll={true}`, so every category change reset the page past the 84svh hero. Added `scroll={false}` to the "All" pill and the effect pills.

**Added an "Open Shader Lab" CTA to the hero** — previously the only interactive element up there was the "Most liked" pill.

## Renderer — CRT opacity fading to black

`CrtPass.render` re-implemented the base `PassNode.render` body but never assigned `this.inputNode.value = inputTexture`. `inputNode` is the *base* of the opacity blend, so it stayed pointing at the empty `THREE.Texture()` created in the constructor — the shader was computing `mix(black, crt, opacity)`.

It was the only pass in the codebase overriding `render` without calling `super.render` (`halftone`, `pixel-trail`, `ascii`, `ink`, `pixel-sorting`, `blob-tracking` all do). Replaced the duplicated body with `super.render(...)` + `captureHistory(...)`, which is exactly equivalent plus the fix.

This also fixes `multiply`/`darken` blend modes and `mask` composite mode on CRT at full opacity, which were blending against black for the same reason. Fixed in both the app copy and `packages/shader-lab-react`.

## Editor

**Duplicate layer.** The `duplicateLayer` store action already existed but had no UI — only the MCP tool used it. Added it to the layer row menu and a `Cmd+D` shortcut, both going through a shared `duplicateLayers()` helper.

The helper also copies the layer's timeline tracks via a new `duplicateLayerTracks` action; without it a duplicated animated layer came out static. The agent-bridge `duplicate_layer` command now routes through the same helper, so the MCP path gets this too.

**Replace image.** Image layers get a `Source` section with a **Replace** button, so the image can be swapped without rebuilding the layer and losing its settings. Kind is validated twice (pre-check plus post-`loadAsset` with rollback), mirroring the existing relink flow.

The hidden `<input type="file">` is hosted in `PropertiesSidebar` rather than the content component: `SelectedLayerPropertiesContent` is also rendered in two hidden measuring trees, so an input there would exist 3× with colliding refs.

Pulled the per-kind `accept` string out of `layer-sidebar.tsx` into `getAssetAccept()` in `media-file.ts` so the relink and replace flows share one list.

## Verification

Driven against the running app over CDP, with negative controls:

| | control (unfixed) | treatment |
|---|---|---|
| Scroll position on category change | 600 → **0** | 600 → **600** |
| CRT canvas luminance @ 0% opacity | **28.46** (baseline 38.39) | **37.33** (baseline 37.06) |

CRT now fades monotonically: 100% → 34.83, 50% → 36.23, 0% → 37.33 ≈ baseline.

Duplicate produces `Bloom Copy` directly after `Bloom` via both the menu and `Cmd+D`. Replace swapped `ascii.webp` → `dithering.webp` on the same layer with no new layer added.

`typecheck`, both package typechecks, `lint`, and the MCP reference snapshot check all pass. Lint is at the same 2 warnings as a clean tree (both pre-existing in `properties-sidebar.tsx`).

## Not addressed

Pre-existing gaps left alone: `cloneLayer` shares the `maskConfig` object reference with its source (safe today only because `setLayerMaskConfig` spreads on write), audio links aren't duplicated, and `SCENES_ANCHOR_ID` is defined but nothing links to `#scenes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)