### PR TITLE
Name author in package metadata, and fill the npm discoverability gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,3 +669,4 @@ export const sketch = Fn(() => {
 
 - Website: [basement.studio](https://basement.studio/)
 - npm: [@basementstudio/shader-lab](https://www.npmjs.com/package/@basementstudio/shader-lab)
+- Author: [Tobi Moccagatta](https://github.com/git-chad)

--- a/packages/shader-lab-mcp/package.json
+++ b/packages/shader-lab-mcp/package.json
@@ -3,6 +3,7 @@
   "description": "MCP server that drives the Shader Lab editor: layer control and custom shader authoring. Built with xmcp.",
   "version": "0.1.1",
   "license": "MIT",
+  "author": "Tobi Moccagatta (https://github.com/git-chad)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/basementstudio/shader-lab.git",

--- a/packages/shader-lab-react/package.json
+++ b/packages/shader-lab-react/package.json
@@ -2,6 +2,7 @@
   "name": "@basementstudio/shader-lab",
   "version": "3.0.1",
   "description": "Portable React runtime for Shader Lab exports.",
+  "author": "Tobi Moccagatta (https://github.com/git-chad)",
   "type": "module",
   "sideEffects": false,
   "main": "./dist/src/index.js",
@@ -21,6 +22,18 @@
     "type": "git",
     "url": "https://github.com/basementstudio/shader-lab"
   },
+  "homepage": "https://eng.basement.studio/tools/shader-lab",
+  "keywords": [
+    "shader",
+    "shaders",
+    "webgpu",
+    "tsl",
+    "three",
+    "threejs",
+    "react",
+    "shader-lab",
+    "creative-coding"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
`@basementstudio/shader-lab` v3.0.1 publishes with no `author`, no `keywords` and no `homepage`, which leaves the flagship package unattributed on npm and absent from search for `webgpu`, `tsl` or `shader` — the terms someone looking for this would actually type. This adds all three, using the field ordering `shader-lab-mcp` already established, plus the same `author` line on the MCP package and one bullet in the README's existing `## Links` section.

Metadata only — no version bumps, no publish, no changes to repo topics.

**Question, not a change in this PR:** `@basementstudio/shader-lab` ships with no `license` field while `@basementstudio/shader-lab-mcp` beside it is MIT. An absent license means "all rights reserved" by default, which blocks adoption for anyone whose legal or dependency-audit tooling checks it. I've deliberately not set one since that's a company call — what should it be?